### PR TITLE
feat: add Alpine AJAX integration and example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alpine-ajax"
+version = "0.3.1"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2713,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "topcoat-alpine-ajax",
  "topcoat-asset",
  "topcoat-cookie",
  "topcoat-core",
@@ -2724,6 +2733,16 @@ dependencies = [
  "topcoat-view",
  "topcoat-view-macro",
  "uuid",
+]
+
+[[package]]
+name = "topcoat-alpine-ajax"
+version = "0.3.1"
+dependencies = [
+ "http",
+ "tokio",
+ "topcoat",
+ "topcoat-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/topcoat",
+    "crates/topcoat-alpine-ajax",
     "crates/topcoat-asset",
     "crates/topcoat-cli",
     "crates/topcoat-cookie",
@@ -29,6 +30,7 @@ members = [
     "crates/topcoat-view/grammar",
     "crates/topcoat-view/macro",
 
+    "examples/alpine-ajax",
     "examples/app-context",
     "examples/asset",
     "examples/context",
@@ -100,6 +102,7 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
+topcoat-alpine-ajax = { version = "0.3.1", path = "crates/topcoat-alpine-ajax" }
 topcoat-asset = { version = "0.3.1", path = "crates/topcoat-asset" }
 topcoat-cookie = { version = "0.3.1", path = "crates/topcoat-cookie" }
 topcoat-core = { version = "0.3.1", path = "crates/topcoat-core" }

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 **Third-party integrations**
 - [Tailwind](https://docs.rs/topcoat/latest/topcoat/tailwind/index.html): Tailwind CSS without Node, wired into the asset pipeline.
 - [htmx](https://docs.rs/topcoat/latest/topcoat/htmx/index.html): drive partial HTML swaps from the server with request/response header helpers.
+- [Alpine AJAX](https://docs.rs/topcoat/latest/topcoat/alpine_ajax/index.html): drive partial HTML swaps from the server with Alpine AJAX's request-header conventions.
 
 ## Roadmap
 

--- a/crates/topcoat-alpine-ajax/Cargo.toml
+++ b/crates/topcoat-alpine-ajax/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "topcoat-alpine-ajax"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+topcoat-core.workspace = true
+
+http.workspace = true
+
+[dev-dependencies]
+topcoat = { workspace = true, features = ["alpine-ajax", "router"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-udeps.ignore]
+development = ["topcoat"]

--- a/crates/topcoat-alpine-ajax/README.md
+++ b/crates/topcoat-alpine-ajax/README.md
@@ -1,0 +1,1 @@
+This crate is part of [`topcoat`](https://github.com/tokio-rs/topcoat).

--- a/crates/topcoat-alpine-ajax/src/header.rs
+++ b/crates/topcoat-alpine-ajax/src/header.rs
@@ -1,0 +1,15 @@
+//! The Alpine AJAX HTTP header names, as [`HeaderName`] constants.
+//!
+//! See the [Alpine AJAX reference](https://alpine-ajax.js.org/reference/) for
+//! the full semantics of each header.
+
+use http::HeaderName;
+
+// -- Request headers (sent by Alpine AJAX to the server) --
+
+/// `X-Alpine-Request`: always set to `true` on requests issued by Alpine AJAX.
+pub const X_ALPINE_REQUEST: HeaderName = HeaderName::from_static("x-alpine-request");
+
+/// `X-Alpine-Target`: a space-separated list of the `id`s of the target
+/// elements being requested.
+pub const X_ALPINE_TARGET: HeaderName = HeaderName::from_static("x-alpine-target");

--- a/crates/topcoat-alpine-ajax/src/lib.rs
+++ b/crates/topcoat-alpine-ajax/src/lib.rs
@@ -1,0 +1,23 @@
+//! [Alpine AJAX](https://alpine-ajax.js.org) support for Topcoat.
+//!
+//! Alpine AJAX's wire protocol is much thinner than htmx's: the client sends
+//! two request headers and defines no server-to-client response header
+//! convention at all. This crate provides read-only accessors for those
+//! request headers, built on Topcoat's request context rather than on
+//! extractors or middleware:
+//!
+//! - **Request accessors** ([`ajax_request`], [`ajax_targets`], [`ajax_target`])
+//!   read the [Alpine AJAX request headers](https://alpine-ajax.js.org/reference/)
+//!   from a `cx: &Cx`.
+//!
+//! Merge strategies (`x-merge`), navigation (`x-target`), and client-side
+//! events (`ajax:*`) are pure client-side concerns configured directly in
+//! markup or JS and have no server-side counterpart to wrap.
+//!
+//! The raw header names are available as constants in the [`header`] module.
+
+pub mod header;
+
+mod request;
+
+pub use request::*;

--- a/crates/topcoat-alpine-ajax/src/request.rs
+++ b/crates/topcoat-alpine-ajax/src/request.rs
@@ -1,0 +1,139 @@
+use http::{HeaderName, request::Parts};
+use topcoat_core::context::{Cx, request_context};
+
+use crate::header;
+
+/// Reads the request header `name` as a string slice, or [`None`] when it is
+/// absent or not valid UTF-8.
+///
+/// The header map is borrowed straight from the request, so these reads are
+/// cheap pointer lookups: there is nothing worth caching with `#[memoize]`,
+/// and borrowing avoids the allocation a memoized owned value would require.
+fn header<'cx>(cx: &'cx Cx, name: &HeaderName) -> Option<&'cx str> {
+    request_context::<Parts>(cx)
+        .headers
+        .get(name)?
+        .to_str()
+        .ok()
+}
+
+/// Returns `true` when the current request was issued by Alpine AJAX, i.e. it
+/// carries an `X-Alpine-Request: true` header.
+///
+/// # Panics
+///
+/// Panics if called outside a router request (no request [`Parts`] in context).
+#[inline]
+#[must_use]
+pub fn ajax_request(cx: &Cx) -> bool {
+    header(cx, &header::X_ALPINE_REQUEST) == Some("true")
+}
+
+/// Returns the target element `id`s from the `X-Alpine-Target` header, or an
+/// empty iterator when the header is absent.
+///
+/// # Panics
+///
+/// Panics if called outside a router request (no request [`Parts`] in context).
+pub fn ajax_targets(cx: &Cx) -> impl Iterator<Item = &str> {
+    header(cx, &header::X_ALPINE_TARGET)
+        .unwrap_or_default()
+        .split_whitespace()
+}
+
+/// Returns `true` when `id` is among the requested target elements, i.e. it
+/// appears in the `X-Alpine-Target` header.
+///
+/// # Panics
+///
+/// Panics if called outside a router request (no request [`Parts`] in context).
+#[must_use]
+pub fn ajax_target(cx: &Cx, id: &str) -> bool {
+    ajax_targets(cx).any(|target| target == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Request;
+    use topcoat_core::context::CxTestBuilder;
+
+    use super::*;
+
+    /// Builds a `Cx` whose request carries the given headers.
+    fn cx_with(headers: &[(&HeaderName, &str)]) -> Cx {
+        let mut builder = Request::builder();
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let (parts, ()) = builder.body(()).unwrap().into_parts();
+
+        CxTestBuilder::new().request_context(parts).build()
+    }
+
+    #[test]
+    fn ajax_request_true_when_header_true() {
+        let cx = cx_with(&[(&header::X_ALPINE_REQUEST, "true")]);
+        assert!(ajax_request(&cx));
+    }
+
+    #[test]
+    fn ajax_request_false_when_header_false() {
+        let cx = cx_with(&[(&header::X_ALPINE_REQUEST, "false")]);
+        assert!(!ajax_request(&cx));
+    }
+
+    #[test]
+    fn ajax_request_false_when_header_missing() {
+        let cx = cx_with(&[]);
+        assert!(!ajax_request(&cx));
+    }
+
+    #[test]
+    fn ajax_targets_empty_when_header_missing() {
+        let cx = cx_with(&[]);
+        assert_eq!(ajax_targets(&cx).count(), 0);
+    }
+
+    #[test]
+    fn ajax_targets_empty_when_header_empty_string() {
+        let cx = cx_with(&[(&header::X_ALPINE_TARGET, "")]);
+        assert_eq!(ajax_targets(&cx).count(), 0);
+    }
+
+    #[test]
+    fn ajax_targets_single_id() {
+        let cx = cx_with(&[(&header::X_ALPINE_TARGET, "comments")]);
+        assert_eq!(ajax_targets(&cx).collect::<Vec<_>>(), vec!["comments"]);
+    }
+
+    #[test]
+    fn ajax_targets_multiple_space_separated_ids() {
+        let cx = cx_with(&[(&header::X_ALPINE_TARGET, "comments comments_count")]);
+        assert_eq!(
+            ajax_targets(&cx).collect::<Vec<_>>(),
+            vec!["comments", "comments_count"]
+        );
+    }
+
+    #[test]
+    fn ajax_targets_tolerates_extra_whitespace() {
+        let cx = cx_with(&[(&header::X_ALPINE_TARGET, "  comments   count  ")]);
+        assert_eq!(
+            ajax_targets(&cx).collect::<Vec<_>>(),
+            vec!["comments", "count"]
+        );
+    }
+
+    #[test]
+    fn ajax_target_matches_one_of_multiple_ids() {
+        let cx = cx_with(&[(&header::X_ALPINE_TARGET, "comments comments_count")]);
+        assert!(ajax_target(&cx, "comments_count"));
+        assert!(!ajax_target(&cx, "sidebar"));
+    }
+
+    #[test]
+    fn ajax_target_false_when_header_missing() {
+        let cx = cx_with(&[]);
+        assert!(!ajax_target(&cx, "comments"));
+    }
+}

--- a/crates/topcoat-view/grammar/src/view/html_ident.rs
+++ b/crates/topcoat-view/grammar/src/view/html_ident.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Write};
 use proc_macro2::{LineColumn, Span, TokenStream};
 use quote::ToTokens;
 use syn::{
-    Ident, Token,
+    Ident, LitInt, Token,
     ext::IdentExt,
     parse::{Parse, ParseStream},
     spanned::Spanned,
@@ -21,21 +21,6 @@ pub struct HtmlIdent {
     pub rest: Vec<HtmlIdentSegment>,
 }
 
-/// A trailing `<sep><ident>` segment of an [`HtmlIdent`].
-#[derive(Debug, PartialEq)]
-pub struct HtmlIdentSegment {
-    pub separator: HtmlIdentSeparator,
-    pub ident: Ident,
-}
-
-/// The character joining two segments of an [`HtmlIdent`].
-#[derive(Debug, PartialEq)]
-pub enum HtmlIdentSeparator {
-    Dash(Token![-]),
-    Colon(Token![:]),
-    Dot(Token![.]),
-}
-
 impl HtmlIdent {
     /// The source span covering the identifier. Falls back to the first
     /// segment's span when the underlying [`Span::join`] is unavailable (i.e.
@@ -44,7 +29,7 @@ impl HtmlIdent {
     pub fn span(&self) -> Span {
         let first = self.first.span();
         match self.rest.last() {
-            Some(segment) => first.join(segment.ident.span()).unwrap_or(first),
+            Some(segment) => first.join(segment.part.span()).unwrap_or(first),
             None => first,
         }
     }
@@ -92,20 +77,35 @@ impl HtmlIdent {
                 ));
             }
 
-            let ident = Ident::parse_any(input)?;
-            if !is_adjacent(separator_span.end(), ident.span().start()) {
+            let part = HtmlIdentPart::parse(input)?;
+            if !is_adjacent(separator_span.end(), part.span().start()) {
                 return Err(syn::Error::new(
-                    ident.span(),
+                    part.span(),
                     "whitespace is not allowed inside an HTML identifier",
                 ));
             }
 
-            prev_end = ident.span().end();
-            rest.push(HtmlIdentSegment { separator, ident });
+            prev_end = part.span().end();
+            rest.push(HtmlIdentSegment { separator, part });
         }
 
         Ok(Self { first, rest })
     }
+}
+
+/// A trailing `<sep><part>` segment of an [`HtmlIdent`].
+#[derive(Debug, PartialEq)]
+pub struct HtmlIdentSegment {
+    pub separator: HtmlIdentSeparator,
+    pub part: HtmlIdentPart,
+}
+
+/// The character joining two segments of an [`HtmlIdent`].
+#[derive(Debug, PartialEq)]
+pub enum HtmlIdentSeparator {
+    Dash(Token![-]),
+    Colon(Token![:]),
+    Dot(Token![.]),
 }
 
 impl HtmlIdentSeparator {
@@ -127,12 +127,75 @@ impl HtmlIdentSeparator {
     }
 }
 
+/// The identifier portion of an [`HtmlIdentSegment`]. Usually a Rust-style
+/// identifier, but HTML attribute names may also carry a bare number such as
+/// Alpine AJAX's `x-target.422` status-code modifiers -- including wildcard
+/// forms like `4xx` -- which are not valid Rust identifiers.
+#[derive(Debug, PartialEq)]
+pub enum HtmlIdentPart {
+    Ident(Ident),
+    Int(LitInt),
+}
+
+impl HtmlIdentPart {
+    /// Parses a segment identifier: either a Rust identifier (including
+    /// keywords) or an integer literal, which the Rust lexer produces for
+    /// segments that begin with a digit such as `422` or `4xx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input begins with neither of those.
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(LitInt) {
+            Ok(Self::Int(input.parse()?))
+        } else {
+            Ok(Self::Ident(Ident::parse_any(input)?))
+        }
+    }
+
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Ident(ident) => ident.span(),
+            Self::Int(int) => int.span(),
+        }
+    }
+}
+
+impl Display for HtmlIdentPart {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ident(ident) => Display::fmt(ident, f),
+            Self::Int(int) => Display::fmt(int, f),
+        }
+    }
+}
+
+impl ToTokens for HtmlIdentPart {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Ident(ident) => ident.to_tokens(tokens),
+            Self::Int(int) => int.to_tokens(tokens),
+        }
+    }
+}
+
+#[cfg(feature = "pretty")]
+impl topcoat_core_grammar::pretty::PrettyPrint for HtmlIdentPart {
+    fn pretty_print(&self, printer: &mut topcoat_core_grammar::pretty::Printer<'_>) {
+        match self {
+            Self::Ident(ident) => ident.pretty_print(printer),
+            Self::Int(int) => int.pretty_print(printer),
+        }
+    }
+}
+
 impl Display for HtmlIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.first, f)?;
         for segment in &self.rest {
             f.write_char(segment.separator.as_char())?;
-            Display::fmt(&segment.ident, f)?;
+            Display::fmt(&segment.part, f)?;
         }
         Ok(())
     }
