### PR TITLE
fix: rust-analzyer experimental diagnostics

### DIFF
--- a/crates/topcoat-core/grammar/src/paths.rs
+++ b/crates/topcoat-core/grammar/src/paths.rs
@@ -28,9 +28,6 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
-
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -128,21 +125,18 @@ fn join(base: &str, submodule: &str) -> String {
 /// `extern crate self as topcoat_...;` alias so that this same extern name also
 /// resolves within its own non-doctest builds. See the [module docs](self).
 ///
-/// One `rustc` process compiles one crate, so the answer is fixed for the whole
-/// compilation; it is resolved once per package and cached.
-fn crate_base(package: &'static str) -> Option<String> {
-    static CACHE: OnceLock<Mutex<HashMap<&'static str, Option<String>>>> = OnceLock::new();
-    CACHE
-        .get_or_init(Mutex::default)
-        .lock()
-        .expect("crate path cache is not poisoned")
-        .entry(package)
-        .or_insert_with(|| match crate_name(package) {
-            Ok(FoundCrate::Itself) => Some(format!("::{}", package.replace('-', "_"))),
-            Ok(FoundCrate::Name(name)) => Some(format!("::{name}")),
-            Err(_) => None,
-        })
-        .clone()
+/// The lookup runs on every call rather than being cached per package: under
+/// rust-analyzer, a single long-lived proc-macro server process expands macros
+/// for every crate in the workspace, so the answer depends on which crate's
+/// call site is currently being expanded (`CARGO_MANIFEST_DIR`). `crate_name`
+/// caches the parsed manifest per `CARGO_MANIFEST_DIR` itself, keeping repeated
+/// lookups cheap.
+fn crate_base(package: &str) -> Option<String> {
+    match crate_name(package) {
+        Ok(FoundCrate::Itself) => Some(format!("::{}", package.replace('-', "_"))),
+        Ok(FoundCrate::Name(name)) => Some(format!("::{name}")),
+        Err(_) => None,
+    }
 }
 
 /// `::topcoat::asset`, or `topcoat_asset` standalone.

--- a/crates/topcoat-view/grammar/src/view/component.rs
+++ b/crates/topcoat-view/grammar/src/view/component.rs
@@ -96,11 +96,11 @@ impl WriteView for Component {
             ExprKind::View,
             quote_spanned! {self.paren_token.span.span()=>
                 {
-                    // The marker is built via `Default` so the same construction
-                    // works for both unit-struct and generic (`PhantomData`) markers.
-                    #![allow(clippy::default_constructed_unit_structs)]
                     use #topcoat_view::Component;
                     let props = #name::props_builder()#(#setters)*#child.build();
+                    // The marker is built via `Default` so the same construction
+                    // works for both unit-struct and generic (`PhantomData`) markers.
+                    #[allow(clippy::default_constructed_unit_structs)]
                     Component::render(
                         #name::default(),
                         __cx,


### PR DESCRIPTION
with rust-analyzer's experimental diagnostics enabled, the view macro produced warnings. fixes #113 