### PR TITLE
chore: release v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -472,7 +472,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "tokio",
@@ -787,7 +787,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1002,7 +1002,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1413,7 +1413,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manual-router"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1928,7 +1928,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2243,7 +2243,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "toasty",
@@ -2611,7 +2611,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "futures-util",
  "inventory",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "http",
  "memchr",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "axum",
  "clap",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "cookie 0.18.1",
  "http",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "quote",
  "serde",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "inventory",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "quote",
  "syn",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "http",
  "serde",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "http",
  "quote",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "quote",
  "syn",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "criterion",
  "itoa",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "quote",
  "syn",
@@ -3107,7 +3107,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -97,30 +97,30 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-asset = { version = "0.0.3", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.0.3", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.0.3", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.0.3", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.0.3", path = "crates/topcoat-core/macro" }
-topcoat-font = { version = "0.0.3", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.0.3", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.0.3", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.0.3", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.0.3", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.0.3", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.0.3", path = "crates/topcoat-icon/macro" }
-topcoat-router = { version = "0.0.3", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.0.3", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.0.3", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.0.3", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.0.3", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.0.3", path = "crates/topcoat-runtime/macro" }
-topcoat-tailwind = { version = "0.0.3", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.0.3", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.0.3", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.0.3", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.0.3", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.0.3", path = "crates/topcoat-view/macro" }
+topcoat-asset = { version = "0.0.4", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.0.4", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.0.4", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.0.4", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.0.4", path = "crates/topcoat-core/macro" }
+topcoat-font = { version = "0.0.4", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.0.4", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.0.4", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.0.4", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.0.4", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.0.4", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.0.4", path = "crates/topcoat-icon/macro" }
+topcoat-router = { version = "0.0.4", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.0.4", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.0.4", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.0.4", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.0.4", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.0.4", path = "crates/topcoat-runtime/macro" }
+topcoat-tailwind = { version = "0.0.4", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.0.4", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.0.4", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.0.4", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.0.4", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.0.4", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-router/CHANGELOG.md
+++ b/crates/topcoat-router/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.0.3...topcoat-router-v0.0.4) - 2026-07-15
+
+### Added
+
+- tower layers ([#103](https://github.com/tokio-rs/topcoat/pull/103))
+
 ## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-router-v0.0.1) - 2026-07-14
 
 ### Other

--- a/crates/topcoat-ui/registry/CHANGELOG.md
+++ b/crates/topcoat-ui/registry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.0.3...topcoat-ui-registry-v0.0.4) - 2026-07-15
+
+### Fixed
+
+- build
+- build
+
 ## [0.0.2](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.0.1...topcoat-ui-registry-v0.0.2) - 2026-07-14
 
 ### Other

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.0.3...topcoat-view-v0.0.4) - 2026-07-15
+
+### Other
+
+- dtolnay itoa and zmij ([#102](https://github.com/tokio-rs/topcoat/pull/102))
+
 ## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-view-v0.0.1) - 2026-07-14
 
 ### Other

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.0.3...topcoat-v0.0.4) - 2026-07-15
+
+### Added
+
+- tower layers ([#103](https://github.com/tokio-rs/topcoat/pull/103))
+
 ## [0.0.3](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.0.2...topcoat-v0.0.3) - 2026-07-14
 
 ### Other

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.0.3", features = ["font-fontsource"] }
+topcoat = { version = "0.0.4", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.0.3", features = ["htmx"] }
+topcoat = { version = "0.0.4", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.0.3", features = ["icon-iconify"] }
+topcoat = { version = "0.0.4", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.0.3", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.0.4", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.0.3", features = ["tailwind"] }
+topcoat = { version = "0.0.4", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.0.3", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.0.4", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.0.3 -> 0.0.4
* `topcoat-view`: 0.0.3 -> 0.0.4 (✓ API compatible changes)
* `topcoat-router`: 0.0.3 -> 0.0.4 (✓ API compatible changes)
* `topcoat-asset`: 0.0.3 -> 0.0.4
* `topcoat-cookie`: 0.0.3 -> 0.0.4
* `topcoat-core-grammar`: 0.0.3 -> 0.0.4
* `topcoat-core-macro`: 0.0.3 -> 0.0.4
* `topcoat-view-grammar`: 0.0.3 -> 0.0.4
* `topcoat-view-macro`: 0.0.3 -> 0.0.4
* `topcoat-font`: 0.0.3 -> 0.0.4
* `topcoat-font-grammar`: 0.0.3 -> 0.0.4
* `topcoat-font-macro`: 0.0.3 -> 0.0.4
* `topcoat-htmx`: 0.0.3 -> 0.0.4
* `topcoat-icon`: 0.0.3 -> 0.0.4
* `topcoat-icon-grammar`: 0.0.3 -> 0.0.4
* `topcoat-icon-macro`: 0.0.3 -> 0.0.4
* `topcoat-router-grammar`: 0.0.3 -> 0.0.4
* `topcoat-router-macro`: 0.0.3 -> 0.0.4
* `topcoat-runtime`: 0.0.3 -> 0.0.4
* `topcoat-runtime-grammar`: 0.0.3 -> 0.0.4
* `topcoat-runtime-macro`: 0.0.3 -> 0.0.4
* `topcoat-tailwind`: 0.0.3 -> 0.0.4
* `topcoat-ui-registry`: 0.0.3 -> 0.0.4 (✓ API compatible changes)
* `topcoat`: 0.0.3 -> 0.0.4 (✓ API compatible changes)
* `topcoat-ui`: 0.0.3 -> 0.0.4
* `topcoat-cli`: 0.0.3 -> 0.0.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-core-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-view`

<blockquote>

## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.0.3...topcoat-view-v0.0.4) - 2026-07-15

### Other

- dtolnay itoa and zmij ([#102](https://github.com/tokio-rs/topcoat/pull/102))
</blockquote>

## `topcoat-router`

<blockquote>

## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.0.3...topcoat-router-v0.0.4) - 2026-07-15

### Added

- tower layers ([#103](https://github.com/tokio-rs/topcoat/pull/103))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-asset-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-cookie-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-core-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-core-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-view-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-view-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-font`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-font-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-font-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-font-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-htmx-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-icon-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-icon-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-icon-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-router-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-router-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-runtime-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-runtime-grammar-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-runtime-macro-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-tailwind-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.0.3...topcoat-ui-registry-v0.0.4) - 2026-07-15

### Fixed

- build
- build
</blockquote>

## `topcoat`

<blockquote>

## [0.0.4](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.0.3...topcoat-v0.0.4) - 2026-07-15

### Added

- tower layers ([#103](https://github.com/tokio-rs/topcoat/pull/103))
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.0.1](https://github.com/tokio-rs/topcoat/releases/tag/topcoat-ui-v0.0.1) - 2026-07-14

### Other

- initial release
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.0.2](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.0.1...topcoat-cli-v0.0.2) - 2026-07-14

### Other

- release v0.0.1 ([#93](https://github.com/tokio-rs/topcoat/pull/93))
- add udeps workflow ([#96](https://github.com/tokio-rs/topcoat/pull/96))
- Merge crates ([#94](https://github.com/tokio-rs/topcoat/pull/94))
- Work around release-plz bug
- Topcoat UI components: `card`, `input`, `select`, and `dropdown_menu` ([#91](https://github.com/tokio-rs/topcoat/pull/91))
- Use dotted topcoat paths
- Release plz ([#92](https://github.com/tokio-rs/topcoat/pull/92))
- Fix topcoat fmt line numbers ([#88](https://github.com/tokio-rs/topcoat/pull/88))
- Topcoat UI registry crate ([#87](https://github.com/tokio-rs/topcoat/pull/87))
- Add class macro ([#84](https://github.com/tokio-rs/topcoat/pull/84))
- Share version and edition across workspace
- Refactor ast/runtime split crates into grammar crates ([#83](https://github.com/tokio-rs/topcoat/pull/83))
- Icon improvements ([#76](https://github.com/tokio-rs/topcoat/pull/76))
- Support running commands in release mode ([#68](https://github.com/tokio-rs/topcoat/pull/68))
- Purge special characters ([#61](https://github.com/tokio-rs/topcoat/pull/61))
- Better dev server ([#60](https://github.com/tokio-rs/topcoat/pull/60))
- Remove README headlines
- Improve source code formatter ([#53](https://github.com/tokio-rs/topcoat/pull/53))
- Pretty printing for font macros ([#52](https://github.com/tokio-rs/topcoat/pull/52))
- Enable pedantic lints ([#45](https://github.com/tokio-rs/topcoat/pull/45))
- Ditch mod.rs ([#42](https://github.com/tokio-rs/topcoat/pull/42))
- Improve build times ([#41](https://github.com/tokio-rs/topcoat/pull/41))
- Better docs ([#37](https://github.com/tokio-rs/topcoat/pull/37))
- Topcoat UI ([#27](https://github.com/tokio-rs/topcoat/pull/27))
- Exclude non-mutating file access events from the dev file watcher ([#21](https://github.com/tokio-rs/topcoat/pull/21))
- Merge develop ([#11](https://github.com/tokio-rs/topcoat/pull/11))
- New example project and docs ([#9](https://github.com/tokio-rs/topcoat/pull/9))
- Fix cargo fingerprint issues
- Serve dev script from dev server
- Fix spinner issues
- Add progress numbers for dev rebuild
- Minor improvements
- Fix warning
- Refactor asset cli
- Refactor CLI
- Add clean command
- Add web assets
- Add default topcoat fmt
- Refactor view crate ast folder
- Add working route prototype
- Improve dev server asset error handling
- Minor improvements
- Add incremental bundling
- Refactor
- Add bundle CLI
- WIP
- Add asset list functionality
- Rename MacroRegistry to Registry
- Fix warnings
- Extract pretty printing into separate crate
- Fix CI errors
- Add formatting elapsed time print
- Improve formatter file logic
- Add topcoat fmt globbing
- Move rust str formatting to view macro crate
- Improve error printing
- Pretty print progress
- Start pretty printer
- Support multiple watch dirs
- Fix casing
- Use stable port for dev server
- First working dev server demo
- Clean up Cargo.tomls
- More improvements
- Add prettier dev server output
- Basic dev server
- Add basic CLI crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).