@@ -159,7 +222,7 @@ impl ToTokens for HtmlIdent {
                 HtmlIdentSeparator::Colon(t) => t.to_tokens(tokens),
                 HtmlIdentSeparator::Dot(t) => t.to_tokens(tokens),
             }
-            segment.ident.to_tokens(tokens);
+            segment.part.to_tokens(tokens);
         }
     }
 }
@@ -174,7 +237,7 @@ impl topcoat_core_grammar::pretty::PrettyPrint for HtmlIdent {
                 HtmlIdentSeparator::Colon(token) => token.pretty_print(printer),
                 HtmlIdentSeparator::Dot(token) => token.pretty_print(printer),
             }
-            segment.ident.pretty_print(printer);
+            segment.part.pretty_print(printer);
         }
     }
 }
@@ -224,6 +287,27 @@ mod tests {
     #[test]
     fn parses_dot_separated_ident() {
         assert_eq!(parse("class.active").to_string(), "class.active");
+    }
+
+    #[test]
+    fn parses_numeric_segment() {
+        // Alpine AJAX status-code modifiers: a segment may be a bare number.
+        assert_eq!(parse("x-target.422").to_string(), "x-target.422");
+    }
+
+    #[test]
+    fn parses_wildcard_status_segment() {
+        // `4xx`/`5xx` lex as integer literals with an identifier suffix.
+        assert_eq!(parse("x-target.4xx").to_string(), "x-target.4xx");
+        assert_eq!(parse("x-target.5xx").to_string(), "x-target.5xx");
+    }
+
+    #[test]
+    fn whitespace_around_numeric_segment_is_rejected() {
+        assert!(
+            parse_err("x-target. 422")
+                .contains("whitespace is not allowed inside an HTML identifier")
+        );
     }
 
     #[test]

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -25,6 +25,7 @@ default = [
 	"discover",
 ]
 full = [
+	"alpine-ajax",
 	"asset",
 	"compression",
 	"cookie",
@@ -44,6 +45,9 @@ full = [
 	"view",
 ]
 
+alpine-ajax = [
+	"dep:topcoat-alpine-ajax",
+]
 asset = [
 	"dep:topcoat-asset",
 	"topcoat-font?/asset",
@@ -129,6 +133,7 @@ view = [
 ]
 
 [dependencies]
+topcoat-alpine-ajax = { workspace = true, optional = true }
 topcoat-asset = { workspace = true, optional = true }
 topcoat-cookie = { workspace = true, optional = true }
 topcoat-core.workspace = true

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -27,8 +27,8 @@ async fn root(slot: Slot<'_>) -> Result {
         <!DOCTYPE html>
         <html>
             <head>
-                <script defer=(true) src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.4/dist/cdn.min.js"></script>
-                <script defer=(true) src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/dist/cdn.min.js"></script>
+                <script defer="" src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.4/dist/cdn.min.js"></script>
+                <script defer="" src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/dist/cdn.min.js"></script>
             </head>
             <body>(slot.await?)</body>
         </html>
@@ -121,12 +121,12 @@ async fn create_comment(cx: &Cx /* , Form(input): Form<NewComment> */) -> Result
         return (
             StatusCode::UNPROCESSABLE_ENTITY,
             view! {
-                <form id="comment_form" x-target="comment_form comments" ("x-target.422")="comment_form">
+                <form id="comment_form" x-target="comment_form comments" x-target.422="comment_form">
                     <textarea name="body"></textarea>
                     <p class="error">(message)</p>
                     <button type="submit">"Post"</button>
                 </form>
-                <div id="alert" x-sync=(true) role="status">
+                <div id="alert" x-sync="" role="status">
                     <p>(message)</p>
                 </div>
             }?,

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -1,0 +1,145 @@
+[Alpine AJAX](https://alpine-ajax.js.org) is an Alpine.js plugin that lets HTML drive its own updates. Attributes like `x-target` make a `<form>` or `<a>` issue a fetch request and merge the returned HTML fragment into one or more target elements, without a full reload and without writing JavaScript. The server just answers with the markup for the piece of the page that changed.
+
+The browser tells the server about the request through two `X-Alpine-*` HTTP headers. Unlike htmx, Alpine AJAX defines no response header convention: there is nothing for the server to set to control navigation, retargeting, or client-side events -- those are all configured directly in markup (`x-merge`, `x-target`) or JavaScript (`ajax:*` events). Topcoat helps you read the request headers.
+
+Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the `alpine-ajax` feature.
+
+```toml
+# Cargo.toml
+[dependencies]
+topcoat = { version = "0.3.1", features = ["alpine-ajax"] }
+```
+
+# Loading the Alpine AJAX script
+
+Alpine AJAX is a plugin for Alpine.js core, so the browser must load both, in order: the plugin script first, then Alpine.js itself. Load both with `defer` so they run after the document has parsed; without it, Alpine can start initializing before `<body>` exists and silently skip binding directives on the page's first render.
+
+```rust
+use topcoat::{
+    Result,
+    router::{Slot, layout},
+    view::view,
+};
+
+#[layout]
+async fn root(slot: Slot<'_>) -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <script defer=(true) src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.4/dist/cdn.min.js"></script>
+                <script defer=(true) src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/dist/cdn.min.js"></script>
+            </head>
+            <body>(slot.await?)</body>
+        </html>
+    }
+}
+```
+
+# Reading request headers
+
+When Alpine AJAX makes a request it sends two headers describing itself and what it's targeting.
+
+```rust
+use topcoat::{
+    Result,
+    alpine_ajax::ajax_request,
+    context::Cx,
+    router::{Slot, layout},
+    view::view,
+};
+
+#[layout]
+async fn root(cx: &Cx, slot: Slot<'_>) -> Result {
+    // Alpine AJAX only merges the requested target elements, so we do not
+    // need to return the full layout shell. Just the page's content is
+    // enough.
+    if ajax_request(cx) {
+        return slot.await;
+    }
+
+    // Non-AJAX requests require a full page render including the layout shell.
+    view! {
+        <html>
+            <body>
+                <nav> /* persistent navigation */ </nav>
+                <main>(slot.await?)</main>
+            </body>
+        </html>
+    }
+}
+```
+
+- [`ajax_request`]: was this request issued by Alpine AJAX?
+- [`ajax_targets`]: an iterator over the `id`s of the target elements being requested.
+- [`ajax_target`]: is a given `id` among the requested targets?
+
+# Sending alert messages with `x-sync`
+
+A form's `x-target` only merges the elements it names, and by default only for a `2xx` response. Alpine AJAX's `x-sync` attribute is the escape hatch: any element on the page carrying `x-sync` is refreshed whenever a response contains a matching `id`, regardless of whether that `id` was targeted and regardless of status code. That makes it the right tool for a flash message or alert region that lives outside whatever a form explicitly targets:
+
+```html
+<div id="alert" x-sync role="status"></div>
+
+<form x-target="comment_form comments" method="post" action="/comments">
+    <textarea name="body"></textarea>
+    <button type="submit">"Post"</button>
+</form>
+```
+
+Render the `#alert` markup into every response from `/comments` (success or failure) and Alpine AJAX picks it up and replaces it in place, without it ever appearing in that form's `x-target`.
+
+Pairing this with `x-target`'s status-code modifiers covers form validation end to end. Add a modifier so the target list changes on a non-2xx response -- `x-target.422` merges only on a `422`, `x-target.4xx` on any `4xx`, `x-target.error` on `4xx` or `5xx`:
+
+```html
+<form
+    id="comment_form"
+    x-target="comment_form comments"
+    x-target.422="comment_form"
+    method="post"
+    action="/comments"
+>
+    ...
+</form>
+```
+
+A validation failure can respond `422` with just the `#comment_form` fragment (the textarea and an inline error) -- `comments` is left alone because it isn't in the `.422` target list -- while a success responds `200` and updates both. The Rust attribute name needs the parenthesized-expression form, since `422` on its own is not a valid identifier segment:
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{IntoResponse, Response, StatusCode, route},
+    view::view,
+};
+
+#[route(POST "/comments")]
+async fn create_comment(cx: &Cx /* , Form(input): Form<NewComment> */) -> Result<Response> {
+    let error: Option<&str> = None; // validate `input` here
+
+    if let Some(message) = error {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            view! {
+                <form id="comment_form" x-target="comment_form comments" ("x-target.422")="comment_form">
+                    <textarea name="body"></textarea>
+                    <p class="error">(message)</p>
+                    <button type="submit">"Post"</button>
+                </form>
+                <div id="alert" x-sync=(true) role="status">
+                    <p>(message)</p>
+                </div>
+            }?,
+        )
+            .into_response(cx);
+    }
+
+    // ...save the comment, then respond with the cleared form, the updated
+    // `comments` list, and an `#alert` confirmation, same as above but `200`.
+    # unreachable!()
+}
+```
+
+# Header constants
+
+The raw `X-Alpine-*` header names are available as `HeaderName` constants in [`topcoat::alpine_ajax::header`](crate::alpine_ajax::header), for when you want to read a header directly.

--- a/crates/topcoat/src/alpine_ajax.rs
+++ b/crates/topcoat/src/alpine_ajax.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../docs/alpine-ajax.md")]
+
+pub use topcoat_alpine_ajax::*;

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -16,6 +16,9 @@ pub type Result<T = view::View, E = topcoat_core::error::Error> = topcoat_core::
 #[cfg(not(feature = "view"))]
 pub type Result<T, E = topcoat_core::error::Error> = topcoat_core::error::Result<T, E>;
 
+#[cfg(feature = "alpine-ajax")]
+pub mod alpine_ajax;
+
 #[cfg(feature = "asset")]
 pub mod asset;
 

--- a/examples/alpine-ajax/Cargo.toml
+++ b/examples/alpine-ajax/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "alpine-ajax"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+topcoat = { workspace = true, features = ["alpine-ajax"] }
+
+[lints]
+workspace = true

--- a/examples/alpine-ajax/src/main.rs
+++ b/examples/alpine-ajax/src/main.rs
@@ -39,13 +39,13 @@ async fn root(cx: &Cx, slot: Slot<'_>) -> Result {
                 // initializing before `<body>` exists and silently skip
                 // binding directives on the page's first render.
                 <script
-                    defer=(true)
+                    defer=""
                     src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.4/dist/cdn.min.js"
                 >
 
                 </script>
                 <script
-                    defer=(true)
+                    defer=""
                     src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/dist/cdn.min.js"
                 >
 

--- a/examples/alpine-ajax/src/main.rs
+++ b/examples/alpine-ajax/src/main.rs
@@ -1,0 +1,96 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use topcoat::{
+    Result,
+    alpine_ajax::ajax_request,
+    context::{Cx, app_context},
+    router::{
+        IntoResponse, Response, Router, RouterBuilderDiscoverExt, Slot, layout, page, route,
+        see_other,
+    },
+    view::view,
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(
+        Router::builder()
+            .discover()
+            .app_context(Counter(AtomicU64::new(0)))
+            .build(),
+    )
+    .await
+    .unwrap();
+}
+
+#[layout("/")]
+async fn root(cx: &Cx, slot: Slot<'_>) -> Result {
+    // For client-side navigations we don't need to return the full HTML shell again.
+    // Alpine AJAX automatically merges just the targeted content.
+    if ajax_request(cx) {
+        return slot.await;
+    }
+
+    view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                // `defer` matters here: without it, Alpine can start
+                // initializing before `<body>` exists and silently skip
+                // binding directives on the page's first render.
+                <script
+                    defer=(true)
+                    src="https://cdn.jsdelivr.net/npm/@imacrayon/alpine-ajax@0.12.4/dist/cdn.min.js"
+                >
+
+                </script>
+                <script
+                    defer=(true)
+                    src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/dist/cdn.min.js"
+                >
+
+                </script>
+                topcoat::dev::script()
+            </head>
+            <body>(slot.await?)</body>
+        </html>
+    }
+}
+
+#[page("/")]
+async fn home(cx: &Cx) -> Result {
+    let count = app_context::<Counter>(cx).0.load(Ordering::Relaxed);
+
+    view! {
+        <h1>
+            "Count: "
+            <span id="count">(count)</span>
+        </h1>
+        <form method="post" action="/increment" x-target="count">
+            <button type="submit">"Increment"</button>
+        </form>
+    }
+}
+
+// A shared counter, registered as app context.
+struct Counter(AtomicU64);
+
+// Bumps the counter. For an Alpine AJAX request, returns just the `<span>`
+// wrapping the new value, which Alpine AJAX merges into whichever elements
+// the request targeted (here, `#count`, per the form's `x-target="count"`).
+//
+// The form is a plain HTML `<form method="post">`, so this also has to work
+// with JavaScript disabled: the browser then submits a full-page request,
+// which isn't an Alpine AJAX request, so this falls back to the
+// Post/Redirect/Get pattern, sending the browser back to `/` to see the
+// updated count.
+#[route(POST "/increment")]
+async fn increment(cx: &Cx) -> Result<Response> {
+    let count = app_context::<Counter>(cx).0.fetch_add(1, Ordering::Relaxed) + 1;
+
+    if ajax_request(cx) {
+        return view! { <span id="count">(count)</span> }?.into_response(cx);
+    }
+
+    see_other("/").into_response(cx)
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,6 +19,11 @@ release = true
 version_group = "topcoat"
 
 [[package]]
+name = "topcoat-alpine-ajax"
+release = true
+version_group = "topcoat"
+
+[[package]]
 name = "topcoat-asset"
 release = true
 version_group = "topcoat"


### PR DESCRIPTION
Adds Third-party integration for [Alpine AJAX](https://alpine-ajax.js.org/)([Alpine.js](https://alpinejs.dev/) Plugin)