### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpine-ajax"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -472,7 +472,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "tokio",
@@ -635,7 +635,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datastar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -820,7 +820,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1060,7 +1060,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1525,7 +1525,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mail"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "tokio",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "manual-router"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2058,7 +2058,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "tokio",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "sse"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2393,7 +2393,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "toasty",
@@ -2759,7 +2759,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-alpine-ajax"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "http",
  "tokio",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "http",
  "memchr",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "console",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cookie 0.18.1",
  "getrandom 0.2.17",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quote",
  "serde",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-datastar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "http",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heck",
  "inventory",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quote",
  "syn",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "http",
  "serde",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "lettre",
  "thiserror",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quote",
  "syn",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "http",
  "quote",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quote",
  "syn",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "http",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "quote",
  "syn",
@@ -3329,7 +3329,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "websocket"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -110,36 +110,36 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-alpine-ajax = { version = "0.4.0", path = "crates/topcoat-alpine-ajax" }
-topcoat-asset = { version = "0.4.0", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.4.0", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.4.0", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.4.0", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.4.0", path = "crates/topcoat-core/macro" }
-topcoat-datastar = { version = "0.4.0", path = "crates/topcoat-datastar" }
-topcoat-font = { version = "0.4.0", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.4.0", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.4.0", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.4.0", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.4.0", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.4.0", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.4.0", path = "crates/topcoat-icon/macro" }
-topcoat-mail = { version = "0.4.0", path = "crates/topcoat-mail" }
-topcoat-mail-grammar = { version = "0.4.0", path = "crates/topcoat-mail/grammar" }
-topcoat-mail-macro = { version = "0.4.0", path = "crates/topcoat-mail/macro" }
-topcoat-router = { version = "0.4.0", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.4.0", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.4.0", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.4.0", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.4.0", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.4.0", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.4.0", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.4.0", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.4.0", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.4.0", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.4.0", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.4.0", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.4.0", path = "crates/topcoat-view/macro" }
+topcoat-alpine-ajax = { version = "0.5.0", path = "crates/topcoat-alpine-ajax" }
+topcoat-asset = { version = "0.5.0", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.5.0", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.5.0", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.5.0", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.5.0", path = "crates/topcoat-core/macro" }
+topcoat-datastar = { version = "0.5.0", path = "crates/topcoat-datastar" }
+topcoat-font = { version = "0.5.0", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.5.0", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.5.0", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.5.0", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.5.0", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.5.0", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.5.0", path = "crates/topcoat-icon/macro" }
+topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
+topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
+topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
+topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.5.0", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.5.0", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.5.0", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.5.0", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.5.0", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.5.0", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.5.0", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.5.0", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.5.0", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.5.0", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-asset/CHANGELOG.md
+++ b/crates/topcoat-asset/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.4.0...topcoat-asset-v0.5.0) - 2026-07-27
+
+### Added
+
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Fixed
+
+- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- [**breaking**] change order of AssetConfig::hosted_at
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.3.1...topcoat-asset-v0.4.0) - 2026-07-22
 
 ### Added

