### PR TITLE
fix: keep embedded asset declarations alive on MSVC builds

### DIFF
--- a/crates/topcoat-cli/src/cargo.rs
+++ b/crates/topcoat-cli/src/cargo.rs
@@ -165,6 +165,14 @@ pub async fn build(
             cmd.env_remove(&k);
         }
     }
+    // MSVC's linker strips the `#[used]` statics that carry the embedded
+    // asset declarations (see `topcoat-asset`), so on Windows the bundler
+    // finds no assets and every page panics resolving them. /OPT:NOREF keeps
+    // unreferenced data alive. RUSTFLAGS was stripped above, so this sets a
+    // deterministic value rather than appending to user state.
+    if cfg!(all(windows, target_env = "msvc")) {
+        cmd.env("RUSTFLAGS", "-C link-arg=/OPT:NOREF");
+    }
     cmd.args(["build", "--message-format=json-diagnostic-rendered-ansi"]);
     cmd.env("CARGO_TERM_PROGRESS_WHEN", "always");
     cmd.env("CARGO_TERM_PROGRESS_WIDTH", "80");


### PR DESCRIPTION
## Problem

The asset bundler discovers assets by scanning the built binary for the encoded declarations the `asset!` macro embeds as `#[used]` statics. The MSVC linker strips the ones declared inside function bodies (only module-scope declarations such as the runtime script's `SCRIPT` survive), so on Windows the bundler finds almost nothing and every page panics at render time:

```
thread 'tokio-rt-worker' panicked at crates\topcoat-asset\src\bundle.rs:211:17:
failed to resolve asset Asset(...) in app context's asset bundle
```

Measured on the `ui` example (Windows 11, stable MSVC toolchain, dev profile): the binary contains **1** `TOPCOAT_ASSET` marker out of the expected 3. Linking with `/OPT:NOREF` retains all 3 and the app works fully (Tailwind css + Geist fonts + runtime script all bundle and serve).

## Fix

Pass `-C link-arg=/OPT:NOREF` via `RUSTFLAGS` for the CLI's inner cargo build when running on a Windows MSVC host. This covers `topcoat dev`, `topcoat asset bundle`, and `topcoat asset list`. The environment is already stripped of inherited `RUSTFLAGS` at that point, so the value is deterministic.

Trade-off stated in the commit: CLI builds now carry a different fingerprint than a plain `cargo build` on Windows (one extra rebuild when alternating between them). Correctness over cache reuse.

## Limitations / future direction

A plain `cargo run` of an app (the getting-started flow before installing the CLI) still hits the bug on Windows. Longer term the macro likely wants `#[used(linker)]` once that stabilizes, or a retention scheme like linkme/inventory use; until then the linker flag could also be documented for manual builds. Happy to add a docs note in this PR if wanted.

## Verified

On Windows 11: with no workspace/user linker config, `topcoat asset list` on the `ui` example goes from 1 discovered asset to the full set (tailwind.css, 18 Geist woff2 files, runtime script), and `topcoat dev` serves the example fully styled instead of panicking per request.