### PR TITLE
Add READMEs to topcoat-cookie and topcoat-ui crates

### DIFF
--- a/crates/topcoat-cookie/README.md
+++ b/crates/topcoat-cookie/README.md
@@ -1,0 +1,3 @@
+# topcoat-cookie
+
+This crate is part of [`topcoat`](https://github.com/tokio-rs/topcoat).

--- a/crates/topcoat-ui/README.md
+++ b/crates/topcoat-ui/README.md
@@ -1,0 +1,3 @@
+# topcoat-ui
+
+This crate is part of [`topcoat`](https://github.com/tokio-rs/topcoat).


### PR DESCRIPTION
Adds minimal READMEs to the two crates that were missing them, matching the format used by the other crates.