### PR TITLE
Topcoat UI components: `card`, `input`, `select`, and `dropdown_menu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,7 @@ name = "topcoat-ui-registry"
 version = "0.1.0"
 dependencies = [
  "topcoat",
+ "topcoat-icon-iconify",
 ]
 
 [[package]]

--- a/crates/topcoat-cli/src/ui/init.rs
+++ b/crates/topcoat-cli/src/ui/init.rs
@@ -72,13 +72,13 @@ impl InitCommand {
             .dim(),
         );
 
-        // The theme's `--font-sans` expects the Lexend family to be available.
+        // The theme's `--font-sans` expects the Geist family to be available.
         // Point the user at topcoat-font to provide it.
         println!();
         println!(
             "{} This theme uses the {} font. Set it up with topcoat-font:",
             style("!").yellow(),
-            style("Lexend").bold(),
+            style("Geist").bold(),
         );
         println!(
             "  {} enable topcoat's {} feature",
@@ -88,7 +88,7 @@ impl InitCommand {
         println!("  {} load it in your page's <head>:", style("-").dim());
         println!(
             "{}",
-            style("      topcoat::font::link(font: fontsource_font!(LEXEND))").dim(),
+            style("      topcoat::font::link(font: fontsource_font!(GEIST))").dim(),
         );
         Ok(())
     }

--- a/crates/topcoat-ui/registry/Cargo.toml
+++ b/crates/topcoat-ui/registry/Cargo.toml
@@ -28,7 +28,7 @@ topcoat = { path = "../../topcoat", features = ["icon-iconify"] }
 # The staging API is used directly rather than through the `topcoat` facade:
 # a build-dependency on the facade would close the dependency cycle that the
 # dev-dependency above avoids.
-topcoat-icon-iconify = { workspace = true, features = ["build"] }
+topcoat-icon-iconify = { path = "../../topcoat-icon/iconify", features = ["build"] }
 
 [lints]
 workspace = true

--- a/crates/topcoat-ui/registry/Cargo.toml
+++ b/crates/topcoat-ui/registry/Cargo.toml
@@ -15,7 +15,13 @@ registry = "."
 # `topcoat` would form a cycle. As a dev-dependency it is available when the
 # component sources are compiled (under `cfg(test)`) without creating one.
 [dev-dependencies]
-topcoat.workspace = true
+topcoat = { workspace = true, features = ["icon-iconify"] }
+
+[build-dependencies]
+# The staging API is used directly rather than through the `topcoat` facade:
+# a build-dependency on the facade would close the dependency cycle that the
+# dev-dependency above avoids.
+topcoat-icon-iconify = { workspace = true, features = ["build"] }
 
 [lints]
 workspace = true

--- a/crates/topcoat-ui/registry/build.rs
+++ b/crates/topcoat-ui/registry/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Stage the Feather icon set for the `iconify_icon!` references in the
+    // component sources.
+    topcoat_icon_iconify::BuildConfig::new()
+        .icon_set("feather")
+        .stage()
+        .unwrap();
+}

--- a/crates/topcoat-ui/registry/registry.toml
+++ b/crates/topcoat-ui/registry/registry.toml
@@ -14,3 +14,12 @@ source = "src/components/button.rs"
 
 [components.card]
 source = "src/components/card.rs"
+
+[components.dropdown_menu]
+source = "src/components/dropdown_menu.rs"
+
+[components.input]
+source = "src/components/input.rs"
+
+[components.select]
+source = "src/components/select.rs"

--- a/crates/topcoat-ui/registry/registry.toml
+++ b/crates/topcoat-ui/registry/registry.toml
@@ -11,3 +11,6 @@ source = "themes/neutral.css"
 
 [components.button]
 source = "src/components/button.rs"
+
+[components.card]
+source = "src/components/card.rs"

--- a/crates/topcoat-ui/registry/src/components.rs
+++ b/crates/topcoat-ui/registry/src/components.rs
@@ -1,1 +1,2 @@
 pub mod button;
+pub mod card;

--- a/crates/topcoat-ui/registry/src/components.rs
+++ b/crates/topcoat-ui/registry/src/components.rs
@@ -1,2 +1,5 @@
 pub mod button;
 pub mod card;
+pub mod dropdown_menu;
+pub mod input;
+pub mod select;

--- a/crates/topcoat-ui/registry/src/components/button.rs
+++ b/crates/topcoat-ui/registry/src/components/button.rs
@@ -140,7 +140,12 @@ pub async fn button(
 ) -> Result {
     view! {
         <button
-            class=(class!(BASE, variant.classes(), size.classes(), attrs.remove("class")))
+            class=(class!(
+                BASE,
+                variant.classes(),
+                size.classes(),
+                attrs.remove("class"),
+            ))
             (attrs)
         >
             (child)

--- a/crates/topcoat-ui/registry/src/components/button.rs
+++ b/crates/topcoat-ui/registry/src/components/button.rs
@@ -1,6 +1,5 @@
 use topcoat::{
     Result,
-    context::Cx,
     view::{Attributes, View, class, component, view},
 };
 
@@ -134,19 +133,17 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// directly.
 #[component]
 pub async fn button(
-    cx: &Cx,
     #[default] variant: ButtonVariant,
     #[default] size: ButtonSize,
     #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    // There is no tailwind-merge here, so a caller's `class` is appended
-    // rather than merged: a conflicting utility wins by being last, per the
-    // CSS cascade.
-    let class = class!(BASE, variant.classes(), size.classes());
-    if let Some(extra) = attrs.insert(cx, "class", class) {
-        attrs.insert(cx, "class", (class, " ", extra));
+    view! {
+        <button
+            class=(class!(BASE, variant.classes(), size.classes(), attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </button>
     }
-
-    view! { <button (attrs)>(child)</button> }
 }

--- a/crates/topcoat-ui/registry/src/components/button.rs
+++ b/crates/topcoat-ui/registry/src/components/button.rs
@@ -30,24 +30,31 @@ impl ButtonVariant {
     /// overrides. Every variant with a resting fill or border casts the
     /// theme's control shadow; `Ghost` is flat until hovered, so it casts
     /// none.
+    ///
+    /// Each variant sets its own border color rather than inheriting a
+    /// transparent one from [`BASE`]: with two border-color classes on the
+    /// same element, stylesheet order (not class order) would decide the
+    /// winner.
     fn classes(self) -> &'static str {
         match self {
             Self::Primary => {
-                "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 \
-                 active:bg-primary/80"
+                "border-transparent bg-primary text-primary-foreground shadow-xs \
+                 hover:bg-primary/90 active:bg-primary/80"
             }
             Self::Secondary => {
-                "bg-foreground/5 text-foreground shadow-xs hover:bg-foreground/10 \
-                 active:bg-foreground/15"
+                "border-transparent bg-foreground/5 text-foreground shadow-xs \
+                 hover:bg-foreground/10 active:bg-foreground/15"
             }
             Self::Outline => {
                 "border-border text-foreground shadow-xs hover:bg-foreground/5 \
                  active:bg-foreground/10"
             }
-            Self::Ghost => "text-foreground hover:bg-foreground/5 active:bg-foreground/10",
+            Self::Ghost => {
+                "border-transparent text-foreground hover:bg-foreground/5 active:bg-foreground/10"
+            }
             Self::Destructive => {
-                "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90 \
-                 active:bg-destructive/80"
+                "border-transparent bg-destructive text-destructive-foreground shadow-xs \
+                 hover:bg-destructive/90 active:bg-destructive/80"
             }
         }
     }
@@ -87,9 +94,9 @@ impl ButtonSize {
 
 /// The classes shared by every button, regardless of variant or size.
 ///
-/// Every button carries a transparent border so that the `Outline` variant,
-/// which only recolors it, does not change the button's dimensions.
-const BASE: &str = "inline-flex shrink-0 items-center justify-center border border-transparent \
+/// Every button carries a border (colored per variant) so that the `Outline`
+/// variant, which only recolors it, does not change the button's dimensions.
+const BASE: &str = "inline-flex shrink-0 items-center justify-center border \
     font-medium whitespace-nowrap transition-colors outline-none select-none \
     focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
     focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";

--- a/crates/topcoat-ui/registry/src/components/button.rs
+++ b/crates/topcoat-ui/registry/src/components/button.rs
@@ -1,6 +1,7 @@
 use topcoat::{
     Result,
-    view::{Attributes, View, component, view},
+    context::Cx,
+    view::{Attributes, View, class, component, view},
 };
 
 /// The visual style of a [`button`].
@@ -114,9 +115,9 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// A button component.
 ///
 /// The `variant` and `size` parameters select the styling, defaulting to
-/// `Primary` and `Md`. Extra `class`es are appended to the computed ones, and
-/// any further `attrs` (such as `type`, `disabled`, or event handlers) are
-/// forwarded to the underlying `<button>`. Child nodes become the button's
+/// `Primary` and `Md`. The `attrs` (such as `class`, `type`, `disabled`, or
+/// event handlers) are forwarded to the underlying `<button>`; a `class` among
+/// them is appended to the computed classes. Child nodes become the button's
 /// content.
 ///
 /// ```rust
@@ -133,21 +134,19 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// directly.
 #[component]
 pub async fn button(
+    cx: &Cx,
     #[default] variant: ButtonVariant,
     #[default] size: ButtonSize,
-    #[into]
-    #[default]
-    class: String,
-    #[default] attrs: Attributes,
+    #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    // There is no tailwind-merge here, so caller classes are appended rather
-    // than merged: a conflicting utility wins by being last, per the CSS
-    // cascade.
-    let class = match class.trim() {
-        "" => button_variants(variant, size),
-        extra => format!("{} {extra}", button_variants(variant, size)),
-    };
+    // There is no tailwind-merge here, so a caller's `class` is appended
+    // rather than merged: a conflicting utility wins by being last, per the
+    // CSS cascade.
+    let class = class!(BASE, variant.classes(), size.classes());
+    if let Some(extra) = attrs.insert(cx, "class", class) {
+        attrs.insert(cx, "class", (class, " ", extra));
+    }
 
-    view! { <button class=(class) (attrs)>(child)</button> }
+    view! { <button (attrs)>(child)</button> }
 }

