### PR TITLE
perf: switch leptos benchmark to islands mode

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -129,7 +129,8 @@ cd benchmarks/axum-maud && PORT=8090 ./target/release/storefront-axum-maud
   per-response CPU cost buys a many-times-smaller transfer.
 - **Response sizes intentionally differ.** Topcoat and Axum + Maud ship plain
   HTML with zero JavaScript. Next.js embeds its RSC payload and script tags;
-  Leptos embeds hydration data and the wasm loader. That is each framework's realistic
+  Leptos runs in islands mode, so it ships the wasm loader but no serialized
+  page data. That is each framework's realistic
   production output for this app, and the `bytes/resp` column keeps the
   difference visible. Larger documents cost real time to render and transfer,
   so this is part of the comparison, not noise in it.
@@ -137,8 +138,10 @@ cd benchmarks/axum-maud && PORT=8090 ./target/release/storefront-axum-maud
   `export const dynamic = "force-dynamic"`; the build output lists them as
   dynamic and responses carry `Cache-Control: ... no-store` (asserted by
   `verify_parity.sh`).
-- **Leptos uses `SsrMode::Async`**, so each response is one complete document
-  (comparable to the others), not an out-of-order stream.
+- **Leptos runs in islands mode.** The storefront has no interactive islands,
+  so the page renders entirely on the server and ships no serialized hydration
+  data, only the wasm loader. Routes still use `SsrMode::Async`, so each response
+  is one complete document (comparable to the others), not an out-of-order stream.
 - **Axum + Maud is the hand-written baseline.** It renders the same component
   tree as plain functions returning `maud` compile-time templates, with axum
   doing the routing and query parsing; there is no framework layer on top.

--- a/benchmarks/leptos/Cargo.toml
+++ b/benchmarks/leptos/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-leptos = { version = "0.8" }
+leptos = { version = "0.8", features = ["islands"] }
 leptos_meta = { version = "0.8" }
 leptos_router = { version = "0.8" }
 leptos_axum = { version = "0.8", optional = true }

--- a/benchmarks/leptos/src/app.rs
+++ b/benchmarks/leptos/src/app.rs
@@ -18,7 +18,7 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="width=device-width, initial-scale=1"/>
                 <AutoReload options=options.clone()/>
-                <HydrationScripts options/>
+                <HydrationScripts options islands=true/>
                 <MetaTags/>
             </head>
             <body class="flex min-h-screen flex-col bg-slate-50 text-slate-900">

--- a/benchmarks/leptos/src/lib.rs
+++ b/benchmarks/leptos/src/lib.rs
@@ -11,5 +11,5 @@ pub mod server_fns;
 #[wasm_bindgen::prelude::wasm_bindgen]
 pub fn hydrate() {
     console_error_panic_hook::set_once();
-    leptos::mount::hydrate_body(crate::app::App);
+    leptos::mount::hydrate_islands();
 }

--- a/benchmarks/leptos/src/model.rs
+++ b/benchmarks/leptos/src/model.rs
@@ -1,6 +1,7 @@
-//! Serializable DTOs shared between the server renderer and the hydrating
-//! client. Pages receive these from server functions, so all rendering inputs
-//! serialize into the document and hydration reproduces the exact markup.
+//! DTOs returned by the `#[server]` functions the pages call. The `Serialize`
+//! and `Deserialize` derives satisfy the server-function transport. In islands
+//! mode the page shell renders entirely on the server and is never hydrated, so
+//! these values are not embedded in the document.
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Leptos SSR is faster in islands mode, making it a fairer comparison