### PR TITLE
feat: concurrent and observable remote asset fetching

### DIFF
--- a/crates/topcoat-asset/src/bundler.rs
+++ b/crates/topcoat-asset/src/bundler.rs
@@ -1,4 +1,5 @@
 mod cache;
+mod dns;
 mod error;
 
 use std::{
@@ -6,8 +7,15 @@ use std::{
     fmt::Write as _,
     fs, io,
     path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
 };
 
+use http::Uri;
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -15,7 +23,21 @@ use crate::{
 };
 
 use self::cache::Cache;
+use self::dns::CachingResolver;
 pub use self::error::{BundleError, BundleResult};
+
+/// How many remote assets a [`Bundler`] downloads concurrently by default.
+///
+/// Override with [`Bundler::parallelism`].
+pub const DEFAULT_PARALLELISM: usize = 8;
+
+/// The end-to-end timeout the default agent applies to each download.
+///
+/// Construct the bundler with [`Bundler::with_agent`] to use a different
+/// timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_mins(1);
+
+type FetchCallback = Box<dyn Fn(FetchEvent<'_>) + Send + Sync>;
 
 /// Scans a built binary for [`asset!`](crate::asset) declarations and
 /// writes the referenced files into a bundle directory.
@@ -26,16 +48,24 @@ pub use self::error::{BundleError, BundleResult};
 /// [`Manifest`].
 pub struct Bundler {
     cache: Cache,
+    parallelism: usize,
+    on_fetch: Option<FetchCallback>,
 }
 
 impl Bundler {
-    /// Create a bundler with a default [`ureq::Agent`] configured with
-    /// this crate's user agent.
+    /// Create a bundler with a default [`ureq::Agent`] configured with this
+    /// crate's user agent, a [`DEFAULT_TIMEOUT`] per download, and DNS
+    /// lookups cached per host for the life of the bundler.
     pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
-        let agent = ureq::Agent::config_builder()
+        let config = ureq::Agent::config_builder()
             .user_agent(concat!("topcoat-asset/", env!("CARGO_PKG_VERSION")))
-            .build()
-            .into();
+            .timeout_global(Some(DEFAULT_TIMEOUT))
+            .build();
+        let agent = ureq::Agent::with_parts(
+            config,
+            ureq::unversioned::transport::DefaultConnector::default(),
+            CachingResolver::default(),
+        );
         Self::with_agent(cache_dir, agent)
     }
 
@@ -44,7 +74,30 @@ impl Bundler {
     pub fn with_agent(cache_dir: impl Into<PathBuf>, agent: ureq::Agent) -> Self {
         Self {
             cache: Cache::new(cache_dir.into(), agent),
+            parallelism: DEFAULT_PARALLELISM,
+            on_fetch: None,
         }
+    }
+
+    /// Set how many remote assets are downloaded concurrently.
+    ///
+    /// Values are clamped to at least 1. Defaults to [`DEFAULT_PARALLELISM`].
+    #[must_use]
+    pub fn parallelism(mut self, parallelism: usize) -> Self {
+        self.parallelism = parallelism.max(1);
+        self
+    }
+
+    /// Register a callback observing remote fetches during [`Bundler::bundle`].
+    ///
+    /// The bundler itself never prints; use this to surface download progress
+    /// (see [`FetchEvent`]). The callback is invoked once per distinct remote
+    /// URI, from whichever worker thread handled it, so it may be called from
+    /// several threads at once.
+    #[must_use]
+    pub fn on_fetch(mut self, on_fetch: impl Fn(FetchEvent<'_>) + Send + Sync + 'static) -> Self {
+        self.on_fetch = Some(Box::new(on_fetch));
+        self
     }
 
     /// Scan `binary` for embedded assets and sync them into `out_dir`.
@@ -90,6 +143,7 @@ impl Bundler {
         };
 
         let assets = RawAsset::find_in_binary(binary);
+        let downloads = self.fetch_remote(&assets)?;
         let mut entries = Vec::with_capacity(assets.len());
         let mut kept_files = HashSet::with_capacity(assets.len());
 
@@ -97,7 +151,7 @@ impl Bundler {
             let source = asset.source();
             let src = match &source {
                 Source::Path(p) => p.clone(),
-                Source::Url(uri) => self.cache.fetch(uri)?,
+                Source::Url(uri) => downloads[&uri.to_string()].clone(),
             };
             let bytes = fs::read(&src).map_err(|source| AssetError::AssetIo {
                 asset: Box::new(asset.clone()),
@@ -199,5 +253,289 @@ impl Bundler {
             })?;
 
         Ok(())
+    }
+
+    /// Fetch every distinct remote URI among `assets` into the cache, at most
+    /// [`Self::parallelism`] downloads at a time, and return the local path
+    /// for each URI.
+    ///
+    /// Identical URIs are fetched once, so concurrent workers never touch the
+    /// same cache entry. Every URI is attempted even when one fails, and the
+    /// error returned is the one for the earliest failing URI in declaration
+    /// order; neither output nor errors depend on completion order.
+    fn fetch_remote(&self, assets: &[RawAsset]) -> Result<HashMap<String, PathBuf>, BundleError> {
+        let mut uris = Vec::new();
+        let mut seen = HashSet::new();
+        for asset in assets {
+            if let Source::Url(uri) = asset.source()
+                && seen.insert(uri.to_string())
+            {
+                uris.push(uri);
+            }
+        }
+
+        let results: Vec<_> = uris.iter().map(|_| Mutex::new(None)).collect();
+        let next = AtomicUsize::new(0);
+        let workers = self.parallelism.min(uris.len());
+        thread::scope(|scope| {
+            for _ in 0..workers {
+                scope.spawn(|| {
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some(uri) = uris.get(index) else { break };
+                        let result = self.fetch(uri);
+                        *results[index].lock().expect("fetch result lock poisoned") = Some(result);
+                    }
+                });
+            }
+        });
+
+        let mut downloads = HashMap::with_capacity(uris.len());
+        for (uri, result) in uris.iter().zip(results) {
+            let result = result
+                .into_inner()
+                .expect("fetch result lock poisoned")
+                .expect("every uri is claimed by a worker");
+            downloads.insert(uri.to_string(), result?);
+        }
+        Ok(downloads)
+    }
+
+    /// Resolve one remote URI to a local file, downloading on a cache miss,
+    /// and report the outcome to the [`Self::on_fetch`] callback.
+    fn fetch(&self, uri: &Uri) -> Result<PathBuf, BundleError> {
+        if let Some(path) = self.cache.lookup(uri) {
+            self.emit(FetchEvent::CacheHit { uri });
+            return Ok(path);
+        }
+        let start = Instant::now();
+        let path = self.cache.download(uri)?;
+        self.emit(FetchEvent::Downloaded {
+            uri,
+            elapsed: start.elapsed(),
+        });
+        Ok(path)
+    }
+
+    fn emit(&self, event: FetchEvent<'_>) {
+        if let Some(on_fetch) = &self.on_fetch {
+            on_fetch(event);
+        }
+    }
+}
+
+/// A progress notification passed to the callback registered with
+/// [`Bundler::on_fetch`] as [`Bundler::bundle`] fetches remote assets.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FetchEvent<'a> {
+    /// A remote asset was downloaded over the network.
+    Downloaded {
+        /// The asset's source URL.
+        uri: &'a Uri,
+        /// How long the download took.
+        elapsed: Duration,
+    },
+    /// A remote asset was already in the bundler's cache directory; no
+    /// request was made.
+    CacheHit {
+        /// The asset's source URL.
+        uri: &'a Uri,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::{TcpListener, TcpStream},
+        sync::{Arc, atomic::AtomicUsize},
+    };
+
+    use super::*;
+    use crate::{Asset, AssetOptions, ENCODED_ASSET_SIZE};
+
+    /// A minimal HTTP server that counts requests and delays responses by
+    /// path, so tests can control download completion order.
+    struct TestServer {
+        addr: std::net::SocketAddr,
+        requests: Arc<AtomicUsize>,
+    }
+
+    impl TestServer {
+        fn spawn(delay_for: fn(&str) -> Duration) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+            let addr = listener.local_addr().expect("test server addr");
+            let requests = Arc::new(AtomicUsize::new(0));
+            let counter = Arc::clone(&requests);
+            thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(stream) = stream else { break };
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    thread::spawn(move || serve_one(stream, delay_for));
+                }
+            });
+            Self { addr, requests }
+        }
+
+        fn url(&self, path: &str) -> String {
+            format!("http://{}{path}", self.addr)
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.load(Ordering::SeqCst)
+        }
+    }
+
+    fn serve_one(mut stream: TcpStream, delay_for: fn(&str) -> Duration) {
+        let mut head = Vec::new();
+        let mut buf = [0u8; 1024];
+        while !head.windows(4).any(|w| w == b"\r\n\r\n") {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(n) => head.extend_from_slice(&buf[..n]),
+            }
+        }
+        let head = String::from_utf8_lossy(&head);
+        let path = head
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or_default()
+            .to_owned();
+        thread::sleep(delay_for(&path));
+        let body = format!("content of {path}");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = stream.write_all(response.as_bytes());
+    }
+
+    /// Encode an `asset!`-equivalent declaration; distinct `source_file`s
+    /// yield distinct asset ids for the same path.
+    fn encode_asset(path: &str, source_file: &str) -> [u8; ENCODED_ASSET_SIZE] {
+        let options = AssetOptions::NONE;
+        let id = Asset::new("test_crate", source_file, path, &options);
+        RawAsset::encode(
+            id,
+            path,
+            "test_crate",
+            "/nonexistent",
+            source_file,
+            &options,
+        )
+    }
+
+    fn binary_of(assets: &[[u8; ENCODED_ASSET_SIZE]]) -> Vec<u8> {
+        let mut binary = b"junk".to_vec();
+        for asset in assets {
+            binary.extend_from_slice(asset);
+            binary.extend_from_slice(b"padding");
+        }
+        binary
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "topcoat-bundler-test-{}-{name}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    #[test]
+    fn bundles_local_assets_without_network() {
+        let dir = test_dir("local");
+        let asset_path = dir.join("logo.css");
+        fs::write(&asset_path, "body {}").expect("write asset");
+
+        let binary = binary_of(&[encode_asset(
+            asset_path.to_str().expect("utf-8 path"),
+            "a.rs",
+        )]);
+        let out_dir = dir.join("out");
+        Bundler::new(dir.join("cache"))
+            .bundle(&binary, &out_dir)
+            .expect("bundle");
+
+        let manifest = Manifest::load(out_dir.join(MANIFEST_NAME)).expect("load manifest");
+        assert_eq!(manifest.assets.len(), 1);
+        let entry = &manifest.assets[0];
+        assert!(entry.file.starts_with("logo-"));
+        assert_eq!(Path::new(&entry.file).extension(), Some("css".as_ref()));
+        let bundled = fs::read_to_string(out_dir.join(&entry.file)).expect("read bundled");
+        assert_eq!(bundled, "body {}");
+    }
+
+    #[test]
+    fn deduplicates_identical_uris_and_reports_fetches() {
+        let server = TestServer::spawn(|_| Duration::ZERO);
+        let dir = test_dir("dedup");
+        let url = server.url("/shared.css");
+        let binary = binary_of(&[encode_asset(&url, "a.rs"), encode_asset(&url, "b.rs")]);
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let bundler = |events: &Arc<Mutex<Vec<String>>>| {
+            let events = Arc::clone(events);
+            Bundler::new(dir.join("cache")).on_fetch(move |event| {
+                let name = match event {
+                    FetchEvent::Downloaded { .. } => "downloaded",
+                    FetchEvent::CacheHit { .. } => "cache hit",
+                };
+                events.lock().expect("events lock").push(name.to_owned());
+            })
+        };
+
+        bundler(&events)
+            .bundle(&binary, dir.join("out"))
+            .expect("bundle");
+        assert_eq!(server.request_count(), 1);
+        assert_eq!(*events.lock().expect("events lock"), ["downloaded"]);
+
+        let manifest = Manifest::load(dir.join("out").join(MANIFEST_NAME)).expect("load manifest");
+        assert_eq!(manifest.assets.len(), 2);
+        assert_eq!(manifest.assets[0].file, manifest.assets[1].file);
+
+        // A second run is served entirely from the cache directory.
+        events.lock().expect("events lock").clear();
+        bundler(&events)
+            .bundle(&binary, dir.join("out2"))
+            .expect("bundle again");
+        assert_eq!(server.request_count(), 1);
+        assert_eq!(*events.lock().expect("events lock"), ["cache hit"]);
+    }
+
+    #[test]
+    fn manifest_order_is_declaration_order() {
+        // The first-declared asset finishes last: with four concurrent
+        // downloads, completion order inverts declaration order.
+        let server = TestServer::spawn(|path| {
+            if path.starts_with("/0") {
+                Duration::from_millis(200)
+            } else {
+                Duration::ZERO
+            }
+        });
+        let dir = test_dir("order");
+        let assets: Vec<_> = (0..4)
+            .map(|i| encode_asset(&server.url(&format!("/{i}.css")), "a.rs"))
+            .collect();
+        let binary = binary_of(&assets);
+
+        Bundler::new(dir.join("cache"))
+            .parallelism(4)
+            .bundle(&binary, dir.join("out"))
+            .expect("bundle");
+
+        let manifest = Manifest::load(dir.join("out").join(MANIFEST_NAME)).expect("load manifest");
+        let stems: Vec<_> = manifest
+            .assets
+            .iter()
+            .map(|entry| entry.file.split('-').next().expect("file stem"))
+            .collect();
+        assert_eq!(stems, ["0", "1", "2", "3"]);
+        assert_eq!(server.request_count(), 4);
     }
 }

