### PR TITLE
fix: remove double type assertion in DOM binding

### DIFF
--- a/crates/topcoat-runtime/browser/src/binding.ts
+++ b/crates/topcoat-runtime/browser/src/binding.ts
@@ -36,7 +36,7 @@ export function setupBinding(el: Element, attr: Attr, scope: Scope): void {
 
 function write(el: Element, name: string, value: unknown): void {
 	if (PROPERTY_NAMES.has(name)) {
-		(el as unknown as Record<string, unknown>)[name] = value;
+		(el as Element & Record<string, unknown>)[name] = value;
 	}
 	if (isAttributeValueViewParts(value)) {
 		if (!value.isAttributePresent()) {


### PR DESCRIPTION
replaced the `(el as unknown as Record<string, unknown>)` double cast with a single intersection cast `(el as Element & Record<string, unknown>)`

this way it preserves the Element type identity instead of blowing it away with unknown