--- a/crates/topcoat-ui/registry/src/components/card.rs
+++ b/crates/topcoat-ui/registry/src/components/card.rs
@@ -1,0 +1,98 @@
+use topcoat::{
+    Result,
+    view::{Attributes, View, class, component, view},
+};
+
+/// The classes for the [`card`] container.
+///
+/// The card is a column of sections separated by a uniform gap. It carries
+/// vertical padding only; each section brings its own horizontal padding, so
+/// full-bleed content such as an image can span the card's width. The card
+/// casts the theme's raised-surface shadow and sets its own background and
+/// text color, so it reads as a card on any ancestor.
+const CARD: &str = "flex flex-col gap-5 rounded-xl border border-border bg-background py-6 \
+    text-foreground shadow-sm";
+
+/// A card component: a bordered, raised surface grouping related content.
+///
+/// A card stacks sections vertically: typically a [`card_header`], then a
+/// [`card_content`], closed by a [`card_footer`]. Any section can be omitted.
+/// The `attrs` (such as `class` or event handlers) are forwarded to the
+/// underlying `<div>`; a `class` among them is appended to the computed
+/// classes. Child nodes become the card's sections.
+///
+/// ```rust
+/// view! {
+///     card(
+///         attrs: attributes! { class="max-w-sm" },
+///         card_header(
+///             card_title("Delete workspace")
+///             card_description("This cannot be undone.")
+///         )
+///         card_footer(
+///             attrs: attributes! { class="justify-end" },
+///             button(variant: ButtonVariant::Destructive, "Delete")
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn card(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! { <div class=(class!(CARD, attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The opening section of a [`card`], stacking a [`card_title`] and an
+/// optional [`card_description`].
+#[component]
+pub async fn card_header(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <div
+            class=(class!("flex flex-col gap-1.5 px-6", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
+}
+
+/// The heading of a [`card`], rendered as an `<h3>`.
+#[component]
+pub async fn card_title(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <h3 class=(class!("leading-none font-semibold", attrs.remove("class"))) (attrs)>
+            (child)
+        </h3>
+    }
+}
+
+/// The supporting text under a [`card_title`].
+#[component]
+pub async fn card_description(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <p
+            class=(class!("text-sm text-muted-foreground", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </p>
+    }
+}
+
+/// The main body of a [`card`].
+#[component]
+pub async fn card_content(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! { <div class=(class!("px-6", attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The closing section of a [`card`], a horizontal row for actions.
+#[component]
+pub async fn card_footer(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <div
+            class=(class!("flex items-center gap-2 px-6", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
+}

--- a/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
+++ b/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
@@ -1,0 +1,143 @@
+use topcoat::{
+    Result,
+    view::{Attributes, View, class, component, view},
+};
+
+/// A dropdown menu: a trigger that toggles a floating panel of actions.
+///
+/// Built on `<details>`, so it opens and closes without scripting: clicking
+/// the [`dropdown_menu_trigger`] toggles the [`dropdown_menu_content`] panel.
+/// Clicking outside does not close it; that behavior needs scripting. The
+/// `attrs` (such as `class` or `open`) are forwarded to the underlying
+/// `<details>`; a `class` among them is appended to the computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu(
+///         dropdown_menu_trigger("Options")
+///         dropdown_menu_content(
+///             dropdown_menu_item("Rename")
+///             dropdown_menu_item("Duplicate")
+///             dropdown_menu_separator()
+///             dropdown_menu_item(
+///                 attrs: attributes! { class="text-destructive" },
+///                 "Delete"
+///             )
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <details
+            class=(class!("group relative inline-block", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </details>
+    }
+}
+
+/// The trigger of a [`dropdown_menu`]: a `<summary>` that toggles the menu.
+///
+/// Child nodes become the trigger's content; any view works. The trigger
+/// carries no styling of its own: dress it as a button by passing the classes
+/// from [`button_variants`](super::button::button_variants), or leave it bare
+/// for a custom look. While the menu is open the `group-open:` variant
+/// applies within it, so a chevron with `group-open:rotate-180` flips along.
+/// The `attrs` are forwarded to the `<summary>`; a `class` among them is
+/// appended to the computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu_trigger(
+///         attrs: attributes! {
+///             class=(button_variants(ButtonVariant::Outline, ButtonSize::Md))
+///         },
+///         "Options"
+///         icon(
+///             data: iconify_icon!("feather:chevron-down"),
+///             attrs: attributes! { class="group-open:rotate-180" }
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu_trigger(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <summary
+            class=(class!(
+                "cursor-pointer list-none [&::-webkit-details-marker]:hidden",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+        </summary>
+    }
+}
+
+/// The classes for the [`dropdown_menu_content`] panel.
+///
+/// The panel drops directly below the trigger, aligned to its left edge, on a
+/// raised surface styled like a card; `z-50` lifts it over later content. It
+/// sets its own background and text color, so it reads the same on any
+/// ancestor.
+const CONTENT: &str = "absolute top-full left-0 z-50 mt-1 min-w-40 rounded-lg border \
+    border-border bg-background p-1 text-foreground shadow-sm";
+
+/// The floating panel of a [`dropdown_menu`], holding the menu's items.
+#[component]
+pub async fn dropdown_menu_content(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! { <div class=(class!(CONTENT, attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The classes for a [`dropdown_menu_item`] row.
+///
+/// Hover, focus, and press tint the row like a ghost button, deriving the
+/// states from the foreground color so they hold up in both color schemes.
+const ITEM: &str = "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm \
+    whitespace-nowrap outline-none hover:bg-foreground/5 focus-visible:bg-foreground/5 \
+    active:bg-foreground/10 disabled:pointer-events-none disabled:opacity-50";
+
+/// One action in a [`dropdown_menu_content`], rendered as a `<button>`.
+#[component]
+pub async fn dropdown_menu_item(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <button class=(class!(ITEM, attrs.remove("class"))) (attrs)>(child)</button>
+    }
+}
+
+/// A non-interactive heading grouping the items after it.
+#[component]
+pub async fn dropdown_menu_label(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <p
+            class=(class!(
+                "px-2 py-1.5 text-xs font-medium text-muted-foreground",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+        </p>
+    }
+}
+
+/// A hairline rule separating groups of items.
+#[component]
+pub async fn dropdown_menu_separator(#[default] mut attrs: Attributes) -> Result {
+    view! {
+        <hr class=(class!("-mx-1 my-1 border-border", attrs.remove("class"))) (attrs)>
+    }
+}

--- a/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
+++ b/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
@@ -1,6 +1,7 @@
 use topcoat::{
     Result,
-    view::{Attributes, View, class, component, view},
+    icon::{icon, iconify::iconify_icon},
+    view::{Attributes, View, attributes, class, component, view},
 };
 
 /// A dropdown menu: a trigger that toggles a floating panel of actions.
@@ -39,6 +40,10 @@ pub async fn dropdown_menu(#[default] mut attrs: Attributes, #[default] child: V
     }
 }
 
+/// The classes making a `<summary>` a plain clickable trigger: the default
+/// disclosure marker is hidden and the cursor marks it as interactive.
+const TRIGGER: &str = "cursor-pointer list-none [&::-webkit-details-marker]:hidden";
+
 /// The trigger of a [`dropdown_menu`]: a `<summary>` that toggles the menu.
 ///
 /// Child nodes become the trigger's content; any view works. The trigger
@@ -69,34 +74,35 @@ pub async fn dropdown_menu_trigger(
     #[default] child: View,
 ) -> Result {
     view! {
-        <summary
-            class=(class!(
-                "cursor-pointer list-none [&::-webkit-details-marker]:hidden",
-                attrs.remove("class"),
-            ))
-            (attrs)
-        >
+        <summary class=(class!(TRIGGER, attrs.remove("class"))) (attrs)>
             (child)
         </summary>
     }
 }
 
-/// The classes for the [`dropdown_menu_content`] panel.
-///
-/// The panel drops directly below the trigger, aligned to its left edge, on a
-/// raised surface styled like a card; `z-50` lifts it over later content. It
-/// sets its own background and text color, so it reads the same on any
-/// ancestor.
-const CONTENT: &str = "absolute top-full left-0 z-50 mt-1 min-w-40 rounded-lg border \
-    border-border bg-background p-1 text-foreground shadow-sm";
+/// The classes shared by the [`dropdown_menu_content`] and
+/// [`dropdown_menu_sub_content`] panels: a raised surface styled like a card;
+/// `z-50` lifts it over later content. It sets its own background and text
+/// color, so it reads the same on any ancestor.
+const PANEL: &str = "absolute z-50 min-w-40 rounded-lg border border-border bg-background p-1 \
+    text-foreground shadow-sm";
 
 /// The floating panel of a [`dropdown_menu`], holding the menu's items.
+///
+/// The panel drops directly below the trigger, aligned to its left edge.
 #[component]
 pub async fn dropdown_menu_content(
     #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    view! { <div class=(class!(CONTENT, attrs.remove("class"))) (attrs)>(child)</div> }
+    view! {
+        <div
+            class=(class!(PANEL, "top-full left-0 mt-1", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
 }
 
 /// The classes for a [`dropdown_menu_item`] row.
@@ -109,9 +115,99 @@ const ITEM: &str = "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-l
 
 /// One action in a [`dropdown_menu_content`], rendered as a `<button>`.
 #[component]
-pub async fn dropdown_menu_item(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+pub async fn dropdown_menu_item(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
     view! {
         <button class=(class!(ITEM, attrs.remove("class"))) (attrs)>(child)</button>
+    }
+}
+
+/// A nested submenu placed among the items of a [`dropdown_menu_content`].
+///
+/// Like the [`dropdown_menu`] itself it is built on `<details>`, so clicking
+/// the [`dropdown_menu_sub_trigger`] toggles its [`dropdown_menu_sub_content`]
+/// panel without scripting. The submenu tracks its own open state under the
+/// `group/sub` name, so the `group-open/sub:` variant targets it without
+/// disturbing the enclosing menu's `group`. Closing the enclosing menu hides
+/// an open submenu but does not close it, so it is open again the next time
+/// the menu opens; resetting it needs scripting. The `attrs` are forwarded to
+/// the underlying `<details>`; a `class` among them is appended to the
+/// computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu_content(
+///         dropdown_menu_item("Back")
+///         dropdown_menu_sub(
+///             dropdown_menu_sub_trigger("Move to")
+///             dropdown_menu_sub_content(
+///                 dropdown_menu_item("Inbox")
+///                 dropdown_menu_item("Archive")
+///             )
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu_sub(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <details class=(class!("group/sub relative", attrs.remove("class"))) (attrs)>
+            (child)
+        </details>
+    }
+}
+
+/// The trigger row of a [`dropdown_menu_sub`]: a `<summary>` styled as a
+/// [`dropdown_menu_item`] that toggles the submenu.
+///
+/// Child nodes become the row's label; a chevron pointing toward the submenu
+/// is appended automatically, and the row stays tinted while the submenu is
+/// open. The `attrs` are forwarded to the `<summary>`; a `class` among them is
+/// appended to the computed classes.
+#[component]
+pub async fn dropdown_menu_sub_trigger(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <summary
+            class=(class!(
+                ITEM,
+                TRIGGER,
+                "group-open/sub:bg-foreground/5",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+            icon(
+                data: iconify_icon!("feather:chevron-right"),
+                attrs: attributes! { class="ml-auto size-4" }
+            )
+        </summary>
+    }
+}
+
+/// The floating panel of a [`dropdown_menu_sub`], holding the submenu's items.
+///
+/// A submenu opens beside its trigger rather than below it: `left-full` places
+/// it against the right edge of the parent panel, `top-0` lines its top up with
+/// the trigger row, and `ml-1` leaves the same gap the menu keeps from its own
+/// trigger.
+#[component]
+pub async fn dropdown_menu_sub_content(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <div
+            class=(class!(PANEL, "top-0 left-full ml-1", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
     }
 }
 

--- a/crates/topcoat-ui/registry/src/components/input.rs
+++ b/crates/topcoat-ui/registry/src/components/input.rs
@@ -1,0 +1,33 @@
+use topcoat::{
+    Result,
+    view::{Attributes, class, component, view},
+};
+
+/// The classes for the [`input`] control.
+///
+/// The height, text size, radius, shadow, and focus ring match the `Md`
+/// button, so an input and a button sit flush in a row. File inputs restyle
+/// the browser's upload button into quiet, borderless text.
+const INPUT: &str = "h-9 w-full min-w-0 rounded-lg border border-border bg-background px-3 \
+    text-sm shadow-xs transition-colors outline-none \
+    placeholder:text-muted-foreground \
+    file:mr-3 file:h-full file:border-0 file:bg-transparent file:text-sm file:font-medium \
+    focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
+    focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
+
+/// A text input component.
+///
+/// The `attrs` (such as `type`, `name`, `placeholder`, `disabled`, or event
+/// handlers) are forwarded to the underlying `<input>`; a `class` among them
+/// is appended to the computed classes. The input fills its container, so
+/// size it through the container or with a width class.
+///
+/// ```rust
+/// view! {
+///     input(attrs: attributes! { type="email" placeholder="you@example.com" })
+/// }
+/// ```
+#[component]
+pub async fn input(#[default] mut attrs: Attributes) -> Result {
+    view! { <input class=(class!(INPUT, attrs.remove("class"))) (attrs)> }
+}

--- a/crates/topcoat-ui/registry/src/components/select.rs
+++ b/crates/topcoat-ui/registry/src/components/select.rs
@@ -1,0 +1,124 @@
+use topcoat::{
+    Result,
+    context::Cx,
+    icon::{IconData, icon, iconify::iconify_icon},
+    view::{Attributes, View, attributes, class, component, view},
+};
+
+/// The classes for the native `<select>` inside the [`select`] component.
+///
+/// Sized to match the input control. The native dropdown arrow is suppressed
+/// so the component can draw its own chevron, which keeps the control looking
+/// the same across browsers; the extra right padding reserves the chevron's
+/// space.
+const SELECT: &str = "h-9 w-full appearance-none items-center rounded-lg border border-border \
+    bg-background pr-8 pl-3 text-left text-sm shadow-xs transition-colors outline-none \
+    focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
+    focus-visible:ring-offset-background disabled:pointer-events-none";
+
+/// The classes restyling the drop-down picker, for browsers that support
+/// customizable selects (`appearance: base-select`, set on the `<select>` by
+/// the component's wrapper).
+///
+/// The panel and its option rows take after the dropdown menu's content and
+/// items: the same raised surface, the same ghost-tinted hover and focus
+/// states, and the checked option marked by a checkmark on the row's right
+/// edge: the [`CHECKMARK`] icon, masked over the theme's muted foreground
+/// (see [`checkmark_style`]). The browser's own picker icon is hidden in
+/// favor of the component's chevron. On browsers without support every rule
+/// here is inert and the operating system's picker shows instead.
+const PICKER: &str = "[&::picker(select)]:[appearance:base-select] \
+    [&::picker(select)]:mt-1 [&::picker(select)]:rounded-lg \
+    [&::picker(select)]:border [&::picker(select)]:border-border \
+    [&::picker(select)]:bg-background [&::picker(select)]:p-1 \
+    [&::picker(select)]:text-foreground [&::picker(select)]:shadow-sm \
+    [&::picker-icon]:hidden \
+    [&_option]:flex [&_option]:items-center [&_option]:gap-2 [&_option]:rounded-md \
+    [&_option]:px-2 [&_option]:py-1.5 [&_option]:text-sm [&_option]:outline-none \
+    [&_option:hover]:bg-foreground/5 [&_option:focus]:bg-foreground/5 \
+    [&_option:checked]:font-medium \
+    [&_option::checkmark]:order-1 [&_option::checkmark]:ml-auto \
+    [&_option::checkmark]:size-4 [&_option::checkmark]:shrink-0 \
+    [&_option::checkmark]:content-[''] [&_option::checkmark]:bg-muted-foreground \
+    [&_option::checkmark]:[mask-size:100%_100%] \
+    [&_option::checkmark]:[mask-image:var(--select-checkmark)]";
+
+/// The icon marking the picker's checked option.
+const CHECKMARK: IconData = iconify_icon!("feather:check");
+
+/// The inline style for the [`select`] wrapper, carrying [`CHECKMARK`] as a
+/// data URI in the `--select-checkmark` custom property. The indirection
+/// exists because the `::checkmark` pseudo-element can only take the icon
+/// through a stylesheet, as a mask image, while the icon's markup is only
+/// available here.
+fn checkmark_style(cx: &Cx) -> String {
+    let svg = format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{}">{}</svg>"#,
+        CHECKMARK.view_box(),
+        CHECKMARK.into_body().render(cx),
+    );
+    let mut style = String::from(r#"--select-checkmark: url("data:image/svg+xml,"#);
+    // Percent-encode the characters that cannot appear in a double-quoted
+    // CSS url().
+    for char in svg.chars() {
+        match char {
+            '%' => style.push_str("%25"),
+            '"' => style.push_str("%22"),
+            '#' => style.push_str("%23"),
+            _ => style.push(char),
+        }
+    }
+    style.push_str(r#"")"#);
+    style
+}
+
+/// A select component: a themed native `<select>`.
+///
+/// Child nodes become the `<select>`'s content, typically `<option>` and
+/// `<optgroup>` elements. The `attrs` (such as `name`, `disabled`, or event
+/// handlers) are forwarded to the `<select>`; a `class` among them is appended
+/// to the wrapping element's classes, so width utilities size the whole
+/// control. Like the input, it fills its container by default.
+///
+/// On browsers with customizable select support the drop-down picker is
+/// restyled to match the dropdown menu component, and the chevron flips while
+/// it is open; other browsers keep the operating system's picker. The control
+/// itself looks the same everywhere.
+///
+/// ```rust
+/// view! {
+///     select(
+///         attrs: attributes! { name="region" },
+///         <option>"eu-central-1"</option>
+///         <option>"us-east-1"</option>
+///     )
+/// }
+/// ```
+#[component]
+pub async fn select(cx: &Cx, #[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    // `appearance: base-select` opts into the customizable picker. It is set
+    // from the wrapper because the descendant selector outranks the
+    // `appearance-none` fallback in specificity, making the outcome
+    // independent of stylesheet order; browsers without support drop the
+    // invalid declaration and keep the fallback.
+    view! {
+        <span
+            class=(class!(
+                "relative block has-[:disabled]:opacity-50 \
+                 [&>select]:[appearance:base-select] \
+                 [&:has(select:open)>svg]:rotate-180",
+                attrs.remove("class"),
+            ))
+            style=(checkmark_style(cx))
+        >
+            <select class=(class!(SELECT, PICKER)) (attrs)>(child)</select>
+            icon(
+                data: iconify_icon!("feather:chevron-down"),
+                attrs: attributes! {
+                    class="pointer-events-none absolute top-1/2 right-3 size-4 \
+                        -translate-y-1/2 text-muted-foreground transition-transform"
+                }
+            )
+        </span>
+    }
+}

--- a/crates/topcoat-ui/registry/themes/neutral.css
+++ b/crates/topcoat-ui/registry/themes/neutral.css
@@ -1,4 +1,4 @@
-/* Neutral, the built-in Topcoat theme: a graphite palette set in Lexend.
+/* Neutral, the built-in Topcoat theme.
 
    The theme is a small set of design tokens. Components refer to tokens only,
    never to raw colors, so a project restyles itself by editing the values in
@@ -20,7 +20,7 @@
    derive them by applying the fill or foreground color at reduced opacity,
    which adapts to both color schemes automatically.
 
-   The Lexend font is not bundled here; provide it with topcoat-font. */
+   The Geist font is not bundled here; provide it with topcoat-font. */
 
 @import "tailwindcss";
 
@@ -36,7 +36,7 @@
    `border-border`, ...). The indirection through plain variables on `:root`
    and `.dark` is what lets the values swap when the color scheme changes. */
 @theme inline {
-  --font-sans: "Lexend", sans-serif;
+  --font-sans: "Geist", sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-muted-foreground: var(--muted-foreground);

--- a/crates/topcoat-ui/registry/themes/neutral.css
+++ b/crates/topcoat-ui/registry/themes/neutral.css
@@ -60,9 +60,10 @@
   --destructive-foreground: oklch(0.99 0.012 27);
   --border: oklch(0.9 0.008 260);
   --ring: oklch(0.62 0.06 260);
-  --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 7%);
+  --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 12%);
   --shadow-sm:
-    0 1px 2px oklch(0.24 0.02 260 / 7%), 0 2px 8px -2px oklch(0.24 0.02 260 / 6%);
+    0 1px 2px oklch(0.24 0.02 260 / 10%),
+    0 2px 8px -2px oklch(0.24 0.02 260 / 9%);
 }
 
 .dark {

--- a/crates/topcoat-view/macro/docs/class.md
+++ b/crates/topcoat-view/macro/docs/class.md
@@ -43,7 +43,7 @@ view! {
 # }
 ```
 
-An entry can be any value implementing [`ClassViewParts`]: string types, `Option`s of them, a `Vec` or array of entries, or another [`Class`]. Implement the trait for your own types to use them as entries.
+An entry can be any value implementing [`ClassViewParts`]: string types, `Option`s of them, a `Vec` or array of entries, another [`Class`], or an attribute value ([`ViewPart`]) taken from an [`Attributes`] collection. Implement the trait for your own types to use them as entries.
 
 # Absent entries
 
@@ -63,7 +63,9 @@ view! {
 # }
 ```
 
+[`Attributes`]: struct.Attributes.html
 [`Class`]: struct.Class.html
 [`ClassViewParts`]: trait.ClassViewParts.html
+[`ViewPart`]: enum.ViewPart.html
 [`class!`]: macro.class.html
 [`topcoat::view::Class`]: struct.Class.html

--- a/crates/topcoat-view/macro/tests/attributes.rs
+++ b/crates/topcoat-view/macro/tests/attributes.rs
@@ -9,7 +9,7 @@ fn attributes_macro_builds_runtime_attributes() {
         ("data-after", "after"),
     ];
 
-    let mut attrs = topcoat::view::attributes! {
+    let attrs = topcoat::view::attributes! {
         cx =>
         class="button"
         id=(id)

--- a/crates/topcoat-view/src/attribute/attributes.rs
+++ b/crates/topcoat-view/src/attribute/attributes.rs
@@ -55,7 +55,7 @@ impl Attributes {
 
     /// Returns the view parts stored for attribute key `k`, if present.
     #[inline]
-    pub fn get(&mut self, k: impl AsRef<str>) -> Option<&ViewPart> {
+    pub fn get(&self, k: impl AsRef<str>) -> Option<&ViewPart> {
         self.map.get(k.as_ref())
     }
 
@@ -84,6 +84,13 @@ impl Attributes {
         } else {
             self.map.insert(k.into(), ViewPart::empty())
         }
+    }
+
+    /// Removes an attribute, returning its rendered value if the key was
+    /// present.
+    #[inline]
+    pub fn remove(&mut self, k: impl AsRef<str>) -> Option<ViewPart> {
+        self.map.remove(k.as_ref())
     }
 
     /// Removes all attributes from the collection.
@@ -195,6 +202,15 @@ mod tests {
         attrs.insert(&Cx::default(), "class", "button");
         assert!(attrs.get("class").is_some());
         assert!(attrs.get("missing").is_none());
+    }
+
+    #[test]
+    fn remove_returns_value_and_deletes_entry() {
+        let mut attrs = Attributes::new();
+        attrs.insert(&Cx::default(), "class", "button");
+        assert!(attrs.remove("class").is_some());
+        assert!(!attrs.contains_key("class"));
+        assert!(attrs.remove("class").is_none());
     }
 
     #[test]

--- a/crates/topcoat-view/src/class.rs
+++ b/crates/topcoat-view/src/class.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use topcoat_core::context::Cx;
 
-use crate::{AttributeValueViewParts, PartsWriter};
+use crate::{AttributeValueViewParts, PartsWriter, ViewPart};
 
 /// Converts a value used as a class list entry into view parts.
 ///
@@ -71,6 +71,35 @@ impl ClassViewParts for Cow<'static, str> {
     #[inline]
     fn into_view_parts(self, _cx: &Cx, parts: &mut PartsWriter<'_>) {
         parts.push_str(self);
+    }
+}
+
+/// An attribute value, such as one taken from an
+/// [`Attributes`](crate::Attributes) collection with
+/// [`get`](crate::Attributes::get), spliced in as a single entry.
+impl ClassViewParts for ViewPart {
+    #[inline]
+    fn is_present(&self) -> bool {
+        self.attribute_present()
+    }
+
+    #[inline]
+    fn into_view_parts(self, _cx: &Cx, parts: &mut PartsWriter<'_>) {
+        // The part was already sealed with the context it was written in, so
+        // it is spliced in verbatim rather than escaped a second time.
+        parts.push_part(self);
+    }
+}
+
+impl ClassViewParts for &ViewPart {
+    #[inline]
+    fn is_present(&self) -> bool {
+        self.attribute_present()
+    }
+
+    #[inline]
+    fn into_view_parts(self, cx: &Cx, parts: &mut PartsWriter<'_>) {
+        ClassViewParts::into_view_parts(ViewPart::clone(self), cx, parts);
     }
 }
 
@@ -433,6 +462,20 @@ mod tests {
     fn array_entries_render_with_separators() {
         let class = Class([Some("a"), None, Some("b")]);
         assert_eq!(render(class), "a b");
+    }
+
+    #[test]
+    fn attribute_value_entries_are_spliced_verbatim() {
+        let mut parts = ViewParts::new();
+        PartsWriter::new(&mut parts, HtmlContext::AttributeValue).push_str("[&>*]:mt-2");
+        let part = ViewPart::from(parts);
+        assert_eq!(render(Class(("btn", &part))), "btn [&amp;>*]:mt-2");
+    }
+
+    #[test]
+    fn empty_attribute_value_entry_is_skipped_without_a_separator() {
+        let part = ViewPart::empty();
+        assert_eq!(render(Class(("a", &part, "b"))), "a b");
     }
 
     #[test]

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -9,9 +9,21 @@ hash = "sha256:0e87209c2c62b4a7bd091afc24f9635887d9fda2c90f4471534b1c26e9baa3ce"
 file = "styles.css"
 
 [registries.topcoat.components.button]
-hash = "sha256:47244c31d8274fc7d9512659b94306efcbcd9ea845369cc09691d8e5aced1aa0"
+hash = "sha256:db42b8405ca43e7bc857e9edeb78a115c4de5d4bee7d5085c357579ae2aaf01c"
 file = "src/components/button.rs"
 
 [registries.topcoat.components.card]
 hash = "sha256:45cbe0f5a790e7359ff72ecda4fbf40fb6c7bc8c4928593d1352813a86543a01"
 file = "src/components/card.rs"
+
+[registries.topcoat.components.dropdown_menu]
+hash = "sha256:9b7399d9cb61a3684dea25384a57184e389c3232c91406d5ba2efca8e7675c25"
+file = "src/components/dropdown_menu.rs"
+
+[registries.topcoat.components.input]
+hash = "sha256:fbbe56c47d871e333183ee8b91a0360fe4e7b4326bf7e71defee20417c55445c"
+file = "src/components/input.rs"
+
+[registries.topcoat.components.select]
+hash = "sha256:19d7779d8e7e75a2db78904232fa3db11f8e0e49cfca8a1852c4dcd686ac2d69"
+file = "src/components/select.rs"

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -5,11 +5,11 @@ components_dir = "src/components"
 [theme]
 name = "neutral"
 registry = "topcoat"
-hash = "sha256:0e87209c2c62b4a7bd091afc24f9635887d9fda2c90f4471534b1c26e9baa3ce"
+hash = "sha256:c7bdcb5ea4ff757611ba616e92178169b262be98155c06dfa2407584d51e7459"
 file = "styles.css"
 
 [registries.topcoat.components.button]
-hash = "sha256:db42b8405ca43e7bc857e9edeb78a115c4de5d4bee7d5085c357579ae2aaf01c"
+hash = "sha256:b7885ffcd75843ea22cf4fe496f666ef414d9d1f8fd5648a6b6d6de81550810c"
 file = "src/components/button.rs"
 
 [registries.topcoat.components.card]

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -11,3 +11,7 @@ file = "styles.css"
 [registries.topcoat.components.button]
 hash = "sha256:47244c31d8274fc7d9512659b94306efcbcd9ea845369cc09691d8e5aced1aa0"
 file = "src/components/button.rs"
+
+[registries.topcoat.components.card]
+hash = "sha256:45cbe0f5a790e7359ff72ecda4fbf40fb6c7bc8c4928593d1352813a86543a01"
+file = "src/components/card.rs"

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -17,7 +17,7 @@ hash = "sha256:45cbe0f5a790e7359ff72ecda4fbf40fb6c7bc8c4928593d1352813a86543a01"
 file = "src/components/card.rs"
 
 [registries.topcoat.components.dropdown_menu]
-hash = "sha256:9b7399d9cb61a3684dea25384a57184e389c3232c91406d5ba2efca8e7675c25"
+hash = "sha256:9e2a7e6f4992b8d38de3439bda5b1d92a8bd1dc6db1e579eb90601992c315a1a"
 file = "src/components/dropdown_menu.rs"
 
 [registries.topcoat.components.input]

--- a/examples/ui/src/components.rs
+++ b/examples/ui/src/components.rs
@@ -1,1 +1,2 @@
 pub mod button;
+pub mod card;

--- a/examples/ui/src/components.rs
+++ b/examples/ui/src/components.rs
@@ -1,2 +1,5 @@
 pub mod button;
 pub mod card;
+pub mod dropdown_menu;
+pub mod input;
+pub mod select;

--- a/examples/ui/src/components/button.rs
+++ b/examples/ui/src/components/button.rs
@@ -140,7 +140,12 @@ pub async fn button(
 ) -> Result {
     view! {
         <button
-            class=(class!(BASE, variant.classes(), size.classes(), attrs.remove("class")))
+            class=(class!(
+                BASE,
+                variant.classes(),
+                size.classes(),
+                attrs.remove("class"),
+            ))
             (attrs)
         >
             (child)

--- a/examples/ui/src/components/button.rs
+++ b/examples/ui/src/components/button.rs
@@ -1,6 +1,5 @@
 use topcoat::{
     Result,
-    context::Cx,
     view::{Attributes, View, class, component, view},
 };
 
@@ -134,19 +133,17 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// directly.
 #[component]
 pub async fn button(
-    cx: &Cx,
     #[default] variant: ButtonVariant,
     #[default] size: ButtonSize,
     #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    // There is no tailwind-merge here, so a caller's `class` is appended
-    // rather than merged: a conflicting utility wins by being last, per the
-    // CSS cascade.
-    let class = class!(BASE, variant.classes(), size.classes());
-    if let Some(extra) = attrs.insert(cx, "class", class) {
-        attrs.insert(cx, "class", (class, " ", extra));
+    view! {
+        <button
+            class=(class!(BASE, variant.classes(), size.classes(), attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </button>
     }
-
-    view! { <button (attrs)>(child)</button> }
 }

--- a/examples/ui/src/components/button.rs
+++ b/examples/ui/src/components/button.rs
@@ -30,24 +30,31 @@ impl ButtonVariant {
     /// overrides. Every variant with a resting fill or border casts the
     /// theme's control shadow; `Ghost` is flat until hovered, so it casts
     /// none.
+    ///
+    /// Each variant sets its own border color rather than inheriting a
+    /// transparent one from [`BASE`]: with two border-color classes on the
+    /// same element, stylesheet order (not class order) would decide the
+    /// winner.
     fn classes(self) -> &'static str {
         match self {
             Self::Primary => {
-                "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 \
-                 active:bg-primary/80"
+                "border-transparent bg-primary text-primary-foreground shadow-xs \
+                 hover:bg-primary/90 active:bg-primary/80"
             }
             Self::Secondary => {
-                "bg-foreground/5 text-foreground shadow-xs hover:bg-foreground/10 \
-                 active:bg-foreground/15"
+                "border-transparent bg-foreground/5 text-foreground shadow-xs \
+                 hover:bg-foreground/10 active:bg-foreground/15"
             }
             Self::Outline => {
                 "border-border text-foreground shadow-xs hover:bg-foreground/5 \
                  active:bg-foreground/10"
             }
-            Self::Ghost => "text-foreground hover:bg-foreground/5 active:bg-foreground/10",
+            Self::Ghost => {
+                "border-transparent text-foreground hover:bg-foreground/5 active:bg-foreground/10"
+            }
             Self::Destructive => {
-                "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90 \
-                 active:bg-destructive/80"
+                "border-transparent bg-destructive text-destructive-foreground shadow-xs \
+                 hover:bg-destructive/90 active:bg-destructive/80"
             }
         }
     }
@@ -87,9 +94,9 @@ impl ButtonSize {
 
 /// The classes shared by every button, regardless of variant or size.
 ///
-/// Every button carries a transparent border so that the `Outline` variant,
-/// which only recolors it, does not change the button's dimensions.
-const BASE: &str = "inline-flex shrink-0 items-center justify-center border border-transparent \
+/// Every button carries a border (colored per variant) so that the `Outline`
+/// variant, which only recolors it, does not change the button's dimensions.
+const BASE: &str = "inline-flex shrink-0 items-center justify-center border \
     font-medium whitespace-nowrap transition-colors outline-none select-none \
     focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
     focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";

--- a/examples/ui/src/components/button.rs
+++ b/examples/ui/src/components/button.rs
@@ -1,6 +1,7 @@
 use topcoat::{
     Result,
-    view::{Attributes, View, component, view},
+    context::Cx,
+    view::{Attributes, View, class, component, view},
 };
 
 /// The visual style of a [`button`].
@@ -114,9 +115,9 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// A button component.
 ///
 /// The `variant` and `size` parameters select the styling, defaulting to
-/// `Primary` and `Md`. Extra `class`es are appended to the computed ones, and
-/// any further `attrs` (such as `type`, `disabled`, or event handlers) are
-/// forwarded to the underlying `<button>`. Child nodes become the button's
+/// `Primary` and `Md`. The `attrs` (such as `class`, `type`, `disabled`, or
+/// event handlers) are forwarded to the underlying `<button>`; a `class` among
+/// them is appended to the computed classes. Child nodes become the button's
 /// content.
 ///
 /// ```rust
@@ -133,21 +134,19 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// directly.
 #[component]
 pub async fn button(
+    cx: &Cx,
     #[default] variant: ButtonVariant,
     #[default] size: ButtonSize,
-    #[into]
-    #[default]
-    class: String,
-    #[default] attrs: Attributes,
+    #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    // There is no tailwind-merge here, so caller classes are appended rather
-    // than merged: a conflicting utility wins by being last, per the CSS
-    // cascade.
-    let class = match class.trim() {
-        "" => button_variants(variant, size),
-        extra => format!("{} {extra}", button_variants(variant, size)),
-    };
+    // There is no tailwind-merge here, so a caller's `class` is appended
+    // rather than merged: a conflicting utility wins by being last, per the
+    // CSS cascade.
+    let class = class!(BASE, variant.classes(), size.classes());
+    if let Some(extra) = attrs.insert(cx, "class", class) {
+        attrs.insert(cx, "class", (class, " ", extra));
+    }
 
-    view! { <button class=(class) (attrs)>(child)</button> }
+    view! { <button (attrs)>(child)</button> }
 }

--- a/examples/ui/src/components/card.rs
+++ b/examples/ui/src/components/card.rs
@@ -1,0 +1,98 @@
+use topcoat::{
+    Result,
+    view::{Attributes, View, class, component, view},
+};
+
+/// The classes for the [`card`] container.
+///
+/// The card is a column of sections separated by a uniform gap. It carries
+/// vertical padding only; each section brings its own horizontal padding, so
+/// full-bleed content such as an image can span the card's width. The card
+/// casts the theme's raised-surface shadow and sets its own background and
+/// text color, so it reads as a card on any ancestor.
+const CARD: &str = "flex flex-col gap-5 rounded-xl border border-border bg-background py-6 \
+    text-foreground shadow-sm";
+
+/// A card component: a bordered, raised surface grouping related content.
+///
+/// A card stacks sections vertically: typically a [`card_header`], then a
+/// [`card_content`], closed by a [`card_footer`]. Any section can be omitted.
+/// The `attrs` (such as `class` or event handlers) are forwarded to the
+/// underlying `<div>`; a `class` among them is appended to the computed
+/// classes. Child nodes become the card's sections.
+///
+/// ```rust
+/// view! {
+///     card(
+///         attrs: attributes! { class="max-w-sm" },
+///         card_header(
+///             card_title("Delete workspace")
+///             card_description("This cannot be undone.")
+///         )
+///         card_footer(
+///             attrs: attributes! { class="justify-end" },
+///             button(variant: ButtonVariant::Destructive, "Delete")
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn card(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! { <div class=(class!(CARD, attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The opening section of a [`card`], stacking a [`card_title`] and an
+/// optional [`card_description`].
+#[component]
+pub async fn card_header(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <div
+            class=(class!("flex flex-col gap-1.5 px-6", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
+}
+
+/// The heading of a [`card`], rendered as an `<h3>`.
+#[component]
+pub async fn card_title(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <h3 class=(class!("leading-none font-semibold", attrs.remove("class"))) (attrs)>
+            (child)
+        </h3>
+    }
+}
+
+/// The supporting text under a [`card_title`].
+#[component]
+pub async fn card_description(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <p
+            class=(class!("text-sm text-muted-foreground", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </p>
+    }
+}
+
+/// The main body of a [`card`].
+#[component]
+pub async fn card_content(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! { <div class=(class!("px-6", attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The closing section of a [`card`], a horizontal row for actions.
+#[component]
+pub async fn card_footer(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <div
+            class=(class!("flex items-center gap-2 px-6", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
+}

--- a/examples/ui/src/components/dropdown_menu.rs
+++ b/examples/ui/src/components/dropdown_menu.rs
@@ -1,0 +1,143 @@
+use topcoat::{
+    Result,
+    view::{Attributes, View, class, component, view},
+};
+
+/// A dropdown menu: a trigger that toggles a floating panel of actions.
+///
+/// Built on `<details>`, so it opens and closes without scripting: clicking
+/// the [`dropdown_menu_trigger`] toggles the [`dropdown_menu_content`] panel.
+/// Clicking outside does not close it; that behavior needs scripting. The
+/// `attrs` (such as `class` or `open`) are forwarded to the underlying
+/// `<details>`; a `class` among them is appended to the computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu(
+///         dropdown_menu_trigger("Options")
+///         dropdown_menu_content(
+///             dropdown_menu_item("Rename")
+///             dropdown_menu_item("Duplicate")
+///             dropdown_menu_separator()
+///             dropdown_menu_item(
+///                 attrs: attributes! { class="text-destructive" },
+///                 "Delete"
+///             )
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <details
+            class=(class!("group relative inline-block", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </details>
+    }
+}
+
+/// The trigger of a [`dropdown_menu`]: a `<summary>` that toggles the menu.
+///
+/// Child nodes become the trigger's content; any view works. The trigger
+/// carries no styling of its own: dress it as a button by passing the classes
+/// from [`button_variants`](super::button::button_variants), or leave it bare
+/// for a custom look. While the menu is open the `group-open:` variant
+/// applies within it, so a chevron with `group-open:rotate-180` flips along.
+/// The `attrs` are forwarded to the `<summary>`; a `class` among them is
+/// appended to the computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu_trigger(
+///         attrs: attributes! {
+///             class=(button_variants(ButtonVariant::Outline, ButtonSize::Md))
+///         },
+///         "Options"
+///         icon(
+///             data: iconify_icon!("feather:chevron-down"),
+///             attrs: attributes! { class="group-open:rotate-180" }
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu_trigger(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <summary
+            class=(class!(
+                "cursor-pointer list-none [&::-webkit-details-marker]:hidden",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+        </summary>
+    }
+}
+
+/// The classes for the [`dropdown_menu_content`] panel.
+///
+/// The panel drops directly below the trigger, aligned to its left edge, on a
+/// raised surface styled like a card; `z-50` lifts it over later content. It
+/// sets its own background and text color, so it reads the same on any
+/// ancestor.
+const CONTENT: &str = "absolute top-full left-0 z-50 mt-1 min-w-40 rounded-lg border \
+    border-border bg-background p-1 text-foreground shadow-sm";
+
+/// The floating panel of a [`dropdown_menu`], holding the menu's items.
+#[component]
+pub async fn dropdown_menu_content(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! { <div class=(class!(CONTENT, attrs.remove("class"))) (attrs)>(child)</div> }
+}
+
+/// The classes for a [`dropdown_menu_item`] row.
+///
+/// Hover, focus, and press tint the row like a ghost button, deriving the
+/// states from the foreground color so they hold up in both color schemes.
+const ITEM: &str = "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm \
+    whitespace-nowrap outline-none hover:bg-foreground/5 focus-visible:bg-foreground/5 \
+    active:bg-foreground/10 disabled:pointer-events-none disabled:opacity-50";
+
+/// One action in a [`dropdown_menu_content`], rendered as a `<button>`.
+#[component]
+pub async fn dropdown_menu_item(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <button class=(class!(ITEM, attrs.remove("class"))) (attrs)>(child)</button>
+    }
+}
+
+/// A non-interactive heading grouping the items after it.
+#[component]
+pub async fn dropdown_menu_label(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <p
+            class=(class!(
+                "px-2 py-1.5 text-xs font-medium text-muted-foreground",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+        </p>
+    }
+}
+
+/// A hairline rule separating groups of items.
+#[component]
+pub async fn dropdown_menu_separator(#[default] mut attrs: Attributes) -> Result {
+    view! {
+        <hr class=(class!("-mx-1 my-1 border-border", attrs.remove("class"))) (attrs)>
+    }
+}

--- a/examples/ui/src/components/dropdown_menu.rs
+++ b/examples/ui/src/components/dropdown_menu.rs
@@ -1,6 +1,7 @@
 use topcoat::{
     Result,
-    view::{Attributes, View, class, component, view},
+    icon::{icon, iconify::iconify_icon},
+    view::{Attributes, View, attributes, class, component, view},
 };
 
 /// A dropdown menu: a trigger that toggles a floating panel of actions.
@@ -39,6 +40,10 @@ pub async fn dropdown_menu(#[default] mut attrs: Attributes, #[default] child: V
     }
 }
 
+/// The classes making a `<summary>` a plain clickable trigger: the default
+/// disclosure marker is hidden and the cursor marks it as interactive.
+const TRIGGER: &str = "cursor-pointer list-none [&::-webkit-details-marker]:hidden";
+
 /// The trigger of a [`dropdown_menu`]: a `<summary>` that toggles the menu.
 ///
 /// Child nodes become the trigger's content; any view works. The trigger
@@ -69,34 +74,35 @@ pub async fn dropdown_menu_trigger(
     #[default] child: View,
 ) -> Result {
     view! {
-        <summary
-            class=(class!(
-                "cursor-pointer list-none [&::-webkit-details-marker]:hidden",
-                attrs.remove("class"),
-            ))
-            (attrs)
-        >
+        <summary class=(class!(TRIGGER, attrs.remove("class"))) (attrs)>
             (child)
         </summary>
     }
 }
 
-/// The classes for the [`dropdown_menu_content`] panel.
-///
-/// The panel drops directly below the trigger, aligned to its left edge, on a
-/// raised surface styled like a card; `z-50` lifts it over later content. It
-/// sets its own background and text color, so it reads the same on any
-/// ancestor.
-const CONTENT: &str = "absolute top-full left-0 z-50 mt-1 min-w-40 rounded-lg border \
-    border-border bg-background p-1 text-foreground shadow-sm";
+/// The classes shared by the [`dropdown_menu_content`] and
+/// [`dropdown_menu_sub_content`] panels: a raised surface styled like a card;
+/// `z-50` lifts it over later content. It sets its own background and text
+/// color, so it reads the same on any ancestor.
+const PANEL: &str = "absolute z-50 min-w-40 rounded-lg border border-border bg-background p-1 \
+    text-foreground shadow-sm";
 
 /// The floating panel of a [`dropdown_menu`], holding the menu's items.
+///
+/// The panel drops directly below the trigger, aligned to its left edge.
 #[component]
 pub async fn dropdown_menu_content(
     #[default] mut attrs: Attributes,
     #[default] child: View,
 ) -> Result {
-    view! { <div class=(class!(CONTENT, attrs.remove("class"))) (attrs)>(child)</div> }
+    view! {
+        <div
+            class=(class!(PANEL, "top-full left-0 mt-1", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
+    }
 }
 
 /// The classes for a [`dropdown_menu_item`] row.
@@ -109,9 +115,99 @@ const ITEM: &str = "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-l
 
 /// One action in a [`dropdown_menu_content`], rendered as a `<button>`.
 #[component]
-pub async fn dropdown_menu_item(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+pub async fn dropdown_menu_item(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
     view! {
         <button class=(class!(ITEM, attrs.remove("class"))) (attrs)>(child)</button>
+    }
+}
+
+/// A nested submenu placed among the items of a [`dropdown_menu_content`].
+///
+/// Like the [`dropdown_menu`] itself it is built on `<details>`, so clicking
+/// the [`dropdown_menu_sub_trigger`] toggles its [`dropdown_menu_sub_content`]
+/// panel without scripting. The submenu tracks its own open state under the
+/// `group/sub` name, so the `group-open/sub:` variant targets it without
+/// disturbing the enclosing menu's `group`. Closing the enclosing menu hides
+/// an open submenu but does not close it, so it is open again the next time
+/// the menu opens; resetting it needs scripting. The `attrs` are forwarded to
+/// the underlying `<details>`; a `class` among them is appended to the
+/// computed classes.
+///
+/// ```rust
+/// view! {
+///     dropdown_menu_content(
+///         dropdown_menu_item("Back")
+///         dropdown_menu_sub(
+///             dropdown_menu_sub_trigger("Move to")
+///             dropdown_menu_sub_content(
+///                 dropdown_menu_item("Inbox")
+///                 dropdown_menu_item("Archive")
+///             )
+///         )
+///     )
+/// }
+/// ```
+#[component]
+pub async fn dropdown_menu_sub(#[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    view! {
+        <details class=(class!("group/sub relative", attrs.remove("class"))) (attrs)>
+            (child)
+        </details>
+    }
+}
+
+/// The trigger row of a [`dropdown_menu_sub`]: a `<summary>` styled as a
+/// [`dropdown_menu_item`] that toggles the submenu.
+///
+/// Child nodes become the row's label; a chevron pointing toward the submenu
+/// is appended automatically, and the row stays tinted while the submenu is
+/// open. The `attrs` are forwarded to the `<summary>`; a `class` among them is
+/// appended to the computed classes.
+#[component]
+pub async fn dropdown_menu_sub_trigger(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <summary
+            class=(class!(
+                ITEM,
+                TRIGGER,
+                "group-open/sub:bg-foreground/5",
+                attrs.remove("class"),
+            ))
+            (attrs)
+        >
+            (child)
+            icon(
+                data: iconify_icon!("feather:chevron-right"),
+                attrs: attributes! { class="ml-auto size-4" }
+            )
+        </summary>
+    }
+}
+
+/// The floating panel of a [`dropdown_menu_sub`], holding the submenu's items.
+///
+/// A submenu opens beside its trigger rather than below it: `left-full` places
+/// it against the right edge of the parent panel, `top-0` lines its top up with
+/// the trigger row, and `ml-1` leaves the same gap the menu keeps from its own
+/// trigger.
+#[component]
+pub async fn dropdown_menu_sub_content(
+    #[default] mut attrs: Attributes,
+    #[default] child: View,
+) -> Result {
+    view! {
+        <div
+            class=(class!(PANEL, "top-0 left-full ml-1", attrs.remove("class")))
+            (attrs)
+        >
+            (child)
+        </div>
     }
 }
 

--- a/examples/ui/src/components/input.rs
+++ b/examples/ui/src/components/input.rs
@@ -1,0 +1,33 @@
+use topcoat::{
+    Result,
+    view::{Attributes, class, component, view},
+};
+
+/// The classes for the [`input`] control.
+///
+/// The height, text size, radius, shadow, and focus ring match the `Md`
+/// button, so an input and a button sit flush in a row. File inputs restyle
+/// the browser's upload button into quiet, borderless text.
+const INPUT: &str = "h-9 w-full min-w-0 rounded-lg border border-border bg-background px-3 \
+    text-sm shadow-xs transition-colors outline-none \
+    placeholder:text-muted-foreground \
+    file:mr-3 file:h-full file:border-0 file:bg-transparent file:text-sm file:font-medium \
+    focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
+    focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50";
+
+/// A text input component.
+///
+/// The `attrs` (such as `type`, `name`, `placeholder`, `disabled`, or event
+/// handlers) are forwarded to the underlying `<input>`; a `class` among them
+/// is appended to the computed classes. The input fills its container, so
+/// size it through the container or with a width class.
+///
+/// ```rust
+/// view! {
+///     input(attrs: attributes! { type="email" placeholder="you@example.com" })
+/// }
+/// ```
+#[component]
+pub async fn input(#[default] mut attrs: Attributes) -> Result {
+    view! { <input class=(class!(INPUT, attrs.remove("class"))) (attrs)> }
+}

--- a/examples/ui/src/components/select.rs
+++ b/examples/ui/src/components/select.rs
@@ -1,0 +1,124 @@
+use topcoat::{
+    Result,
+    context::Cx,
+    icon::{IconData, icon, iconify::iconify_icon},
+    view::{Attributes, View, attributes, class, component, view},
+};
+
+/// The classes for the native `<select>` inside the [`select`] component.
+///
+/// Sized to match the input control. The native dropdown arrow is suppressed
+/// so the component can draw its own chevron, which keeps the control looking
+/// the same across browsers; the extra right padding reserves the chevron's
+/// space.
+const SELECT: &str = "h-9 w-full appearance-none items-center rounded-lg border border-border \
+    bg-background pr-8 pl-3 text-left text-sm shadow-xs transition-colors outline-none \
+    focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 \
+    focus-visible:ring-offset-background disabled:pointer-events-none";
+
+/// The classes restyling the drop-down picker, for browsers that support
+/// customizable selects (`appearance: base-select`, set on the `<select>` by
+/// the component's wrapper).
+///
+/// The panel and its option rows take after the dropdown menu's content and
+/// items: the same raised surface, the same ghost-tinted hover and focus
+/// states, and the checked option marked by a checkmark on the row's right
+/// edge: the [`CHECKMARK`] icon, masked over the theme's muted foreground
+/// (see [`checkmark_style`]). The browser's own picker icon is hidden in
+/// favor of the component's chevron. On browsers without support every rule
+/// here is inert and the operating system's picker shows instead.
+const PICKER: &str = "[&::picker(select)]:[appearance:base-select] \
+    [&::picker(select)]:mt-1 [&::picker(select)]:rounded-lg \
+    [&::picker(select)]:border [&::picker(select)]:border-border \
+    [&::picker(select)]:bg-background [&::picker(select)]:p-1 \
+    [&::picker(select)]:text-foreground [&::picker(select)]:shadow-sm \
+    [&::picker-icon]:hidden \
+    [&_option]:flex [&_option]:items-center [&_option]:gap-2 [&_option]:rounded-md \
+    [&_option]:px-2 [&_option]:py-1.5 [&_option]:text-sm [&_option]:outline-none \
+    [&_option:hover]:bg-foreground/5 [&_option:focus]:bg-foreground/5 \
+    [&_option:checked]:font-medium \
+    [&_option::checkmark]:order-1 [&_option::checkmark]:ml-auto \
+    [&_option::checkmark]:size-4 [&_option::checkmark]:shrink-0 \
+    [&_option::checkmark]:content-[''] [&_option::checkmark]:bg-muted-foreground \
+    [&_option::checkmark]:[mask-size:100%_100%] \
+    [&_option::checkmark]:[mask-image:var(--select-checkmark)]";
+
+/// The icon marking the picker's checked option.
+const CHECKMARK: IconData = iconify_icon!("feather:check");
+
+/// The inline style for the [`select`] wrapper, carrying [`CHECKMARK`] as a
+/// data URI in the `--select-checkmark` custom property. The indirection
+/// exists because the `::checkmark` pseudo-element can only take the icon
+/// through a stylesheet, as a mask image, while the icon's markup is only
+/// available here.
+fn checkmark_style(cx: &Cx) -> String {
+    let svg = format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{}">{}</svg>"#,
+        CHECKMARK.view_box(),
+        CHECKMARK.into_body().render(cx),
+    );
+    let mut style = String::from(r#"--select-checkmark: url("data:image/svg+xml,"#);
+    // Percent-encode the characters that cannot appear in a double-quoted
+    // CSS url().
+    for char in svg.chars() {
+        match char {
+            '%' => style.push_str("%25"),
+            '"' => style.push_str("%22"),
+            '#' => style.push_str("%23"),
+            _ => style.push(char),
+        }
+    }
+    style.push_str(r#"")"#);
+    style
+}
+
+/// A select component: a themed native `<select>`.
+///
+/// Child nodes become the `<select>`'s content, typically `<option>` and
+/// `<optgroup>` elements. The `attrs` (such as `name`, `disabled`, or event
+/// handlers) are forwarded to the `<select>`; a `class` among them is appended
+/// to the wrapping element's classes, so width utilities size the whole
+/// control. Like the input, it fills its container by default.
+///
+/// On browsers with customizable select support the drop-down picker is
+/// restyled to match the dropdown menu component, and the chevron flips while
+/// it is open; other browsers keep the operating system's picker. The control
+/// itself looks the same everywhere.
+///
+/// ```rust
+/// view! {
+///     select(
+///         attrs: attributes! { name="region" },
+///         <option>"eu-central-1"</option>
+///         <option>"us-east-1"</option>
+///     )
+/// }
+/// ```
+#[component]
+pub async fn select(cx: &Cx, #[default] mut attrs: Attributes, #[default] child: View) -> Result {
+    // `appearance: base-select` opts into the customizable picker. It is set
+    // from the wrapper because the descendant selector outranks the
+    // `appearance-none` fallback in specificity, making the outcome
+    // independent of stylesheet order; browsers without support drop the
+    // invalid declaration and keep the fallback.
+    view! {
+        <span
+            class=(class!(
+                "relative block has-[:disabled]:opacity-50 \
+                 [&>select]:[appearance:base-select] \
+                 [&:has(select:open)>svg]:rotate-180",
+                attrs.remove("class"),
+            ))
+            style=(checkmark_style(cx))
+        >
+            <select class=(class!(SELECT, PICKER)) (attrs)>(child)</select>
+            icon(
+                data: iconify_icon!("feather:chevron-down"),
+                attrs: attributes! {
+                    class="pointer-events-none absolute top-1/2 right-3 size-4 \
+                        -translate-y-1/2 text-muted-foreground transition-transform"
+                }
+            )
+        </span>
+    }
+}

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -1,6 +1,9 @@
 mod components;
 
 use components::button::{ButtonSize, ButtonVariant, button, button_variants};
+use components::card::{
+    card, card_content, card_description, card_footer, card_header, card_title,
+};
 use topcoat::{
     Result,
     asset::{AssetBundle, RouterBuilderAssetExt},
@@ -107,24 +110,58 @@ async fn home() -> Result {
                     )
 
                     showcase(
+                        title: "Card",
+                        description: "A card stacks a header, content, and footer \
+                            on a bordered, raised surface. Every section is \
+                            optional.",
+                        card(
+                            attrs: attributes! { class="max-w-sm" },
+                            card_header(
+                                card_title("Invite your team")
+                                card_description(
+                                    "Collaborators get access to every project \
+                                     in this workspace."
+                                )
+                            )
+                            card_content(
+                                <p class="text-sm">
+                                    "Invited members can view and edit projects, \
+                                     but only owners can change billing."
+                                </p>
+                            )
+                            card_footer(
+                                button(size: ButtonSize::Sm, "Send invites")
+                                button(
+                                    size: ButtonSize::Sm,
+                                    variant: ButtonVariant::Ghost,
+                                    "Copy link"
+                                )
+                            )
+                        )
+                    )
+
+                    showcase(
                         title: "In context",
                         description: "A confirmation card pairing a quiet dismiss \
                             action with a destructive commit.",
-                        <div
-                            class="max-w-sm rounded-xl border border-border p-6 shadow-sm"
-                        >
-                            <h3 class="font-semibold">"Delete workspace"</h3>
-                            <p class="mt-1 text-sm text-muted-foreground">
-                                "This permanently removes the workspace and all of its data."
-                            </p>
-                            <div class="mt-5 flex justify-end gap-2">
+                        card(
+                            attrs: attributes! { class="max-w-sm" },
+                            card_header(
+                                card_title("Delete workspace")
+                                card_description(
+                                    "This permanently removes the workspace and \
+                                     all of its data."
+                                )
+                            )
+                            card_footer(
+                                attrs: attributes! { class="justify-end" },
                                 button(variant: ButtonVariant::Ghost, "Cancel")
                                 button(
                                     variant: ButtonVariant::Destructive,
                                     "Delete workspace"
                                 )
-                            </div>
-                        </div>
+                            )
+                        )
                     )
 
                     showcase(
@@ -159,23 +196,29 @@ async fn showcase(title: &'static str, description: &'static str, child: View) -
 #[component]
 async fn scheme_panel(label: &'static str) -> Result {
     view! {
-        <div class="rounded-xl border border-border bg-background p-5 shadow-sm">
-            <p class="text-xs font-medium text-muted-foreground">(label)</p>
-            <div class="mt-3 flex flex-wrap items-center gap-2">
-                button(size: ButtonSize::Sm, "Primary")
-                button(
-                    size: ButtonSize::Sm,
-                    variant: ButtonVariant::Secondary,
-                    "Secondary"
-                )
-                button(size: ButtonSize::Sm, variant: ButtonVariant::Outline, "Outline")
-                button(size: ButtonSize::Sm, variant: ButtonVariant::Ghost, "Ghost")
-                button(
-                    size: ButtonSize::Sm,
-                    variant: ButtonVariant::Destructive,
-                    "Destructive"
-                )
-            </div>
-        </div>
+        card(
+            card_content(
+                <p class="text-xs font-medium text-muted-foreground">(label)</p>
+                <div class="mt-3 flex flex-wrap items-center gap-2">
+                    button(size: ButtonSize::Sm, "Primary")
+                    button(
+                        size: ButtonSize::Sm,
+                        variant: ButtonVariant::Secondary,
+                        "Secondary"
+                    )
+                    button(
+                        size: ButtonSize::Sm,
+                        variant: ButtonVariant::Outline,
+                        "Outline"
+                    )
+                    button(size: ButtonSize::Sm, variant: ButtonVariant::Ghost, "Ghost")
+                    button(
+                        size: ButtonSize::Sm,
+                        variant: ButtonVariant::Destructive,
+                        "Destructive"
+                    )
+                </div>
+            )
+        )
     }
 }

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -8,7 +8,7 @@ use topcoat::{
     Result,
     asset::{AssetBundle, RouterBuilderAssetExt},
     font::fontsource::fontsource_font,
-    icon::{icon, iconify},
+    icon::{icon, iconify::iconify_icon},
     router::{Router, RouterBuilderDiscoverExt, page},
     tailwind,
     view::{View, attributes, component, view},
@@ -38,37 +38,137 @@ async fn home() -> Result {
             // The body's background, text color, and font come from the
             // theme's base layer in styles.css; nothing to set up here.
             <body>
-                <main class="mx-auto max-w-3xl px-6 py-16">
-                    <h1 class="text-4xl font-bold tracking-tight">"Topcoat UI"</h1>
-                    <p class="mt-3 max-w-xl text-muted-foreground">
-                        "Components vendored into this project with "
-                        <code class="text-foreground">"topcoat ui add"</code>
-                        ", styled by the design tokens of the installed theme."
-                    </p>
-                    <div class="mt-6 flex flex-wrap items-center gap-3">
-                        button(
-                            size: ButtonSize::Lg,
-                            "Get started"
-                            icon(data: iconify::iconify_icon!("feather:arrow-right"))
-                        )
-                        // Anything can borrow a button's looks: `button_variants`
-                        // returns the class string for a variant and size.
-                        <a
-                            href="https://github.com/tokio-rs/topcoat"
-                            class=(button_variants(
-                                ButtonVariant::Outline,
-                                ButtonSize::Lg,
-                            ))
-                        >
-                            "View on GitHub"
-                        </a>
-                    </div>
+                <main class="mx-auto max-w-6xl px-6 py-16">
+                    <header class="max-w-2xl">
+                        <h1 class="text-4xl font-bold tracking-tight">
+                            "Build your component library"
+                        </h1>
+                        <p class="mt-3 text-muted-foreground">
+                            "Accessible, themeable components vendored into your \
+                             project with "
+                            <code class="text-foreground">"topcoat ui add"</code>
+                            ". Yours to restyle, rewrite, and ship."
+                        </p>
+                        <div class="mt-6 flex flex-wrap items-center gap-3">
+                            button(
+                                size: ButtonSize::Lg,
+                                "Get started"
+                                icon(data: iconify_icon!("feather:arrow-right"))
+                            )
+                            // Anything can borrow a button's looks:
+                            // `button_variants` returns the class string for a
+                            // variant and size.
+                            <a
+                                href="https://github.com/tokio-rs/topcoat"
+                                class=(button_variants(
+                                    ButtonVariant::Outline,
+                                    ButtonSize::Lg,
+                                ))
+                            >
+                                "View on GitHub"
+                            </a>
+                        </div>
+                    </header>
 
-                    showcase(
-                        title: "Variants",
-                        description: "Five variants rank actions from the one \
-                            primary action of a screen down to inline commands, \
-                            plus a destructive style for irreversible ones.",
+                    // A masonry of small, self-contained demos. Each cell is
+                    // a `demo` (built from installed components) or a
+                    // `coming_soon` placeholder for one not yet in the
+                    // registry.
+                    <div class="mt-14 columns-1 gap-4 sm:columns-2 xl:columns-3">
+                        demo(team_card())
+                        demo(buttons_card())
+                        coming_soon(name: "Input")
+                        demo(upgrade_card())
+                        demo(deploy_card())
+                        coming_soon(name: "Tabs")
+                        demo(delete_card())
+                        coming_soon(name: "Switch")
+                        demo(share_card())
+                        coming_soon(name: "Select")
+                        demo(notifications_card())
+                        coming_soon(name: "Dialog")
+                        coming_soon(name: "Dropdown menu")
+                        coming_soon(name: "Avatar")
+                    </div>
+                </main>
+            </body>
+        </html>
+    }
+}
+
+/// A masonry cell: keeps a demo from splitting across columns.
+#[component]
+async fn demo(child: View) -> Result {
+    view! { <div class="mb-4 break-inside-avoid">(child)</div> }
+}
+
+/// A placeholder cell for a component that is not in the registry yet.
+#[component]
+async fn coming_soon(name: &'static str) -> Result {
+    view! {
+        <div
+            class="mb-4 flex break-inside-avoid flex-col items-center justify-center \
+                gap-1 rounded-xl border border-dashed border-border px-6 py-10"
+        >
+            <p class="text-sm font-medium">(name)</p>
+            <p class="text-xs text-muted-foreground">"Coming soon"</p>
+        </div>
+    }
+}
+
+/// A team roster with per-member role controls.
+#[component]
+async fn team_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Your team")
+                card_description("Everyone with access to this workspace.")
+            )
+            card_content(
+                <div class="flex flex-col gap-4">
+                    for (name, email, role) in [
+                        ("Ada Lovelace", "ada@example.com", "Owner"),
+                        ("Grace Hopper", "grace@example.com", "Member"),
+                        ("Alan Turing", "alan@example.com", "Member"),
+                    ] {
+                        <div class="flex items-center justify-between gap-4">
+                            <div class="min-w-0">
+                                <p class="truncate text-sm font-medium">(name)</p>
+                                <p class="truncate text-xs text-muted-foreground">
+                                    (email)
+                                </p>
+                            </div>
+                            button(
+                                size: ButtonSize::Sm,
+                                variant: ButtonVariant::Outline,
+                                (role)
+                                icon(data: iconify_icon!("feather:chevron-down"))
+                            )
+                        </div>
+                    }
+                </div>
+            )
+            card_footer(
+                button(
+                    size: ButtonSize::Sm,
+                    variant: ButtonVariant::Secondary,
+                    icon(data: iconify_icon!("feather:user-plus"))
+                    "Invite member"
+                )
+            )
+        )
+    }
+}
+
+/// The button family: variants, sizes, and the disabled state at a glance.
+#[component]
+async fn buttons_card() -> Result {
+    view! {
+        card(
+            card_content(
+                <div class="flex flex-col gap-3">
+                    <div class="flex flex-wrap items-center gap-2">
                         for (variant, label) in [
                             (ButtonVariant::Primary, "Primary"),
                             (ButtonVariant::Secondary, "Secondary"),
@@ -76,148 +176,170 @@ async fn home() -> Result {
                             (ButtonVariant::Ghost, "Ghost"),
                             (ButtonVariant::Destructive, "Destructive"),
                         ] {
-                            button(variant: variant, (label))
+                            button(size: ButtonSize::Sm, variant: variant, (label))
                         }
-                    )
-
-                    showcase(
-                        title: "Sizes",
-                        description: "Three text sizes and a square one for \
-                            icon-only buttons. Icons are 1em square, so they \
-                            follow the button's text size.",
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2">
                         button(size: ButtonSize::Sm, "Small")
                         button(size: ButtonSize::Md, "Medium")
                         button(size: ButtonSize::Lg, "Large")
                         button(
                             size: ButtonSize::Icon,
                             variant: ButtonVariant::Outline,
-                            icon(
-                                data: iconify::iconify_icon!("feather:plus"),
-                                label: "Add item"
-                            )
+                            icon(data: iconify_icon!("feather:plus"), label: "Add item")
                         )
-                    )
-                    showcase(
-                        title: "Disabled",
-                        description: "Extra attributes forward to the underlying \
-                            <button> element, so disabling works like plain HTML.",
                         button(attrs: attributes! { disabled=(true) }, "Saving...")
-                        button(
-                            variant: ButtonVariant::Outline,
-                            attrs: attributes! { disabled=(true) },
-                            "Undo"
-                        )
-                    )
-
-                    showcase(
-                        title: "Card",
-                        description: "A card stacks a header, content, and footer \
-                            on a bordered, raised surface. Every section is \
-                            optional.",
-                        card(
-                            attrs: attributes! { class="max-w-sm" },
-                            card_header(
-                                card_title("Invite your team")
-                                card_description(
-                                    "Collaborators get access to every project \
-                                     in this workspace."
-                                )
-                            )
-                            card_content(
-                                <p class="text-sm">
-                                    "Invited members can view and edit projects, \
-                                     but only owners can change billing."
-                                </p>
-                            )
-                            card_footer(
-                                button(size: ButtonSize::Sm, "Send invites")
-                                button(
-                                    size: ButtonSize::Sm,
-                                    variant: ButtonVariant::Ghost,
-                                    "Copy link"
-                                )
-                            )
-                        )
-                    )
-
-                    showcase(
-                        title: "In context",
-                        description: "A confirmation card pairing a quiet dismiss \
-                            action with a destructive commit.",
-                        card(
-                            attrs: attributes! { class="max-w-sm" },
-                            card_header(
-                                card_title("Delete workspace")
-                                card_description(
-                                    "This permanently removes the workspace and \
-                                     all of its data."
-                                )
-                            )
-                            card_footer(
-                                attrs: attributes! { class="justify-end" },
-                                button(variant: ButtonVariant::Ghost, "Cancel")
-                                button(
-                                    variant: ButtonVariant::Destructive,
-                                    "Delete workspace"
-                                )
-                            )
-                        )
-                    )
-
-                    showcase(
-                        title: "Color schemes",
-                        description: "Components reference theme tokens instead of \
-                            raw colors, so putting the dark class on an ancestor \
-                            restyles everything inside it.",
-                        <div class="grid w-full gap-4 sm:grid-cols-2">
-                            scheme_panel(label: "Light")
-                            <div class="dark">scheme_panel(label: "Dark")</div>
-                        </div>
-                    )
-                </main>
-            </body>
-        </html>
+                    </div>
+                </div>
+            )
+        )
     }
 }
 
-/// A titled gallery section with a wrapping row for its demos.
+/// A pricing card with a feature list and an upgrade action.
 #[component]
-async fn showcase(title: &'static str, description: &'static str, child: View) -> Result {
-    view! {
-        <section class="mt-14">
-            <h2 class="text-lg font-semibold">(title)</h2>
-            <p class="mt-1 max-w-xl text-sm text-muted-foreground">(description)</p>
-            <div class="mt-5 flex flex-wrap items-center gap-3">(child)</div>
-        </section>
-    }
-}
-
-/// One color scheme's rendition of the button variants, on its own background.
-#[component]
-async fn scheme_panel(label: &'static str) -> Result {
+async fn upgrade_card() -> Result {
     view! {
         card(
+            card_header(
+                card_title("Pro")
+                card_description("For teams shipping to production.")
+            )
             card_content(
-                <p class="text-xs font-medium text-muted-foreground">(label)</p>
-                <div class="mt-3 flex flex-wrap items-center gap-2">
-                    button(size: ButtonSize::Sm, "Primary")
-                    button(
-                        size: ButtonSize::Sm,
-                        variant: ButtonVariant::Secondary,
-                        "Secondary"
+                <p>
+                    <span class="text-3xl font-bold">"$24"</span>
+                    <span class="text-sm text-muted-foreground">" / month"</span>
+                </p>
+                <ul class="mt-4 flex flex-col gap-2 text-sm">
+                    for feature in [
+                        "Unlimited projects",
+                        "Preview deployments",
+                        "Audit log",
+                        "Priority support",
+                    ] {
+                        <li class="flex items-center gap-2">
+                            icon(data: iconify_icon!("feather:check"))
+                            (feature)
+                        </li>
+                    }
+                </ul>
+            )
+            card_footer(button(attrs: attributes! { class="w-full" }, "Upgrade"))
+        )
+    }
+}
+
+/// A dark-scheme demo: the `dark` class on the wrapper restyles everything
+/// inside it, because components reference theme tokens instead of raw colors.
+#[component]
+async fn deploy_card() -> Result {
+    view! {
+        <div class="dark">
+            card(
+                card_header(
+                    card_title("Deployment ready")
+                    card_description(
+                        "topcoat-ui@0.4.2 built in 38s and passed all checks."
                     )
+                )
+                card_footer(
+                    button(size: ButtonSize::Sm, "Promote to production")
                     button(
                         size: ButtonSize::Sm,
+                        variant: ButtonVariant::Ghost,
+                        "View logs"
+                    )
+                )
+            )
+        </div>
+    }
+}
+
+/// A confirmation card pairing a quiet dismiss with a destructive commit.
+#[component]
+async fn delete_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Delete workspace")
+                card_description(
+                    "This permanently removes the workspace and all of its data."
+                )
+            )
+            card_footer(
+                attrs: attributes! { class="justify-end" },
+                button(variant: ButtonVariant::Ghost, "Cancel")
+                button(variant: ButtonVariant::Destructive, "Delete workspace")
+            )
+        )
+    }
+}
+
+/// A share sheet with a copyable link.
+#[component]
+async fn share_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Share this document")
+                card_description("Anyone with the link can view it.")
+            )
+            card_content(
+                <div class="flex items-center gap-2">
+                    <p
+                        class="min-w-0 flex-1 truncate rounded-lg border border-border \
+                            px-3 py-2 text-sm text-muted-foreground"
+                    >
+                        "https://topcoat.dev/d/quickstart"
+                    </p>
+                    button(
+                        size: ButtonSize::Icon,
                         variant: ButtonVariant::Outline,
-                        "Outline"
-                    )
-                    button(size: ButtonSize::Sm, variant: ButtonVariant::Ghost, "Ghost")
-                    button(
-                        size: ButtonSize::Sm,
-                        variant: ButtonVariant::Destructive,
-                        "Destructive"
+                        icon(data: iconify_icon!("feather:copy"), label: "Copy link")
                     )
                 </div>
+            )
+        )
+    }
+}
+
+/// An inbox digest with a bulk action in the footer.
+#[component]
+async fn notifications_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Notifications")
+                card_description("You have 3 unread messages.")
+            )
+            card_content(
+                <div class="flex flex-col gap-4">
+                    for (title, time) in [
+                        ("Your invoice for June is ready.", "2h ago"),
+                        ("grace@example.com joined your team.", "5h ago"),
+                        ("Deployment to production succeeded.", "1d ago"),
+                    ] {
+                        <div class="flex items-start gap-3">
+                            <span
+                                class="mt-1.5 size-2 shrink-0 rounded-full bg-primary"
+                            >
+
+                            </span>
+                            <div class="min-w-0">
+                                <p class="text-sm">(title)</p>
+                                <p class="text-xs text-muted-foreground">(time)</p>
+                            </div>
+                        </div>
+                    }
+                </div>
+            )
+            card_footer(
+                button(
+                    size: ButtonSize::Sm,
+                    variant: ButtonVariant::Outline,
+                    icon(data: iconify_icon!("feather:check"))
+                    "Mark all as read"
+                )
             )
         )
     }

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -39,7 +39,7 @@ async fn home() -> Result {
             <head>
                 <title>"Topcoat UI"</title>
                 topcoat::dev::script()
-                topcoat::font::link(font: fontsource_font!(LEXEND, host: Asset))
+                topcoat::font::link(font: fontsource_font!(GEIST, host: Asset))
                 <link rel="stylesheet" href=(tailwind::stylesheet!())>
             </head>
             // The body's background, text color, and font come from the

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -6,7 +6,8 @@ use components::card::{
 };
 use components::dropdown_menu::{
     dropdown_menu, dropdown_menu_content, dropdown_menu_item, dropdown_menu_label,
-    dropdown_menu_separator, dropdown_menu_trigger,
+    dropdown_menu_separator, dropdown_menu_sub, dropdown_menu_sub_content,
+    dropdown_menu_sub_trigger, dropdown_menu_trigger,
 };
 use components::input::input;
 use components::select::select;
@@ -297,12 +298,23 @@ async fn branches_card() -> Result {
                         dropdown_menu_item("feature/showcase")
                         dropdown_menu_item("feature/dark-mode")
                         dropdown_menu_separator()
+                        // A submenu opens its own panel beside this row; it is
+                        // rendered open here so the page shows it.
+                        dropdown_menu_sub(
+                            attrs: attributes! { open=(true) },
+                            dropdown_menu_sub_trigger("Checkout tag")
+                            dropdown_menu_sub_content(
+                                dropdown_menu_item("v1.2.0")
+                                dropdown_menu_item("v1.1.0")
+                                dropdown_menu_item("v1.0.0")
+                            )
+                        )
                         dropdown_menu_item("Create branch...")
                     )
                 )
-                // The open menu floats over the flow; reserve its room so it
-                // stays within the card.
-                <div class="h-44"></div>
+                // The open menu and submenu float over the flow; reserve
+                // their room so they stay within the card.
+                <div class="h-64"></div>
             )
         )
     }

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -4,6 +4,12 @@ use components::button::{ButtonSize, ButtonVariant, button, button_variants};
 use components::card::{
     card, card_content, card_description, card_footer, card_header, card_title,
 };
+use components::dropdown_menu::{
+    dropdown_menu, dropdown_menu_content, dropdown_menu_item, dropdown_menu_label,
+    dropdown_menu_separator, dropdown_menu_trigger,
+};
+use components::input::input;
+use components::select::select;
 use topcoat::{
     Result,
     asset::{AssetBundle, RouterBuilderAssetExt},
@@ -77,17 +83,17 @@ async fn home() -> Result {
                     <div class="mt-14 columns-1 gap-4 sm:columns-2 xl:columns-3">
                         demo(team_card())
                         demo(buttons_card())
-                        coming_soon(name: "Input")
+                        demo(sign_in_card())
                         demo(upgrade_card())
                         demo(deploy_card())
                         coming_soon(name: "Tabs")
                         demo(delete_card())
-                        coming_soon(name: "Switch")
+                        demo(branches_card())
                         demo(share_card())
-                        coming_soon(name: "Select")
+                        coming_soon(name: "Switch")
+                        demo(project_card())
                         demo(notifications_card())
                         coming_soon(name: "Dialog")
-                        coming_soon(name: "Dropdown menu")
                         coming_soon(name: "Avatar")
                     </div>
                 </main>
@@ -191,6 +197,112 @@ async fn buttons_card() -> Result {
                         button(attrs: attributes! { disabled=(true) }, "Saving...")
                     </div>
                 </div>
+            )
+        )
+    }
+}
+
+/// A sign-in form pairing labeled inputs with a full-width submit.
+#[component]
+async fn sign_in_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Sign in")
+                card_description("Use your work email to continue.")
+            )
+            card_content(
+                <form class="flex flex-col gap-4">
+                    <label class="flex flex-col gap-2">
+                        <span class="text-sm font-medium">"Email"</span>
+                        input(
+                            attrs: attributes! { type="email" placeholder="you@example.com" }
+                        )
+                    </label>
+                    <label class="flex flex-col gap-2">
+                        <span class="text-sm font-medium">"Password"</span>
+                        input(attrs: attributes! { type="password" })
+                    </label>
+                </form>
+            )
+            card_footer(button(attrs: attributes! { class="w-full" }, "Sign in"))
+        )
+    }
+}
+
+/// A creation form mixing an input, a select, and a confirming footer.
+#[component]
+async fn project_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Create project")
+                card_description("Deploys go to the region you pick here.")
+            )
+            card_content(
+                <form class="flex flex-col gap-4">
+                    <label class="flex flex-col gap-2">
+                        <span class="text-sm font-medium">"Name"</span>
+                        input(attrs: attributes! { placeholder="my-app" })
+                    </label>
+                    <label class="flex flex-col gap-2">
+                        <span class="text-sm font-medium">"Region"</span>
+                        select(
+                            <option>"eu-central-1"</option>
+                            <option>"us-east-1"</option>
+                            <option>"ap-southeast-2"</option>
+                        )
+                    </label>
+                </form>
+            )
+            card_footer(
+                attrs: attributes! { class="justify-end" },
+                button(variant: ButtonVariant::Ghost, "Cancel")
+                button("Create project")
+            )
+        )
+    }
+}
+
+/// A branch switcher, rendered open so the menu shows on the page.
+#[component]
+async fn branches_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Branches")
+                card_description("Switch the branch this preview builds from.")
+            )
+            card_content(
+                dropdown_menu(
+                    attrs: attributes! { open=(true) },
+                    // The trigger takes any content; this one borrows the
+                    // outline button's looks and adds a flipping chevron.
+                    dropdown_menu_trigger(
+                        attrs: attributes! {
+                            class=(button_variants(
+                                ButtonVariant::Outline,
+                                ButtonSize::Sm,
+                            ))
+                        },
+                        "feature/showcase"
+                        icon(
+                            data: iconify_icon!("feather:chevron-down"),
+                            attrs: attributes! { class="transition-transform group-open:rotate-180" }
+                        )
+                    )
+                    dropdown_menu_content(
+                        dropdown_menu_label("Switch branch")
+                        dropdown_menu_item("main")
+                        dropdown_menu_item("feature/showcase")
+                        dropdown_menu_item("feature/dark-mode")
+                        dropdown_menu_separator()
+                        dropdown_menu_item("Create branch...")
+                    )
+                )
+                // The open menu floats over the flow; reserve its room so it
+                // stays within the card.
+                <div class="h-44"></div>
             )
         )
     }

--- a/examples/ui/styles.css
+++ b/examples/ui/styles.css
@@ -1,4 +1,4 @@
-/* Neutral, the built-in Topcoat theme: a graphite palette set in Lexend.
+/* Neutral, the built-in Topcoat theme.
 
    The theme is a small set of design tokens. Components refer to tokens only,
    never to raw colors, so a project restyles itself by editing the values in
@@ -20,7 +20,7 @@
    derive them by applying the fill or foreground color at reduced opacity,
    which adapts to both color schemes automatically.
 
-   The Lexend font is not bundled here; provide it with topcoat-font. */
+   The Geist font is not bundled here; provide it with topcoat-font. */
 
 @import "tailwindcss";
 
@@ -36,7 +36,7 @@
    `border-border`, ...). The indirection through plain variables on `:root`
    and `.dark` is what lets the values swap when the color scheme changes. */
 @theme inline {
-  --font-sans: "Lexend", sans-serif;
+  --font-sans: "Geist", sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-muted-foreground: var(--muted-foreground);

--- a/examples/ui/styles.css
+++ b/examples/ui/styles.css
@@ -60,9 +60,10 @@
   --destructive-foreground: oklch(0.99 0.012 27);
   --border: oklch(0.9 0.008 260);
   --ring: oklch(0.62 0.06 260);
-  --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 7%);
+  --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 12%);
   --shadow-sm:
-    0 1px 2px oklch(0.24 0.02 260 / 7%), 0 2px 8px -2px oklch(0.24 0.02 260 / 6%);
+    0 1px 2px oklch(0.24 0.02 260 / 10%),
+    0 2px 8px -2px oklch(0.24 0.02 260 / 9%);
 }
 
 .dark {


### PR DESCRIPTION
- New `card` component.
- New `input` component.
- New `select` component.
- New `dropdown_menu` component.
- Switched from Lexend to Geist font.
- Fixed outlined button variant not having any outline.

<img width="366" height="324" alt="image" src="https://github.com/user-attachments/assets/5d39ec25-c5dd-478a-a602-9be519ee94d1" />
<img width="372" height="194" alt="image" src="https://github.com/user-attachments/assets/ccb39e3d-a7a2-42b0-9e4a-4d5ef76c0b40" />
<img width="369" height="412" alt="image" src="https://github.com/user-attachments/assets/e8e69d8b-394c-4573-9307-246bee96c33e" />