--- a/crates/topcoat-asset/src/bundler/cache.rs
+++ b/crates/topcoat-asset/src/bundler/cache.rs
@@ -15,14 +15,17 @@ impl Cache {
         Self { dir, agent }
     }
 
-    /// Return the local path of `uri`'s cached contents, downloading first if needed.
-    ///
-    /// Performs a blocking HTTP request when the asset isn't already cached.
-    pub fn fetch(&self, uri: &Uri) -> Result<PathBuf, BundleError> {
+    /// Return the local path of `uri`'s cached contents, if present.
+    pub fn lookup(&self, uri: &Uri) -> Option<PathBuf> {
         let path = self.cached_path(uri);
-        if path.exists() {
-            return Ok(path);
-        }
+        path.exists().then_some(path)
+    }
+
+    /// Download `uri` into the cache and return the local path of its contents.
+    ///
+    /// Performs a blocking HTTP request.
+    pub fn download(&self, uri: &Uri) -> Result<PathBuf, BundleError> {
+        let path = self.cached_path(uri);
 
         fs::create_dir_all(&self.dir).map_err(|source| BundleError::CacheIo {
             path: self.dir.clone(),
@@ -41,8 +44,9 @@ impl Cache {
         let mut reader = body.as_reader();
 
         // Stream to a sibling tempfile then rename so a partial download can't be mistaken for a
-        // hit.
-        let tmp = path.with_extension("download");
+        // hit. The tempfile name includes the process id so another bundler process downloading
+        // the same URI can't interleave writes with ours; whichever renames last wins atomically.
+        let tmp = path.with_extension(format!("download.{}", std::process::id()));
         let mut file = fs::File::create(&tmp).map_err(|source| BundleError::CacheIo {
             path: tmp.clone(),
             source,

--- a/crates/topcoat-asset/src/bundler/dns.rs
+++ b/crates/topcoat-asset/src/bundler/dns.rs
@@ -1,0 +1,67 @@
+use std::{collections::HashMap, net::SocketAddr, sync::Mutex};
+
+use http::Uri;
+use ureq::{
+    config::Config,
+    unversioned::{
+        resolver::{DefaultResolver, ResolvedSocketAddrs, Resolver},
+        transport::NextTimeout,
+    },
+};
+
+/// A [`Resolver`] that memoizes DNS lookups per host for the life of the agent.
+///
+/// ureq resolves a request's host before consulting its connection pool, so
+/// every request pays a fresh lookup even when a pooled keep-alive connection
+/// is about to be reused. A bundle run typically fetches many assets from a
+/// handful of hosts, and on systems with slow or partially unreachable DNS
+/// each lookup can take seconds. Caching per host bounds that cost to one
+/// lookup per host per run.
+///
+/// Failed lookups are not cached, so a transient DNS error on one asset does
+/// not poison the rest of the run.
+// The `ureq::unversioned` module is exempt from ureq's semver guarantees; a
+// breaking change there surfaces as a compile error in this file.
+#[derive(Debug, Default)]
+pub struct CachingResolver {
+    inner: DefaultResolver,
+    cache: Mutex<HashMap<String, Vec<SocketAddr>>>,
+}
+
+impl CachingResolver {
+    fn lock_cache(&self) -> std::sync::MutexGuard<'_, HashMap<String, Vec<SocketAddr>>> {
+        self.cache.lock().expect("resolver cache lock poisoned")
+    }
+}
+
+impl Resolver for CachingResolver {
+    fn resolve(
+        &self,
+        uri: &Uri,
+        config: &Config,
+        timeout: NextTimeout,
+    ) -> Result<ResolvedSocketAddrs, ureq::Error> {
+        let key = match (uri.scheme(), uri.authority()) {
+            (Some(scheme), Some(authority)) => DefaultResolver::host_and_port(scheme, authority),
+            _ => None,
+        };
+        // Without a resolvable authority, let the default resolver produce
+        // its regular error.
+        let Some(key) = key else {
+            return self.inner.resolve(uri, config, timeout);
+        };
+
+        if let Some(addrs) = self.lock_cache().get(&key) {
+            let mut resolved = self.empty();
+            for addr in addrs {
+                resolved.push(*addr);
+            }
+            return Ok(resolved);
+        }
+
+        let resolved = self.inner.resolve(uri, config, timeout)?;
+        self.lock_cache()
+            .insert(key, resolved.iter().copied().collect());
+        Ok(resolved)
+    }
+}

--- a/crates/topcoat-cli/src/asset/bundle.rs
+++ b/crates/topcoat-cli/src/asset/bundle.rs
@@ -1,10 +1,15 @@
 use std::error::Error;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use clap::Args;
 use console::style;
+use topcoat_asset::FetchEvent;
 
 use crate::cargo::BuildFlags;
+use crate::dev::spinner::Spinner;
 
 use super::{CACHE_SCOPE, OUT_SUBDIR};
 
@@ -15,14 +20,49 @@ pub(super) struct BundleArgs {
     /// Output directory for the bundle (defaults to <cargo-target>/assets)
     #[arg(short, long)]
     out: Option<PathBuf>,
+    /// Print nothing but the bundle directory and errors
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
+    /// Also print remote assets served from the download cache
+    #[arg(short, long)]
+    verbose: bool,
 }
 
 pub(super) async fn run(args: BundleArgs) {
-    let (_, bytes) = crate::cargo::build_and_read(&args.build.into(), |_, _| {})
-        .await
-        .unwrap_or_else(|e| e.print_and_exit());
+    let spinner = Spinner::new("building");
+    let progress = spinner.bar();
+    let build = crate::cargo::build_and_read(&args.build.into(), move |current, total| {
+        progress.set_message(format!("building ({current}/{total})"));
+    })
+    .await;
+    drop(spinner);
+    let (_, bytes) = build.unwrap_or_else(|e| e.print_and_exit());
 
-    let out_dir = match run_bundle(&bytes, args.out).await {
+    let quiet = args.quiet;
+    let verbose = args.verbose;
+    let cache_hits = Arc::new(AtomicUsize::new(0));
+    let hits = Arc::clone(&cache_hits);
+    let result = run_bundle(&bytes, args.out, move |event| match event {
+        FetchEvent::Downloaded { uri, elapsed } => {
+            if !quiet {
+                println!(
+                    "{} {uri} ({})",
+                    style("downloaded").green(),
+                    format_elapsed(elapsed)
+                );
+            }
+        }
+        FetchEvent::CacheHit { uri } => {
+            if verbose {
+                println!("{} {uri}", style("cached").dim());
+            }
+            hits.fetch_add(1, Ordering::Relaxed);
+        }
+        _ => {}
+    })
+    .await;
+
+    let out_dir = match result {
         Ok(path) => path,
         Err(error) => {
             eprintln!(
@@ -33,12 +73,28 @@ pub(super) async fn run(args: BundleArgs) {
         }
     };
 
+    let cache_hits = cache_hits.load(Ordering::Relaxed);
+    if cache_hits > 0 && !args.quiet && !args.verbose {
+        println!(
+            "{}",
+            style(format!("{cache_hits} remote assets already cached")).dim()
+        );
+    }
     println!("bundled assets into {}", out_dir.display());
+}
+
+fn format_elapsed(elapsed: Duration) -> String {
+    if elapsed.as_secs() >= 1 {
+        format!("{:.1}s", elapsed.as_secs_f64())
+    } else {
+        format!("{}ms", elapsed.as_millis())
+    }
 }
 
 pub(crate) async fn run_bundle(
     bytes: &[u8],
     out_override: Option<PathBuf>,
+    on_fetch: impl Fn(FetchEvent<'_>) + Send + Sync + 'static,
 ) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
     let target_dir = crate::cargo::target_dir()
         .await
@@ -50,7 +106,9 @@ pub(crate) async fn run_bundle(
     let bytes = bytes.to_vec();
     let bundle_dir = out_dir.clone();
     tokio::task::spawn_blocking(move || {
-        topcoat_asset::Bundler::new(cache_dir).bundle(&bytes, &bundle_dir)
+        topcoat_asset::Bundler::new(cache_dir)
+            .on_fetch(on_fetch)
+            .bundle(&bytes, &bundle_dir)
     })
     .await??;
     Ok(out_dir)

--- a/crates/topcoat-cli/src/dev.rs
+++ b/crates/topcoat-cli/src/dev.rs
@@ -21,7 +21,7 @@ mod app_server;
 mod broadcast_server;
 mod build;
 mod keyboard;
-mod spinner;
+pub(crate) mod spinner;
 mod watch;
 
 use std::path::Path;

--- a/crates/topcoat-cli/src/dev/build.rs
+++ b/crates/topcoat-cli/src/dev/build.rs
@@ -93,7 +93,13 @@ async fn build(kind: BuildKind, opts: BuildOpts) -> Option<PathBuf> {
     };
 
     let spinner = Spinner::new("bundling assets");
-    let bundled = crate::asset::run_bundle(&bytes, None).await;
+    let progress = spinner.bar();
+    let bundled = crate::asset::run_bundle(&bytes, None, move |event| {
+        if let topcoat_asset::FetchEvent::Downloaded { uri, .. } = event {
+            progress.set_message(format!("bundling assets ({uri})"));
+        }
+    })
+    .await;
     drop(spinner);
 
     if let Err(error) = bundled {


### PR DESCRIPTION
A production Docker build spent ~160s in `topcoat asset bundle` printing nothing. The issue was the host failing to fetch the DNS and that taking 5s synchronously (in serial) to fall back to the correct DNS. That's a host issue, but the lack of parallelization in the asset bundler here made a 5s problem into a 160s problem.

I did use Claude to write this, but I'm a real person/programmer I promise. :)

I'm not sure if the callback (`on_fetch`) is a nice API. I would probably favor a stream based API, whether tokio streams or iterators for the sync, but let me know what you think.