### PR TITLE
chore: release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -519,7 +519,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "tokio",
@@ -834,7 +834,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1062,7 +1062,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1489,7 +1489,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manual-router"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2004,7 +2004,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "tokio",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2328,7 +2328,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "toasty",
@@ -2696,7 +2696,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures-util",
  "inventory",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "memchr",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "clap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cookie 0.18.1",
  "http",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote",
  "serde",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "heck",
  "inventory",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote",
  "syn",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "serde",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "quote",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote",
  "syn",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "rand 0.10.2",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "http",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote",
  "syn",
@@ -3211,7 +3211,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -100,31 +100,31 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-asset = { version = "0.3.0", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.3.0", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.3.0", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.3.0", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.3.0", path = "crates/topcoat-core/macro" }
-topcoat-font = { version = "0.3.0", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.3.0", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.3.0", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.3.0", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.3.0", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.3.0", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.3.0", path = "crates/topcoat-icon/macro" }
-topcoat-router = { version = "0.3.0", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.3.0", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.3.0", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.3.0", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.3.0", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.3.0", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.3.0", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.3.0", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.3.0", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.3.0", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.3.0", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.3.0", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.3.0", path = "crates/topcoat-view/macro" }
+topcoat-asset = { version = "0.3.1", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.3.1", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.3.1", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.3.1", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.3.1", path = "crates/topcoat-core/macro" }
+topcoat-font = { version = "0.3.1", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.3.1", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.3.1", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.3.1", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.3.1", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.3.1", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.3.1", path = "crates/topcoat-icon/macro" }
+topcoat-router = { version = "0.3.1", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.3.1", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.3.1", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.3.1", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.3.1", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.3.1", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.3.1", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.3.1", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.3.1", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.3.1", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.3.1", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.3.1", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.3.1", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-cli/CHANGELOG.md
+++ b/crates/topcoat-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.0...topcoat-cli-v0.3.1) - 2026-07-20
+
+### Added
+
+- more sophisticated dev server file watching ([#146](https://github.com/tokio-rs/topcoat/pull/146))
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.2.0...topcoat-cli-v0.3.0) - 2026-07-19
 
 ### Added

--- a/crates/topcoat-runtime/CHANGELOG.md
+++ b/crates/topcoat-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.3.0...topcoat-runtime-v0.3.1) - 2026-07-20
+
+### Fixed
+
+- signal comment xss vulnerability ([#154](https://github.com/tokio-rs/topcoat/pull/154))
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.2.0...topcoat-runtime-v0.3.0) - 2026-07-19
 
 ### Fixed

--- a/crates/topcoat-session/CHANGELOG.md
+++ b/crates/topcoat-session/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.3.0...topcoat-session-v0.3.1) - 2026-07-20
+
+### Other
+
+- token encode and decode behavior ([#153](https://github.com/tokio-rs/topcoat/pull/153))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.1.3...topcoat-session-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.0...topcoat-view-v0.3.1) - 2026-07-20
+
+### Fixed
+
+- signal comment xss vulnerability ([#154](https://github.com/tokio-rs/topcoat/pull/154))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.1.3...topcoat-view-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.0...topcoat-v0.3.1) - 2026-07-20
+
+### Other
+
+- add note on build time improvements
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.2.0...topcoat-v0.3.0) - 2026-07-19
 
 ### Added

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.3.0", features = ["font-fontsource"] }
+topcoat = { version = "0.3.1", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.3.0", features = ["htmx"] }
+topcoat = { version = "0.3.1", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.0", features = ["icon-iconify"] }
+topcoat = { version = "0.3.1", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.0", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.3.1", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.0", features = ["tailwind"] }
+topcoat = { version = "0.3.1", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.3.1", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.0", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.3.1", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.3.1", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.3.0 -> 0.3.1
* `topcoat-view`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `topcoat-router`: 0.3.0 -> 0.3.1
* `topcoat-asset`: 0.3.0 -> 0.3.1
* `topcoat-cookie`: 0.3.0 -> 0.3.1
* `topcoat-core-grammar`: 0.3.0 -> 0.3.1
* `topcoat-core-macro`: 0.3.0 -> 0.3.1
* `topcoat-view-grammar`: 0.3.0 -> 0.3.1
* `topcoat-view-macro`: 0.3.0 -> 0.3.1
* `topcoat-font`: 0.3.0 -> 0.3.1
* `topcoat-font-grammar`: 0.3.0 -> 0.3.1
* `topcoat-font-macro`: 0.3.0 -> 0.3.1
* `topcoat-htmx`: 0.3.0 -> 0.3.1
* `topcoat-icon`: 0.3.0 -> 0.3.1
* `topcoat-icon-grammar`: 0.3.0 -> 0.3.1
* `topcoat-icon-macro`: 0.3.0 -> 0.3.1
* `topcoat-router-grammar`: 0.3.0 -> 0.3.1
* `topcoat-router-macro`: 0.3.0 -> 0.3.1
* `topcoat-runtime`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `topcoat-runtime-grammar`: 0.3.0 -> 0.3.1
* `topcoat-runtime-macro`: 0.3.0 -> 0.3.1
* `topcoat-session`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `topcoat-tailwind`: 0.3.0 -> 0.3.1
* `topcoat-ui-registry`: 0.3.0 -> 0.3.1
* `topcoat`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `topcoat-ui`: 0.3.0 -> 0.3.1
* `topcoat-cli`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.1.3...topcoat-core-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-view`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.0...topcoat-view-v0.3.1) - 2026-07-20

### Fixed

- signal comment xss vulnerability ([#154](https://github.com/tokio-rs/topcoat/pull/154))
</blockquote>

## `topcoat-router`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.1.3...topcoat-router-v0.2.0) - 2026-07-19

### Added

- [**breaking**] compression ([#133](https://github.com/tokio-rs/topcoat/pull/133))
- [**breaking**] graceful shutdown ([#132](https://github.com/tokio-rs/topcoat/pull/132))

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.1.3...topcoat-asset-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.1.3...topcoat-cookie-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.2.0...topcoat-core-grammar-v0.3.0) - 2026-07-19

### Fixed

- view macro using ExprLet instead of Local ([#142](https://github.com/tokio-rs/topcoat/pull/142))
- rust-analzyer experimental diagnostics ([#135](https://github.com/tokio-rs/topcoat/pull/135))
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.1.3...topcoat-core-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.2.0...topcoat-view-grammar-v0.3.0) - 2026-07-19

### Fixed

- view macro using ExprLet instead of Local ([#142](https://github.com/tokio-rs/topcoat/pull/142))
- rust-analzyer experimental diagnostics ([#135](https://github.com/tokio-rs/topcoat/pull/135))
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.2.0...topcoat-view-macro-v0.3.0) - 2026-07-19

### Fixed

- view macro using ExprLet instead of Local ([#142](https://github.com/tokio-rs/topcoat/pull/142))
</blockquote>

## `topcoat-font`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.1.3...topcoat-font-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.1.3...topcoat-font-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.1.3...topcoat-font-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.1.3...topcoat-htmx-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.1.3...topcoat-icon-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.1.3...topcoat-router-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.1.3...topcoat-router-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.3.0...topcoat-runtime-v0.3.1) - 2026-07-20

### Fixed

- signal comment xss vulnerability ([#154](https://github.com/tokio-rs/topcoat/pull/154))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.1.3...topcoat-runtime-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.1.3...topcoat-runtime-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.3.0...topcoat-session-v0.3.1) - 2026-07-20

### Other

- token encode and decode behavior ([#153](https://github.com/tokio-rs/topcoat/pull/153))
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.1.3...topcoat-ui-registry-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.0...topcoat-v0.3.1) - 2026-07-20

### Other

- add note on build time improvements
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.1.3...topcoat-ui-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.0...topcoat-cli-v0.3.1) - 2026-07-20

### Added

- more sophisticated dev server file watching ([#146](https://github.com/tokio-rs/topcoat/pull/146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).