### PR TITLE
Share asset resolver

### DIFF
--- a/crates/topcoat-asset/src/resolver.rs
+++ b/crates/topcoat-asset/src/resolver.rs
@@ -1,5 +1,7 @@
 use crate::BundledAsset;
 
+pub(crate) const ASSET_ROUTE_PREFIX: &str = "/_topcoat/assets";
+
 pub type ResolveAssetRouteFn =
     dyn (Fn(&BundledAsset, &mut dyn std::fmt::Write) -> std::fmt::Result) + Send + Sync;
 
@@ -27,5 +29,22 @@ impl AssetRouteResolver {
         write: &mut dyn std::fmt::Write,
     ) -> std::fmt::Result {
         (self.resolve_fn)(bundled_asset, write)
+    }
+}
+
+impl Default for AssetRouteResolver {
+    /// Builds the resolver used by
+    /// [`RouterBuilderAssetExt::assets`](crate::RouterBuilderAssetExt::assets).
+    fn default() -> Self {
+        Self::new(Box::new(|bundled_asset, write| {
+            write.write_str(ASSET_ROUTE_PREFIX)?;
+            write.write_str("/")?;
+            write.write_str(
+                bundled_asset
+                    .name()
+                    .to_str()
+                    .expect("asset needs UTF-8 name"),
+            )
+        }))
     }
 }

--- a/crates/topcoat-asset/src/router.rs
+++ b/crates/topcoat-asset/src/router.rs
@@ -5,10 +5,7 @@ use http::{HeaderValue, Method, StatusCode};
 use topcoat_core::runtime::context::Cx;
 use topcoat_router::runtime::{Body, Path, PathBuf, Response, Route, RouteFuture, RouterBuilder};
 
-use crate::{AssetBundle, AssetRouteResolver, BundledAsset};
-
-/// URL prefix every bundled asset is served under.
-const ASSET_ROUTE_PREFIX: &str = "/_topcoat/assets";
+use crate::{ASSET_ROUTE_PREFIX, AssetBundle, AssetRouteResolver, BundledAsset};
 
 /// `Cache-Control` applied to every served asset. Bundled filenames carry a
 /// content hash, so their contents never change for a given URL.
@@ -121,17 +118,7 @@ impl RouterBuilderAssetExt for RouterBuilder {
         }
 
         self = self.app_context(bundle);
-        self = self.app_context(AssetRouteResolver::new(Box::new(|bundled_asset, write| {
-            write.write_str(ASSET_ROUTE_PREFIX)?;
-            write.write_str("/")?;
-            write.write_str(
-                bundled_asset
-                    .name()
-                    .to_str()
-                    .expect("asset needs UTF-8 name"),
-            )?;
-            Ok(())
-        })));
+        self = self.app_context(AssetRouteResolver::default());
 
         self
     }


### PR DESCRIPTION
## Summary

- provide the standard asset route resolver through `AssetRouteResolver::default()`
- reuse that resolver when registering router assets

## Why

Non-request renderers need the same asset URL path logic as the HTTP router. Previously, the standard resolver was constructed only inside `RouterBuilderAssetExt::assets`, so other renderers had to duplicate it.

This gives mailers and other renderers a supported way to install the same resolver in their application context.

This PR is stacked on `codex/decouple-render-context` because that branch introduces the reusable application context consumed by the mailer.

## Checks

- `cargo fmt -p topcoat-asset -- --check`
- `cargo test -p topcoat-asset`
- `cargo clippy -p topcoat-asset --all-targets -- -D warnings`