### PR TITLE
feat: add optional context accessors

### DIFF
--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -12,8 +12,9 @@ use crate::{abort::AbortStore, memoize::MemoizeCache};
 ///
 /// Pages, layouts, components, and routes can take `cx: &Cx` as an optional
 /// parameter when they need request-scoped information; Topcoat passes it
-/// automatically. Use it to read values registered for the request with
-/// [`app_context`] and [`request_context`].
+/// automatically. Use it to read values registered for the request with the
+/// app and request context helpers, such as [`app_context`] and
+/// [`request_context`].
 #[derive(Debug, Default)]
 pub struct Cx {
     id: CxId,
@@ -48,8 +49,8 @@ impl Cx {
 /// `&mut CxBuilder` through the layers wrapping the matched route so each can
 /// register request-scoped values with [`insert`](Self::insert) before the
 /// route runs. Because a `CxBuilder` dereferences to the [`Cx`] it is building,
-/// app and request context can be read through it (with [`app_context`] and
-/// [`request_context`]) while it is still being assembled.
+/// app and request context can be read through it (with helpers such as
+/// [`app_context`] and [`request_context`]) while it is still being assembled.
 #[derive(Debug, Default)]
 pub struct CxBuilder {
     cx: Cx,

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -4,14 +4,40 @@
 //! Each [`Cx`] carries two of them:
 //!
 //! - **App context** is registered once at startup and shared across every request handled by the
-//!   router. Within a request, [`app_context`] retrieves a reference to a registered value by its
-//!   type.
+//!   router. Within a request, [`app_context`] retrieves a required value and [`try_app_context`]
+//!   retrieves an optional value by its type.
 //! - **Request context** is scoped to a single request and dropped when the request ends. Within a
-//!   request, [`request_context`] retrieves a reference to a registered value by its type.
+//!   request, [`request_context`] retrieves a required value and [`try_request_context`] retrieves
+//!   an optional value by its type.
 
 use std::any::{Any, type_name};
 
 use crate::context::Cx;
+
+/// Returns a reference to the app context value of type `T` registered on the
+/// router, or `None` if no such value has been registered.
+///
+/// The lookup is keyed by `T`'s [`TypeId`](std::any::TypeId), so each type may
+/// have at most one registered value.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::context::{Cx, try_app_context};
+///
+/// struct FeatureConfig;
+///
+/// fn feature_config(cx: &Cx) -> Option<&FeatureConfig> {
+///     try_app_context(cx)
+/// }
+/// ```
+#[must_use]
+pub fn try_app_context<T>(cx: &Cx) -> Option<&T>
+where
+    T: Any + Send + Sync,
+{
+    cx.app_context.get::<T>()
+}
 
 /// Returns a reference to the app context value of type `T` registered on the
 /// router.
@@ -43,13 +69,40 @@ pub fn app_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,
 {
-    match cx.app_context.get::<T>() {
+    match try_app_context(cx) {
         Some(value) => value,
         None => panic!(
             "attempted to access app context of type `{:?}`, but this type was not registered for this context",
             type_name::<T>()
         ),
     }
+}
+
+/// Returns a reference to the request context value of type `T` registered on
+/// the current request's [`Cx`], or `None` if no such value has been registered.
+///
+/// The lookup is keyed by `T`'s [`TypeId`](std::any::TypeId), so each type may
+/// have at most one registered value per request. Request context lives only
+/// for the duration of the request that owns it; once the request completes,
+/// every value is dropped.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::context::{Cx, try_request_context};
+///
+/// struct Customer;
+///
+/// fn current_customer(cx: &Cx) -> Option<&Customer> {
+///     try_request_context(cx)
+/// }
+/// ```
+#[must_use]
+pub fn try_request_context<T>(cx: &Cx) -> Option<&T>
+where
+    T: Any + Send + Sync,
+{
+    cx.request_context.get::<T>()
 }
 
 /// Returns a reference to the request context value of type `T` registered on
@@ -80,7 +133,7 @@ pub fn request_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,
 {
-    match cx.request_context.get::<T>() {
+    match try_request_context(cx) {
         Some(value) => value,
         None => panic!(
             "attempted to access request context of type `{:?}`, but this type was not registered for this context",
@@ -94,7 +147,8 @@ where
 /// Each registered value is stored under its [`TypeId`](std::any::TypeId), so a given type can
 /// only be registered once per `ContextMap`. Used by [`Cx`] to hold both the
 /// router-wide app context and the per-request request context; values are
-/// retrieved within a request via [`app_context`] or [`request_context`].
+/// retrieved within a request via [`app_context`], [`try_app_context`],
+/// [`request_context`], or [`try_request_context`].
 #[derive(Default, Debug)]
 pub struct ContextMap {
     entries: anymap3::Map<dyn Any + Send + Sync>,
@@ -227,6 +281,21 @@ mod tests {
     }
 
     #[test]
+    fn try_app_context_returns_registered_value() {
+        let cx = CxTestBuilder::new()
+            .app_context(Database("primary"))
+            .build();
+
+        assert_eq!(try_app_context::<Database>(&cx), Some(&Database("primary")));
+    }
+
+    #[test]
+    fn try_app_context_returns_none_for_unregistered_type() {
+        let cx = Cx::default();
+        assert_eq!(try_app_context::<Database>(&cx), None);
+    }
+
+    #[test]
     #[should_panic(expected = "attempted to access app context")]
     fn app_context_panics_for_unregistered_type() {
         let cx = Cx::default();
@@ -241,6 +310,24 @@ mod tests {
 
         let db: &Database = request_context(&cx);
         assert_eq!(db, &Database("primary"));
+    }
+
+    #[test]
+    fn try_request_context_returns_registered_value() {
+        let cx = CxTestBuilder::new()
+            .request_context(Database("primary"))
+            .build();
+
+        assert_eq!(
+            try_request_context::<Database>(&cx),
+            Some(&Database("primary"))
+        );
+    }
+
+    #[test]
+    fn try_request_context_returns_none_for_unregistered_type() {
+        let cx = Cx::default();
+        assert_eq!(try_request_context::<Database>(&cx), None);
     }
 
     #[test]

--- a/crates/topcoat/docs/app_context.md
+++ b/crates/topcoat/docs/app_context.md
@@ -52,7 +52,19 @@ async fn user_profile(cx: &Cx) -> Result {
 }
 ```
 
-The lookup is keyed by `T`'s `TypeId`, so the type you ask for must exactly match the type you registered. Asking for a type that wasn't registered panics: this is a startup-time bug, not a runtime one.
+The lookup is keyed by `T`'s `TypeId`, so the type you ask for must exactly match the type you registered. Asking `app_context` for a type that wasn't registered panics: this is usually a startup-time bug.
+
+When an app context value is intentionally optional, use `try_app_context::<T>(cx)` instead. It returns `None` when the type was not registered:
+
+```rust
+use topcoat::context::{Cx, try_app_context};
+#
+# struct FeatureConfig;
+
+fn feature_config(cx: &Cx) -> Option<&FeatureConfig> {
+    try_app_context(cx)
+}
+```
 
 ## Requirements
 

--- a/crates/topcoat/docs/context.md
+++ b/crates/topcoat/docs/context.md
@@ -94,8 +94,10 @@ This means your params are available anywhere you have access to a `cx`. See the
 
 This module exposes typed context accessors:
 
-- [`app_context::<T>(cx)`](app_context) reads values registered on the router with `.app_context(value)`.
-- [`request_context::<T>(cx)`](request_context) reads typed values attached to the current request.
+- [`app_context::<T>(cx)`](app_context) reads a required value registered on the router with `.app_context(value)`.
+- [`try_app_context::<T>(cx)`](try_app_context) reads an optional value registered on the router.
+- [`request_context::<T>(cx)`](request_context) reads a required typed value attached to the current request.
+- [`try_request_context::<T>(cx)`](try_request_context) reads an optional typed value attached to the current request.
 
 ```rust
 use topcoat::context::{Cx, app_context};
@@ -107,7 +109,19 @@ fn db(cx: &Cx) -> &Database {
 }
 ```
 
-Values are keyed by Rust type. Asking for a type that was not registered panics, so these helpers are best wrapped in small application-specific functions like `db(cx)`, `config(cx)`, or `current_tenant(cx)`.
+Values are keyed by Rust type. The required helpers panic when the requested type was not registered, so they are best wrapped in small application-specific functions like `db(cx)`, `config(cx)`, or `current_tenant(cx)`.
+
+Use the `try_` helpers when a value is intentionally optional on some requests:
+
+```rust
+use topcoat::context::{Cx, try_request_context};
+#
+# struct Customer;
+
+fn current_customer(cx: &Cx) -> Option<&Customer> {
+    try_request_context(cx)
+}
+```
 
 # Memoization
 


### PR DESCRIPTION
## Summary

- add `try_app_context::<T>(cx)` and `try_request_context::<T>(cx)` for optional typed context reads
- preserve the existing panicking accessors for required context values
- document the optional-value workflow
- cover registered and unregistered values for both context scopes

## Motivation

`ContextMap::get` already supports optional reads, but `Cx` keeps its context maps private and only exposed panicking helpers. This made conditionally registered values, such as an authenticated customer that is absent on anonymous requests, impossible to read safely from `&Cx`.

Fixes #114.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo doc --workspace --all-features --no-deps --locked`
- `cargo fmt --all -- --check`