### PR TITLE
fix: topcoat dev hot reload never succeeds on Windows (exe file lock)

### DIFF
--- a/crates/topcoat-cli/src/dev/app_server.rs
+++ b/crates/topcoat-cli/src/dev/app_server.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 
 use tokio::process::{Child, Command};
@@ -15,7 +15,13 @@ pub struct AppServer {
 
 impl AppServer {
     /// Run the built executable.
+    ///
+    /// On Windows the executable is copied to a shadow path and the copy is
+    /// run instead: a running process locks its image file, so launching the
+    /// original would make every subsequent rebuild fail at the link step
+    /// ("Access is denied") while the server keeps serving.
     pub fn spawn(exe: &Path, dev_url: &str) -> io::Result<Self> {
+        let exe = shadow_copy_for_windows(exe)?;
         let child = Command::new(exe)
             .env("TOPCOAT_DEV_URL", dev_url)
             .stdout(Stdio::inherit())
@@ -44,4 +50,32 @@ impl AppServer {
         let _ = self.child.kill().await;
         let _ = self.child.wait().await;
     }
+}
+
+/// On Windows, copy the executable next to itself (`app.exe` ->
+/// `app.topcoat-dev.exe`) and return the copy's path; other platforms return
+/// the path unchanged. The previous server has already been stopped when this
+/// runs, but Windows can hold the old image briefly after the process is
+/// reaped, so the copy is retried for a moment before giving up.
+fn shadow_copy_for_windows(exe: &Path) -> io::Result<PathBuf> {
+    if !cfg!(windows) {
+        return Ok(exe.to_path_buf());
+    }
+    let mut file_name = exe.file_stem().unwrap_or_default().to_os_string();
+    file_name.push(".topcoat-dev");
+    if let Some(extension) = exe.extension() {
+        file_name.push(".");
+        file_name.push(extension);
+    }
+    let shadow = exe.with_file_name(file_name);
+
+    let mut last_error = None;
+    for _ in 0..20 {
+        match std::fs::copy(exe, &shadow) {
+            Ok(_) => return Ok(shadow),
+            Err(error) => last_error = Some(error),
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    Err(last_error.expect("copy attempted at least once"))
 }


### PR DESCRIPTION
## Problem

`topcoat dev` keeps the previous application process serving while a rebuild is in flight — but on Windows a running process locks its image file, so cargo can never replace the executable at the link step. Every rebuild after the first fails with:

```
error: failed to remove file 'target\debug\app.exe'
Caused by: Access is denied. (os error 5)
```

and the watcher settles into `previous build still running; waiting for changes...` permanently. Hot reload never succeeds on Windows; the only way out is killing the dev server and restarting it for every change.

## Fix

`AppServer::spawn` copies the built executable to a shadow path (`app.topcoat-dev.exe`) and runs the copy, leaving the original free for the next link. The copy is retried briefly because Windows can hold the previous image for a moment after the old process is reaped. Non-Windows platforms run the original path unchanged.

The `BuildStamp` up-to-date check is unaffected — it stamps the original path, which cargo continues to own.

## Verified

On Windows 11: `topcoat dev` on an example app, edit a source file, rebuild completes, server restarts, page serves the new markup (`ready on ...` twice in the log where previously the second cycle always failed with os error 5).