### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpine-ajax"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -527,7 +527,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "tokio",
@@ -842,7 +842,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1070,7 +1070,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1497,7 +1497,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "manual-router"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2012,7 +2012,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "tokio",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2336,7 +2336,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "toasty",
@@ -2704,7 +2704,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "futures-util",
  "inventory",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-alpine-ajax"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "http",
  "tokio",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "http",
  "memchr",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "clap",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cookie 0.18.1",
  "http",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "serde",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "heck",
  "inventory",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "syn",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "http",
  "serde",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "http",
  "quote",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "syn",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64",
  "rand 0.10.2",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "http",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "syn",
@@ -3229,7 +3229,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -102,32 +102,32 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-alpine-ajax = { version = "0.3.1", path = "crates/topcoat-alpine-ajax" }
-topcoat-asset = { version = "0.3.1", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.3.1", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.3.1", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.3.1", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.3.1", path = "crates/topcoat-core/macro" }
-topcoat-font = { version = "0.3.1", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.3.1", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.3.1", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.3.1", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.3.1", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.3.1", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.3.1", path = "crates/topcoat-icon/macro" }
-topcoat-router = { version = "0.3.1", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.3.1", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.3.1", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.3.1", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.3.1", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.3.1", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.3.1", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.3.1", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.3.1", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.3.1", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.3.1", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.3.1", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.3.1", path = "crates/topcoat-view/macro" }
+topcoat-alpine-ajax = { version = "0.4.0", path = "crates/topcoat-alpine-ajax" }
+topcoat-asset = { version = "0.4.0", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.4.0", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.4.0", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.4.0", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.4.0", path = "crates/topcoat-core/macro" }
+topcoat-font = { version = "0.4.0", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.4.0", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.4.0", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.4.0", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.4.0", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.4.0", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.4.0", path = "crates/topcoat-icon/macro" }
+topcoat-router = { version = "0.4.0", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.4.0", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.4.0", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.4.0", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.4.0", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.4.0", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.4.0", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.4.0", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.4.0", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.4.0", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.4.0", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.4.0", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.4.0", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-alpine-ajax/CHANGELOG.md
+++ b/crates/topcoat-alpine-ajax/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/topcoat-asset/CHANGELOG.md
+++ b/crates/topcoat-asset/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.3.1...topcoat-asset-v0.4.0) - 2026-07-22
+
+### Added
+
+- bundler prallelism ([#157](https://github.com/tokio-rs/topcoat/pull/157))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.1.3...topcoat-asset-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-cli/CHANGELOG.md
+++ b/crates/topcoat-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.1...topcoat-cli-v0.4.0) - 2026-07-22
+
+### Added
+
+- bundler prallelism ([#157](https://github.com/tokio-rs/topcoat/pull/157))
+
 ## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.0...topcoat-cli-v0.3.1) - 2026-07-20
 
 ### Added

--- a/crates/topcoat-core/grammar/CHANGELOG.md
+++ b/crates/topcoat-core/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.3.1...topcoat-core-grammar-v0.4.0) - 2026-07-22
+
+### Fixed
+
+- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.2.0...topcoat-core-grammar-v0.3.0) - 2026-07-19
 
 ### Fixed

--- a/crates/topcoat-ui/registry/CHANGELOG.md
+++ b/crates/topcoat-ui/registry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.3.1...topcoat-ui-registry-v0.4.0) - 2026-07-22
+
+### Fixed
+
+- ignore non-compiling Topcoat UI doctest examples ([#162](https://github.com/tokio-rs/topcoat/pull/162))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.1.3...topcoat-ui-registry-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.1...topcoat-view-v0.4.0) - 2026-07-22
+
+### Added
+
+- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))
+
+### Fixed
+
+- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
+- remove zmij, improve floating point formatting ([#156](https://github.com/tokio-rs/topcoat/pull/156))
+
 ## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.0...topcoat-view-v0.3.1) - 2026-07-20
 
 ### Fixed

--- a/crates/topcoat-view/grammar/CHANGELOG.md
+++ b/crates/topcoat-view/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.3.1...topcoat-view-grammar-v0.4.0) - 2026-07-22
+
+### Added
+
+- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))
+
+### Fixed
+
+- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.2.0...topcoat-view-grammar-v0.3.0) - 2026-07-19
 
 ### Fixed

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.1...topcoat-v0.4.0) - 2026-07-22
+
+### Added
+
+- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))
+
+### Other
+
+- fix hyphenation in 'fullstack' to 'full-stack' ([#163](https://github.com/tokio-rs/topcoat/pull/163))
+- add WebTransport to roadmap ([#160](https://github.com/tokio-rs/topcoat/pull/160))
+
 ## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.0...topcoat-v0.3.1) - 2026-07-20
 
 ### Other

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.3.1", features = ["alpine-ajax"] }
+topcoat = { version = "0.4.0", features = ["alpine-ajax"] }
 ```
 
 # Loading the Alpine AJAX script

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.3.1", features = ["font-fontsource"] }
+topcoat = { version = "0.4.0", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.3.1", features = ["htmx"] }
+topcoat = { version = "0.4.0", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.1", features = ["icon-iconify"] }
+topcoat = { version = "0.4.0", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.1", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.4.0", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.1", features = ["tailwind"] }
+topcoat = { version = "0.4.0", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.1", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.4.0", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.3.1", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.4.0", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.3.1", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.4.0", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.3.1 -> 0.4.0
* `topcoat-alpine-ajax`: 0.3.1 -> 0.4.0
* `topcoat-view`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `topcoat-router`: 0.3.1 -> 0.4.0
* `topcoat-asset`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `topcoat-cookie`: 0.3.1 -> 0.4.0
* `topcoat-core-grammar`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `topcoat-core-macro`: 0.3.1 -> 0.4.0
* `topcoat-view-grammar`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `topcoat-view-macro`: 0.3.1 -> 0.4.0
* `topcoat-font`: 0.3.1 -> 0.4.0
* `topcoat-font-grammar`: 0.3.1 -> 0.4.0
* `topcoat-font-macro`: 0.3.1 -> 0.4.0
* `topcoat-htmx`: 0.3.1 -> 0.4.0
* `topcoat-icon`: 0.3.1 -> 0.4.0
* `topcoat-icon-grammar`: 0.3.1 -> 0.4.0
* `topcoat-icon-macro`: 0.3.1 -> 0.4.0
* `topcoat-router-grammar`: 0.3.1 -> 0.4.0
* `topcoat-router-macro`: 0.3.1 -> 0.4.0
* `topcoat-runtime`: 0.3.1 -> 0.4.0
* `topcoat-runtime-grammar`: 0.3.1 -> 0.4.0
* `topcoat-runtime-macro`: 0.3.1 -> 0.4.0
* `topcoat-session`: 0.3.1 -> 0.4.0
* `topcoat-tailwind`: 0.3.1 -> 0.4.0
* `topcoat-ui-registry`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `topcoat`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `topcoat-ui`: 0.3.1 -> 0.4.0
* `topcoat-cli`: 0.3.1 -> 0.4.0 (✓ API compatible changes)

### ⚠ `topcoat-asset` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Bundler::with_agent, previously in file /tmp/.tmp73jMLT/topcoat-asset/src/bundler.rs:44
```

### ⚠ `topcoat-view-grammar` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HtmlIdentSegment.part in /tmp/.tmpTAiq7O/topcoat/crates/topcoat-view/grammar/src/view/html_ident.rs:100

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field ident of struct HtmlIdentSegment, previously in file /tmp/.tmp73jMLT/topcoat-view-grammar/src/view/html_ident.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.1.3...topcoat-core-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>


## `topcoat-view`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.1...topcoat-view-v0.4.0) - 2026-07-22

### Added

- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))

### Fixed

- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
- remove zmij, improve floating point formatting ([#156](https://github.com/tokio-rs/topcoat/pull/156))
</blockquote>

## `topcoat-router`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.1.3...topcoat-router-v0.2.0) - 2026-07-19

### Added

- [**breaking**] compression ([#133](https://github.com/tokio-rs/topcoat/pull/133))
- [**breaking**] graceful shutdown ([#132](https://github.com/tokio-rs/topcoat/pull/132))

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.3.1...topcoat-asset-v0.4.0) - 2026-07-22

### Added

- bundler prallelism ([#157](https://github.com/tokio-rs/topcoat/pull/157))
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.1.3...topcoat-cookie-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.3.1...topcoat-core-grammar-v0.4.0) - 2026-07-22

### Fixed

- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.1.3...topcoat-core-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.3.1...topcoat-view-grammar-v0.4.0) - 2026-07-22

### Added

- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))

### Fixed

- pretty printer forcing newline in empty html elements ([#161](https://github.com/tokio-rs/topcoat/pull/161))
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.2.0...topcoat-view-macro-v0.3.0) - 2026-07-19

### Fixed

- view macro using ExprLet instead of Local ([#142](https://github.com/tokio-rs/topcoat/pull/142))
</blockquote>

## `topcoat-font`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.1.3...topcoat-font-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.1.3...topcoat-font-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.1.3...topcoat-font-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.1.3...topcoat-htmx-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.1.3...topcoat-icon-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.1.3...topcoat-router-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.1.3...topcoat-router-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.3.0...topcoat-runtime-v0.3.1) - 2026-07-20

### Fixed

- signal comment xss vulnerability ([#154](https://github.com/tokio-rs/topcoat/pull/154))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.1.3...topcoat-runtime-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.1.3...topcoat-runtime-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.3.0...topcoat-session-v0.3.1) - 2026-07-20

### Other

- token encode and decode behavior ([#153](https://github.com/tokio-rs/topcoat/pull/153))
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.3.1...topcoat-ui-registry-v0.4.0) - 2026-07-22

### Fixed

- ignore non-compiling Topcoat UI doctest examples ([#162](https://github.com/tokio-rs/topcoat/pull/162))
</blockquote>

## `topcoat`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.1...topcoat-v0.4.0) - 2026-07-22

### Added

- add Alpine AJAX integration and example ([#158](https://github.com/tokio-rs/topcoat/pull/158))

### Other

- fix hyphenation in 'fullstack' to 'full-stack' ([#163](https://github.com/tokio-rs/topcoat/pull/163))
- add WebTransport to roadmap ([#160](https://github.com/tokio-rs/topcoat/pull/160))
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.1.3...topcoat-ui-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.1...topcoat-cli-v0.4.0) - 2026-07-22

### Added

- bundler prallelism ([#157](https://github.com/tokio-rs/topcoat/pull/157))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).