### PR TITLE
fix: ignore non-compiling Topcoat UI doctest examples

### DIFF
--- a/crates/topcoat-ui/registry/src/components/badge.rs
+++ b/crates/topcoat-ui/registry/src/components/badge.rs
@@ -48,7 +48,7 @@ const BASE: &str = "inline-flex w-fit shrink-0 items-center justify-center gap-1
 ///
 /// Use it to give badge styling to another element, such as a link:
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <a href="/releases/v2" class=(badge_variants(BadgeVariant::Outline))>"v2.0"</a>
 /// }
@@ -65,7 +65,7 @@ pub fn badge_variants(variant: BadgeVariant) -> String {
 /// `<span>`; a `class` among them is appended to the computed classes. Child
 /// nodes become the badge's content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     badge(variant: BadgeVariant::Destructive, "Failed")
 /// }

--- a/crates/topcoat-ui/registry/src/components/button.rs
+++ b/crates/topcoat-ui/registry/src/components/button.rs
@@ -106,7 +106,7 @@ const BASE: &str = "inline-flex shrink-0 items-center justify-center border \
 /// Use it to give button styling to an element that is not a `<button>`, such
 /// as a link styled as a button:
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <a href="/login" class=(button_variants(ButtonVariant::Outline, ButtonSize::Md))>
 ///         "Sign in"
@@ -126,7 +126,7 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// them is appended to the computed classes. Child nodes become the button's
 /// content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     button(
 ///         variant: ButtonVariant::Destructive,

--- a/crates/topcoat-ui/registry/src/components/card.rs
+++ b/crates/topcoat-ui/registry/src/components/card.rs
@@ -21,7 +21,7 @@ const CARD: &str = "flex flex-col gap-5 rounded-xl border border-border bg-backg
 /// underlying `<div>`; a `class` among them is appended to the computed
 /// classes. Child nodes become the card's sections.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     card(
 ///         attrs: attributes! { class="max-w-sm" },

--- a/crates/topcoat-ui/registry/src/components/checkbox.rs
+++ b/crates/topcoat-ui/registry/src/components/checkbox.rs
@@ -25,7 +25,7 @@ const CHECKBOX: &str = "peer size-4 shrink-0 appearance-none rounded-[4px] borde
 /// attribute. The indeterminate state is not styled: it is only reachable
 /// through the DOM property, so setting it takes a script to begin with.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex items-center gap-2">
 ///         checkbox(attrs: attributes! { id="terms" name="terms" checked=(true) })

--- a/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
+++ b/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
@@ -12,7 +12,7 @@ use topcoat::{
 /// `attrs` (such as `class` or `open`) are forwarded to the underlying
 /// `<details>`; a `class` among them is appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu(
 ///         dropdown_menu_trigger("Options")
@@ -54,7 +54,7 @@ const TRIGGER: &str = "cursor-pointer list-none [&::-webkit-details-marker]:hidd
 /// The `attrs` are forwarded to the `<summary>`; a `class` among them is
 /// appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu_trigger(
 ///         attrs: attributes! {
@@ -136,7 +136,7 @@ pub async fn dropdown_menu_item(
 /// the underlying `<details>`; a `class` among them is appended to the
 /// computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu_content(
 ///         dropdown_menu_item("Back")

--- a/crates/topcoat-ui/registry/src/components/input.rs
+++ b/crates/topcoat-ui/registry/src/components/input.rs
@@ -22,7 +22,7 @@ const INPUT: &str = "h-9 w-full min-w-0 rounded-lg border border-border bg-backg
 /// is appended to the computed classes. The input fills its container, so
 /// size it through the container or with a width class.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     input(attrs: attributes! { type="email" placeholder="you@example.com" })
 /// }

--- a/crates/topcoat-ui/registry/src/components/label.rs
+++ b/crates/topcoat-ui/registry/src/components/label.rs
@@ -21,7 +21,7 @@ const LABEL: &str = "flex items-center gap-2 text-sm leading-none font-medium se
 /// `for`) are forwarded to the underlying `<label>`; a `class` among them is
 /// appended to the computed classes. Child nodes become the label's content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex flex-col gap-2">
 ///         label(attrs: attributes! { for="email" }, "Email")

--- a/crates/topcoat-ui/registry/src/components/progress.rs
+++ b/crates/topcoat-ui/registry/src/components/progress.rs
@@ -28,7 +28,7 @@ const PROGRESS: &str = "h-2 w-full appearance-none overflow-hidden rounded-full 
 /// among them is appended to the computed classes. The bar fills its
 /// container, so size it through the container or with a width class.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     progress(value: 62.0)
 /// }

--- a/crates/topcoat-ui/registry/src/components/select.rs
+++ b/crates/topcoat-ui/registry/src/components/select.rs
@@ -85,7 +85,7 @@ fn checkmark_style(cx: &Cx) -> String {
 /// it is open; other browsers keep the operating system's picker. The control
 /// itself looks the same everywhere.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     select(
 ///         attrs: attributes! { name="region" },

--- a/crates/topcoat-ui/registry/src/components/spinner.rs
+++ b/crates/topcoat-ui/registry/src/components/spinner.rs
@@ -11,7 +11,7 @@ use topcoat::{
 /// explicitly. The `attrs` (such as `class`) are forwarded to the underlying
 /// `<svg>`; a `class` among them is appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     button(
 ///         attrs: attributes! { disabled=(true) },

--- a/crates/topcoat-ui/registry/src/components/switch.rs
+++ b/crates/topcoat-ui/registry/src/components/switch.rs
@@ -31,7 +31,7 @@ const THUMB: &str = "pointer-events-none absolute top-1/2 left-0.5 size-3.5 -tra
 /// `<input>`; a `class` among them is appended to the wrapping element's
 /// classes. Set the on state with a plain `checked` attribute.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex items-center gap-2">
 ///         switch(attrs: attributes! { id="airplane-mode" checked=(true) })

--- a/crates/topcoat-ui/registry/src/components/textarea.rs
+++ b/crates/topcoat-ui/registry/src/components/textarea.rs
@@ -24,7 +24,7 @@ const TEXTAREA: &str = "field-sizing-content min-h-16 w-full rounded-lg border b
 /// container or with a width class; it grows with its content from a
 /// two-line minimum.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     textarea(attrs: attributes! { name="feedback" placeholder="Tell us more" })
 /// }

--- a/examples/ui/src/components/badge.rs
+++ b/examples/ui/src/components/badge.rs
@@ -48,7 +48,7 @@ const BASE: &str = "inline-flex w-fit shrink-0 items-center justify-center gap-1
 ///
 /// Use it to give badge styling to another element, such as a link:
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <a href="/releases/v2" class=(badge_variants(BadgeVariant::Outline))>"v2.0"</a>
 /// }
@@ -65,7 +65,7 @@ pub fn badge_variants(variant: BadgeVariant) -> String {
 /// `<span>`; a `class` among them is appended to the computed classes. Child
 /// nodes become the badge's content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     badge(variant: BadgeVariant::Destructive, "Failed")
 /// }

--- a/examples/ui/src/components/button.rs
+++ b/examples/ui/src/components/button.rs
@@ -106,7 +106,7 @@ const BASE: &str = "inline-flex shrink-0 items-center justify-center border \
 /// Use it to give button styling to an element that is not a `<button>`, such
 /// as a link styled as a button:
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <a href="/login" class=(button_variants(ButtonVariant::Outline, ButtonSize::Md))>
 ///         "Sign in"
@@ -126,7 +126,7 @@ pub fn button_variants(variant: ButtonVariant, size: ButtonSize) -> String {
 /// them is appended to the computed classes. Child nodes become the button's
 /// content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     button(
 ///         variant: ButtonVariant::Destructive,

--- a/examples/ui/src/components/card.rs
+++ b/examples/ui/src/components/card.rs
@@ -21,7 +21,7 @@ const CARD: &str = "flex flex-col gap-5 rounded-xl border border-border bg-backg
 /// underlying `<div>`; a `class` among them is appended to the computed
 /// classes. Child nodes become the card's sections.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     card(
 ///         attrs: attributes! { class="max-w-sm" },

--- a/examples/ui/src/components/checkbox.rs
+++ b/examples/ui/src/components/checkbox.rs
@@ -25,7 +25,7 @@ const CHECKBOX: &str = "peer size-4 shrink-0 appearance-none rounded-[4px] borde
 /// attribute. The indeterminate state is not styled: it is only reachable
 /// through the DOM property, so setting it takes a script to begin with.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex items-center gap-2">
 ///         checkbox(attrs: attributes! { id="terms" name="terms" checked=(true) })

--- a/examples/ui/src/components/dropdown_menu.rs
+++ b/examples/ui/src/components/dropdown_menu.rs
@@ -12,7 +12,7 @@ use topcoat::{
 /// `attrs` (such as `class` or `open`) are forwarded to the underlying
 /// `<details>`; a `class` among them is appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu(
 ///         dropdown_menu_trigger("Options")
@@ -54,7 +54,7 @@ const TRIGGER: &str = "cursor-pointer list-none [&::-webkit-details-marker]:hidd
 /// The `attrs` are forwarded to the `<summary>`; a `class` among them is
 /// appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu_trigger(
 ///         attrs: attributes! {
@@ -136,7 +136,7 @@ pub async fn dropdown_menu_item(
 /// the underlying `<details>`; a `class` among them is appended to the
 /// computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     dropdown_menu_content(
 ///         dropdown_menu_item("Back")

--- a/examples/ui/src/components/input.rs
+++ b/examples/ui/src/components/input.rs
@@ -22,7 +22,7 @@ const INPUT: &str = "h-9 w-full min-w-0 rounded-lg border border-border bg-backg
 /// is appended to the computed classes. The input fills its container, so
 /// size it through the container or with a width class.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     input(attrs: attributes! { type="email" placeholder="you@example.com" })
 /// }

--- a/examples/ui/src/components/label.rs
+++ b/examples/ui/src/components/label.rs
@@ -21,7 +21,7 @@ const LABEL: &str = "flex items-center gap-2 text-sm leading-none font-medium se
 /// `for`) are forwarded to the underlying `<label>`; a `class` among them is
 /// appended to the computed classes. Child nodes become the label's content.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex flex-col gap-2">
 ///         label(attrs: attributes! { for="email" }, "Email")

--- a/examples/ui/src/components/progress.rs
+++ b/examples/ui/src/components/progress.rs
@@ -28,7 +28,7 @@ const PROGRESS: &str = "h-2 w-full appearance-none overflow-hidden rounded-full 
 /// among them is appended to the computed classes. The bar fills its
 /// container, so size it through the container or with a width class.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     progress(value: 62.0)
 /// }

--- a/examples/ui/src/components/select.rs
+++ b/examples/ui/src/components/select.rs
@@ -85,7 +85,7 @@ fn checkmark_style(cx: &Cx) -> String {
 /// it is open; other browsers keep the operating system's picker. The control
 /// itself looks the same everywhere.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     select(
 ///         attrs: attributes! { name="region" },

--- a/examples/ui/src/components/spinner.rs
+++ b/examples/ui/src/components/spinner.rs
@@ -11,7 +11,7 @@ use topcoat::{
 /// explicitly. The `attrs` (such as `class`) are forwarded to the underlying
 /// `<svg>`; a `class` among them is appended to the computed classes.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     button(
 ///         attrs: attributes! { disabled=(true) },

--- a/examples/ui/src/components/switch.rs
+++ b/examples/ui/src/components/switch.rs
@@ -31,7 +31,7 @@ const THUMB: &str = "pointer-events-none absolute top-1/2 left-0.5 size-3.5 -tra
 /// `<input>`; a `class` among them is appended to the wrapping element's
 /// classes. Set the on state with a plain `checked` attribute.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     <div class="flex items-center gap-2">
 ///         switch(attrs: attributes! { id="airplane-mode" checked=(true) })

--- a/examples/ui/src/components/textarea.rs
+++ b/examples/ui/src/components/textarea.rs
@@ -24,7 +24,7 @@ const TEXTAREA: &str = "field-sizing-content min-h-16 w-full rounded-lg border b
 /// container or with a width class; it grows with its content from a
 /// two-line minimum.
 ///
-/// ```rust
+/// ```ignore
 /// view! {
 ///     textarea(attrs: attributes! { name="feedback" placeholder="Tell us more" })
 /// }


### PR DESCRIPTION
## Summary

- Mark Topcoat UI registry examples as ignored doctests
- Prevent framework-specific `view!` examples from failing documentation tests

## Testing

- Not run (not requested)