--- a/crates/topcoat-cli/CHANGELOG.md
+++ b/crates/topcoat-cli/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.4.0...topcoat-cli-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+- topcoat dev reports more build errors ([#208](https://github.com/tokio-rs/topcoat/pull/208))
+- support wasm asset bundling ([#199](https://github.com/tokio-rs/topcoat/pull/199))
+- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))
+
+### Fixed
+
+- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
+- formatter exiting with code 0 on failed stdin formatting ([#207](https://github.com/tokio-rs/topcoat/pull/207))
+- keep embedded asset declarations alive on MSVC builds ([#170](https://github.com/tokio-rs/topcoat/pull/170))
+- topcoat dev hot reload never succeeds on Windows (exe file lock) ([#169](https://github.com/tokio-rs/topcoat/pull/169))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.3.1...topcoat-cli-v0.4.0) - 2026-07-22
 
 ### Added

--- a/crates/topcoat-cookie/CHANGELOG.md
+++ b/crates/topcoat-cookie/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.4.0...topcoat-cookie-v0.5.0) - 2026-07-27
+
+### Added
+
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.1.3...topcoat-cookie-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-core/CHANGELOG.md
+++ b/crates/topcoat-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.4.0...topcoat-core-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.1.3...topcoat-core-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-core/grammar/CHANGELOG.md
+++ b/crates/topcoat-core/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.4.0...topcoat-core-grammar-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.3.1...topcoat-core-grammar-v0.4.0) - 2026-07-22
 
 ### Fixed

--- a/crates/topcoat-core/macro/CHANGELOG.md
+++ b/crates/topcoat-core/macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.4.0...topcoat-core-macro-v0.5.0) - 2026-07-27
+
+### Other
+
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.1.3...topcoat-core-macro-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-datastar/CHANGELOG.md
+++ b/crates/topcoat-datastar/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.4.0...topcoat-datastar-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(datastar)* add datastar support ([#219](https://github.com/tokio-rs/topcoat/pull/219))

--- a/crates/topcoat-font/CHANGELOG.md
+++ b/crates/topcoat-font/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.4.0...topcoat-font-v0.5.0) - 2026-07-27
+
+### Added
+
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Fixed
+
+- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.1.3...topcoat-font-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-mail/grammar/CHANGELOG.md
+++ b/crates/topcoat-mail/grammar/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.4.0...topcoat-mail-grammar-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))

--- a/crates/topcoat-mail/macro/CHANGELOG.md
+++ b/crates/topcoat-mail/macro/CHANGELOG.md
@@ -6,3 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.4.0...topcoat-mail-macro-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+
+### Other
+
+- *(mail)* mail example and guide ([#221](https://github.com/tokio-rs/topcoat/pull/221))

--- a/crates/topcoat-router/CHANGELOG.md
+++ b/crates/topcoat-router/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.4.0...topcoat-router-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+- *(router)* validate websocket handshake keys ([#215](https://github.com/tokio-rs/topcoat/pull/215))
+- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- support unix listeners ([#190](https://github.com/tokio-rs/topcoat/pull/190))
+- support mounting tower services as routes in the router ([#184](https://github.com/tokio-rs/topcoat/pull/184))
+- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Other
+
+- clarify module router registration
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
+- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
+- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
+- improve router macro docs
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.1.3...topcoat-router-v0.2.0) - 2026-07-19
 
 ### Added

--- a/crates/topcoat-router/grammar/CHANGELOG.md
+++ b/crates/topcoat-router/grammar/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.4.0...topcoat-router-grammar-v0.5.0) - 2026-07-27
+
+### Added
+
+- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Other
+
+- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.1.3...topcoat-router-grammar-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-router/macro/CHANGELOG.md
+++ b/crates/topcoat-router/macro/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.4.0...topcoat-router-macro-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
+- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
+- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
+- improve router macro docs
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.1.3...topcoat-router-macro-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-runtime/CHANGELOG.md
+++ b/crates/topcoat-runtime/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.4.0...topcoat-runtime-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+
+### Fixed
+
+- browser hang when a text expression renders an owned string ([#201](https://github.com/tokio-rs/topcoat/pull/201))
+- remove double type assertion in DOM binding ([#171](https://github.com/tokio-rs/topcoat/pull/171))
+- return Bool surrogates from boolean event fields ([#168](https://github.com/tokio-rs/topcoat/pull/168))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+
 ## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.3.0...topcoat-runtime-v0.3.1) - 2026-07-20
 
 ### Fixed

--- a/crates/topcoat-runtime/grammar/CHANGELOG.md
+++ b/crates/topcoat-runtime/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.4.0...topcoat-runtime-grammar-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.1.3...topcoat-runtime-grammar-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-runtime/macro/CHANGELOG.md
+++ b/crates/topcoat-runtime/macro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.4.0...topcoat-runtime-macro-v0.5.0) - 2026-07-27
+
+### Added
+
+- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.1.3...topcoat-runtime-macro-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-session/CHANGELOG.md
+++ b/crates/topcoat-session/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.4.0...topcoat-session-v0.5.0) - 2026-07-27
+
+### Added
+
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+
+### Other
+
+- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
+
 ## [0.3.1](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.3.0...topcoat-session-v0.3.1) - 2026-07-20
 
 ### Other

--- a/crates/topcoat-ui/registry/CHANGELOG.md
+++ b/crates/topcoat-ui/registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.4.0...topcoat-ui-registry-v0.5.0) - 2026-07-27
+
+### Added
+
+- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
+
+### Fixed
+
+- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.3.1...topcoat-ui-registry-v0.4.0) - 2026-07-22
 
 ### Fixed

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.4.0...topcoat-view-v0.5.0) - 2026-07-27
+
+### Added
+
+- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
+- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- improve view macro docs
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.3.1...topcoat-view-v0.4.0) - 2026-07-22
 
 ### Added

--- a/crates/topcoat-view/grammar/CHANGELOG.md
+++ b/crates/topcoat-view/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.4.0...topcoat-view-grammar-v0.5.0) - 2026-07-27
+
+### Added
+
+- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))
+
+### Fixed
+
+- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.3.1...topcoat-view-grammar-v0.4.0) - 2026-07-22
 
 ### Added

--- a/crates/topcoat-view/macro/CHANGELOG.md
+++ b/crates/topcoat-view/macro/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.4.0...topcoat-view-macro-v0.5.0) - 2026-07-27
+
+### Added
+
+- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
+- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))
+
+### Fixed
+
+- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
+
+### Other
+
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- improve view macro docs
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+
 ## [0.3.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.2.0...topcoat-view-macro-v0.3.0) - 2026-07-19
 
 ### Fixed

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tokio-rs/topcoat/compare/v0.4.0...v0.5.0) - 2026-07-27
+
+### Added
+
+- *(datastar)* add datastar support ([#219](https://github.com/tokio-rs/topcoat/pull/219))
+- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
+- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
+- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))
+- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))
+- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
+- support unix listeners ([#190](https://github.com/tokio-rs/topcoat/pull/190))
+- support mounting tower services as routes in the router ([#184](https://github.com/tokio-rs/topcoat/pull/184))
+- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
+- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
+- topcoat dev reports more build errors ([#208](https://github.com/tokio-rs/topcoat/pull/208))
+- support wasm asset bundling ([#199](https://github.com/tokio-rs/topcoat/pull/199))
+- *(router)* validate websocket handshake keys ([#215](https://github.com/tokio-rs/topcoat/pull/215))
+- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
+- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))
+
+### Fixed
+
+- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
+- formatter exiting with code 0 on failed stdin formatting ([#207](https://github.com/tokio-rs/topcoat/pull/207))
+- keep embedded asset declarations alive on MSVC builds ([#170](https://github.com/tokio-rs/topcoat/pull/170))
+- topcoat dev hot reload never succeeds on Windows (exe file lock) ([#169](https://github.com/tokio-rs/topcoat/pull/169))
+- browser hang when a text expression renders an owned string ([#201](https://github.com/tokio-rs/topcoat/pull/201))
+- remove double type assertion in DOM binding ([#171](https://github.com/tokio-rs/topcoat/pull/171))
+- return Bool surrogates from boolean event fields ([#168](https://github.com/tokio-rs/topcoat/pull/168))
+- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
+
+### Other
+
+- improve readme
+- *(mail)* mail example and guide ([#221](https://github.com/tokio-rs/topcoat/pull/221))
+- add new roadmap items
+- clarify module router registration
+- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
+- [**breaking**] change order of AssetConfig::hosted_at
+- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
+- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
+- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
+- add sitemaps to roadmap
+- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
+- improve router macro docs
+- improve view macro docs
+
 ## [0.4.0](https://github.com/tokio-rs/topcoat/compare/topcoat-v0.3.1...topcoat-v0.4.0) - 2026-07-22
 
 ### Added

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["alpine-ajax"] }
+topcoat = { version = "0.5.0", features = ["alpine-ajax"] }
 ```
 
 # Loading the Alpine AJAX script

--- a/crates/topcoat/docs/datastar.md
+++ b/crates/topcoat/docs/datastar.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::datastar` and gated behind the `d
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["datastar"] }
+topcoat = { version = "0.5.0", features = ["datastar"] }
 ```
 
 # Loading the Datastar script

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.4.0", features = ["font-fontsource"] }
+topcoat = { version = "0.5.0", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["htmx"] }
+topcoat = { version = "0.5.0", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["icon-iconify"] }
+topcoat = { version = "0.5.0", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.4.0", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.5.0", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/mail.md
+++ b/crates/topcoat/docs/mail.md
@@ -5,7 +5,7 @@ Everything below is re-exported from `topcoat::mail` and gated behind the `mail`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["mail", "mail-smtp"] }
+topcoat = { version = "0.5.0", features = ["mail", "mail-smtp"] }
 ```
 
 # Setup

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["tailwind"] }
+topcoat = { version = "0.5.0", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.4.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.5.0", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.4.0", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.5.0", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.4.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.5.0", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-alpine-ajax`: 0.4.0 -> 0.5.0
* `topcoat-view`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-router`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `topcoat-asset`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `topcoat-cookie`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-core-grammar`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-core-macro`: 0.4.0 -> 0.5.0
* `topcoat-datastar`: 0.4.0 -> 0.5.0
* `topcoat-view-grammar`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `topcoat-view-macro`: 0.4.0 -> 0.5.0
* `topcoat-font`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-font-grammar`: 0.4.0 -> 0.5.0
* `topcoat-font-macro`: 0.4.0 -> 0.5.0
* `topcoat-htmx`: 0.4.0 -> 0.5.0
* `topcoat-icon`: 0.4.0 -> 0.5.0
* `topcoat-icon-grammar`: 0.4.0 -> 0.5.0
* `topcoat-icon-macro`: 0.4.0 -> 0.5.0
* `topcoat-mail`: 0.4.0 -> 0.5.0
* `topcoat-mail-grammar`: 0.4.0 -> 0.5.0
* `topcoat-mail-macro`: 0.4.0 -> 0.5.0
* `topcoat-router-grammar`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-router-macro`: 0.4.0 -> 0.5.0
* `topcoat-runtime`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-runtime-grammar`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-runtime-macro`: 0.4.0 -> 0.5.0
* `topcoat-session`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `topcoat-tailwind`: 0.4.0 -> 0.5.0
* `topcoat-ui-registry`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `topcoat-ui`: 0.4.0 -> 0.5.0
* `topcoat-cli`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

### ⚠ `topcoat-router` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function topcoat_router::unauthorized, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/unauthorized.rs:27
  function topcoat_router::method_not_allowed, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/method_not_allowed.rs:19
  function topcoat_router::see_other, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/redirect.rs:114
  function topcoat_router::redirect, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/redirect.rs:26
  function topcoat_router::forbidden, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/forbidden.rs:30
  function topcoat_router::not_found, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/not_found.rs:25
  function topcoat_router::bad_request_at, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/bad_request.rs:34
  function topcoat_router::internal_server_error, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/internal_server.rs:30
  function topcoat_router::bad_request, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/bad_request.rs:25
  function topcoat_router::redirect_permanent, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/redirect.rs:48

--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_const_removed.ron

Failed in:
  RouteFn::new in /tmp/.tmponuI44/topcoat/crates/topcoat-router/src/route.rs:68
  PageFn::new in /tmp/.tmponuI44/topcoat/crates/topcoat-router/src/page.rs:41

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  topcoat_router::PageFn::new takes 2 parameters in /tmp/.tmpl5WEIo/topcoat-router/src/page.rs:33, but now takes 3 parameters in /tmp/.tmponuI44/topcoat/crates/topcoat-router/src/page.rs:41

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_router::TowerNextError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/tower.rs:200
  struct topcoat_router::BadRequestError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/bad_request.rs:47
  struct topcoat_router::Multipart, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/multipart.rs:51
  struct topcoat_router::Field, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/multipart.rs:104
  struct topcoat_router::Css, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/css.rs:20
  struct topcoat_router::Html, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/html.rs:20
  struct topcoat_router::UnauthorizedError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/unauthorized.rs:36
  struct topcoat_router::RawForm, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/form.rs:153
  struct topcoat_router::Json, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/json.rs:57
  struct topcoat_router::RedirectError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/redirect.rs:59
  struct topcoat_router::TowerLayer, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/tower.rs:54
  struct topcoat_router::TowerNext, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/tower.rs:153
  struct topcoat_router::ForbiddenError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/forbidden.rs:39
  struct topcoat_router::NotFoundError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/not_found.rs:34
  struct topcoat_router::MethodNotAllowedError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/method_not_allowed.rs:28
  struct topcoat_router::SeeOther, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/redirect.rs:125
  struct topcoat_router::TowerLayerError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/tower.rs:273
  struct topcoat_router::Form, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/content/form.rs:50
  struct topcoat_router::InternalServerError, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error/internal_server.rs:38

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method method of trait Route, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/route.rs:18

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait topcoat_router::RouterErrorExt, previously in file /tmp/.tmpl5WEIo/topcoat-router/src/error.rs:106
```

### ⚠ `topcoat-asset` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function topcoat_asset::asset_bundle, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/bundle.rs:196

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  Asset::as_u64, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/asset.rs:47
  BundledAsset::path, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/bundle.rs:22
  AssetBundle::empty, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/bundle.rs:62
  AssetBundle::assets, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/bundle.rs:185

--- failure inherent_method_now_doc_hidden: inherent method #[doc(hidden)] added ---

Description:
A method or associated fn is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_now_doc_hidden.ron

Failed in:
  Asset::new in file /tmp/.tmpl5WEIo/topcoat-asset/src/asset.rs:27

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  topcoat_asset::AssetRoute::new takes 1 parameters in /tmp/.tmpl5WEIo/topcoat-asset/src/router.rs:42, but now takes 2 parameters in /tmp/.tmponuI44/topcoat/crates/topcoat-asset/src/serve.rs:42

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_asset::AssetRouteResolver, previously in file /tmp/.tmpl5WEIo/topcoat-asset/src/resolver.rs:8
```

### ⚠ `topcoat-view-grammar` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type ComponentAttr is no longer Send, in /tmp/.tmponuI44/topcoat/crates/topcoat-view/grammar/src/component/attr.rs:13
  type ComponentAttr is no longer Sync, in /tmp/.tmponuI44/topcoat/crates/topcoat-view/grammar/src/component/attr.rs:13

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field ComponentAttr.boxed in /tmp/.tmponuI44/topcoat/crates/topcoat-view/grammar/src/component/attr.rs:14

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Node::ReactiveScope, previously in file /tmp/.tmpl5WEIo/topcoat-view-grammar/src/view/node.rs:37

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_view_grammar::view::ReactiveScope, previously in file /tmp/.tmpl5WEIo/topcoat-view-grammar/src/view/reactive_scope.rs:20
  struct topcoat_view_grammar::view::SignalParam, previously in file /tmp/.tmpl5WEIo/topcoat-view-grammar/src/view/reactive_scope.rs:27
```

### ⚠ `topcoat-session` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_session::ConfigBuilder, previously in file /tmp/.tmpl5WEIo/topcoat-session/src/config.rs:44
  struct topcoat_session::Config, previously in file /tmp/.tmpl5WEIo/topcoat-session/src/config.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.4.0...topcoat-core-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
</blockquote>


## `topcoat-view`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.4.0...topcoat-view-v0.5.0) - 2026-07-27

### Added

- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- improve view macro docs
</blockquote>

## `topcoat-router`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.4.0...topcoat-router-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
- *(router)* validate websocket handshake keys ([#215](https://github.com/tokio-rs/topcoat/pull/215))
- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))
- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- support unix listeners ([#190](https://github.com/tokio-rs/topcoat/pull/190))
- support mounting tower services as routes in the router ([#184](https://github.com/tokio-rs/topcoat/pull/184))
- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Other

- clarify module router registration
- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
- improve router macro docs
- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.4.0...topcoat-asset-v0.5.0) - 2026-07-27

### Added

- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Fixed

- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- [**breaking**] change order of AssetConfig::hosted_at
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.4.0...topcoat-cookie-v0.5.0) - 2026-07-27

### Added

- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.4.0...topcoat-core-grammar-v0.5.0) - 2026-07-27

### Added

- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.4.0...topcoat-core-macro-v0.5.0) - 2026-07-27

### Other

- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
</blockquote>

## `topcoat-datastar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.4.0...topcoat-datastar-v0.5.0) - 2026-07-27

### Added

- *(datastar)* add datastar support ([#219](https://github.com/tokio-rs/topcoat/pull/219))
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.4.0...topcoat-view-grammar-v0.5.0) - 2026-07-27

### Added

- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))

### Fixed

- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.4.0...topcoat-view-macro-v0.5.0) - 2026-07-27

### Added

- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))

### Fixed

- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- improve view macro docs
- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
</blockquote>

## `topcoat-font`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.4.0...topcoat-font-v0.5.0) - 2026-07-27

### Added

- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Fixed

- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.1.3...topcoat-font-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.1.3...topcoat-font-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.1.3...topcoat-htmx-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.1.3...topcoat-icon-grammar-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>


## `topcoat-mail-grammar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.4.0...topcoat-mail-grammar-v0.5.0) - 2026-07-27

### Added

- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
</blockquote>

## `topcoat-mail-macro`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.4.0...topcoat-mail-macro-v0.5.0) - 2026-07-27

### Added

- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))

### Other

- *(mail)* mail example and guide ([#221](https://github.com/tokio-rs/topcoat/pull/221))
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.4.0...topcoat-router-grammar-v0.5.0) - 2026-07-27

### Added

- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Other

- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.4.0...topcoat-router-macro-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
- improve router macro docs
- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.4.0...topcoat-runtime-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))
- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))

### Fixed

- browser hang when a text expression renders an owned string ([#201](https://github.com/tokio-rs/topcoat/pull/201))
- remove double type assertion in DOM binding ([#171](https://github.com/tokio-rs/topcoat/pull/171))
- return Bool surrogates from boolean event fields ([#168](https://github.com/tokio-rs/topcoat/pull/168))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.4.0...topcoat-runtime-grammar-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.4.0...topcoat-runtime-macro-v0.5.0) - 2026-07-27

### Added

- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.4.0...topcoat-session-v0.5.0) - 2026-07-27

### Added

- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))

### Other

- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.4.0...topcoat-ui-registry-v0.5.0) - 2026-07-27

### Added

- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))

### Fixed

- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))
</blockquote>

## `topcoat`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/v0.4.0...v0.5.0) - 2026-07-27

### Added

- *(datastar)* add datastar support ([#219](https://github.com/tokio-rs/topcoat/pull/219))
- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
- *(runtime)* add utility methods for signals with primitive types ([#214](https://github.com/tokio-rs/topcoat/pull/214))
- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))
- support wasm builds ([#191](https://github.com/tokio-rs/topcoat/pull/191))
- support unix listeners ([#190](https://github.com/tokio-rs/topcoat/pull/190))
- support mounting tower services as routes in the router ([#184](https://github.com/tokio-rs/topcoat/pull/184))
- make page HTTP methods customizable ([#181](https://github.com/tokio-rs/topcoat/pull/181))
- add support for routes that handle multiple (or all) methods ([#180](https://github.com/tokio-rs/topcoat/pull/180))
- topcoat dev reports more build errors ([#208](https://github.com/tokio-rs/topcoat/pull/208))
- support wasm asset bundling ([#199](https://github.com/tokio-rs/topcoat/pull/199))
- *(router)* validate websocket handshake keys ([#215](https://github.com/tokio-rs/topcoat/pull/215))
- [**breaking**] improve boolean attribute behavior and docs ([#179](https://github.com/tokio-rs/topcoat/pull/179))
- boxed components for cyclic component definition ([#176](https://github.com/tokio-rs/topcoat/pull/176))

### Fixed

- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
- formatter exiting with code 0 on failed stdin formatting ([#207](https://github.com/tokio-rs/topcoat/pull/207))
- keep embedded asset declarations alive on MSVC builds ([#170](https://github.com/tokio-rs/topcoat/pull/170))
- topcoat dev hot reload never succeeds on Windows (exe file lock) ([#169](https://github.com/tokio-rs/topcoat/pull/169))
- browser hang when a text expression renders an owned string ([#201](https://github.com/tokio-rs/topcoat/pull/201))
- remove double type assertion in DOM binding ([#171](https://github.com/tokio-rs/topcoat/pull/171))
- return Bool surrogates from boolean event fields ([#168](https://github.com/tokio-rs/topcoat/pull/168))
- topcoat formatter breaking at signal syntax ([#172](https://github.com/tokio-rs/topcoat/pull/172))

### Other

- improve readme
- *(mail)* mail example and guide ([#221](https://github.com/tokio-rs/topcoat/pull/221))
- add new roadmap items
- clarify module router registration
- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
- [**breaking**] change order of AssetConfig::hosted_at
- clarify module router paths and parameter handling ([#185](https://github.com/tokio-rs/topcoat/pull/185))
- [**breaking**] dedicated router error module ([#183](https://github.com/tokio-rs/topcoat/pull/183))
- improve router macro docs ([#178](https://github.com/tokio-rs/topcoat/pull/178))
- add sitemaps to roadmap
- [**breaking**] pass layouts the rendered Result<View> instead of a Slot future ([#166](https://github.com/tokio-rs/topcoat/pull/166))
- improve router macro docs
- improve view macro docs
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.1.3...topcoat-ui-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.4.0...topcoat-cli-v0.5.0) - 2026-07-27

### Added

- *(router)* server-sent events ([#218](https://github.com/tokio-rs/topcoat/pull/218))
- *(mail)* email prototype ([#216](https://github.com/tokio-rs/topcoat/pull/216))
- topcoat dev reports more build errors ([#208](https://github.com/tokio-rs/topcoat/pull/208))
- support wasm asset bundling ([#199](https://github.com/tokio-rs/topcoat/pull/199))
- websocket support ([#195](https://github.com/tokio-rs/topcoat/pull/195))

### Fixed

- *(asset)* improve asset linking system ([#217](https://github.com/tokio-rs/topcoat/pull/217))
- formatter exiting with code 0 on failed stdin formatting ([#207](https://github.com/tokio-rs/topcoat/pull/207))
- keep embedded asset declarations alive on MSVC builds ([#170](https://github.com/tokio-rs/topcoat/pull/170))
- topcoat dev hot reload never succeeds on Windows (exe file lock) ([#169](https://github.com/tokio-rs/topcoat/pull/169))

### Other

- fix outdated documentation ([#211](https://github.com/tokio-rs/topcoat/pull/211))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).