### PR TITLE
docs: clarify module router paths and parameter handling

### DIFF
--- a/crates/topcoat-router/docs/module_router.md
+++ b/crates/topcoat-router/docs/module_router.md
@@ -1,8 +1,8 @@
-The `module_router!` macro derives routes from your Rust module structure. The module tree becomes the route table: page, layout, layer, and route handlers can omit explicit path strings and let their enclosing module decide the URL.
+The `module_router!` macro derives a handler's path from its enclosing Rust module. A handler without a path string uses the module path. When registered, a handler with a path string uses that explicit path.
 
 # Setup
 
-Call `module_router!()` from the root module of your route tree. This module becomes the root `/` path. The macro returns a `RouterBuilder`, so call `.build()` once you have added anything else the builder needs.
+Call `module_router!()` from the root module of the route tree. That module maps to `/`. The macro returns a `RouterBuilder`, so add application context or other router extensions before calling `.build()`.
 
 ```rust
 // src/app.rs
@@ -11,27 +11,41 @@ pub fn router() -> topcoat::router::Router {
 }
 ```
 
-Every module-derived `#[page]`, `#[layout]`, `#[layer]`, and `#[route]` under `app` is discovered and registered.
+`module_router!` uses link-time discovery and requires the `discover` feature. The `topcoat` crate enables it by default.
+
+The macro does not scan the filesystem. Rust must compile each route module through a `mod` declaration:
+
+```text
+src/
+  app.rs          # contains `mod settings;`
+  app/
+    settings.rs   # contains `mod profile;`
+    settings/
+      profile.rs
+```
+
+Every module-derived `#[page]`, `#[layout]`, `#[layer]`, and `#[route]` under the module containing `module_router!()` is registered.
 
 # How modules map to routes
 
-Each module's path relative to the root module determines its URL. Module names are converted to **kebab-case** (e.g. `user_settings` becomes `user-settings`).
+Each module below the root contributes one path segment. Static module names are converted to kebab-case.
 
-| Module | Route |
+| Module | Route path |
 |---|---|
 | `app` | `/` |
 | `app::about` | `/about` |
 | `app::blog_posts` | `/blog-posts` |
-| `app::settings` | `/settings` |
 | `app::settings::profile` | `/settings/profile` |
+
+The function name does not affect the path. Two module-derived handlers in the same module receive the same path.
 
 # Pages, layouts, layers, and API routes
 
-A `#[page]` defines a page handler, serving `GET` unless the attribute names other methods (`#[page(POST)]`). A `#[layout]` wraps all pages in the same module and its submodules.
+A `#[page]` serves `GET` unless the attribute declares other methods, such as `#[page(POST)]`. A `#[layout]` wraps pages in its module and descendant modules.
 
 ```rust
 # use topcoat::{Result, router::{layout, page}, view::view};
-// src/app.rs: layout at "/" wraps all pages
+// src/app.rs: both handlers use "/"
 #[layout]
 async fn root_layout(slot: Result) -> Result {
     view! {
@@ -47,14 +61,14 @@ async fn home() -> Result {
 
 ```rust
 # use topcoat::{Result, router::page, view::view};
-// src/app/about.rs: page at "/about"
+// src/app/about.rs: GET /about
 #[page]
 async fn about() -> Result {
     view! { <h1>"About"</h1> }
 }
 ```
 
-API routes use `#[route]` with explicit HTTP methods: a single method, a `[GET, POST]` list, or `*` for every method. Like pages and layouts, routes without a path string derive their URL from the module path:
+An API route declares one method, a method list, or every method:
 
 ```rust
 # use topcoat::{Result, router::route};
@@ -65,10 +79,10 @@ async fn health() -> Result<&'static str> {
 }
 ```
 
-Layers use the same module-derived path as layouts, but wrap request handling instead of rendered view output:
+A layer uses its module path as a prefix:
 
 ```rust
-// src/app/api.rs: wraps routes under /api
+// src/app/api.rs: wraps handlers under /api
 use topcoat::{
     Result,
     context::CxBuilder,
@@ -83,91 +97,198 @@ async fn api_log(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Respo
 }
 ```
 
-# Path overrides
+# Dynamic path parameters
 
-Module-derived paths and explicit paths can be mixed in the same route tree. `#[page]`, `#[layout]`, `#[layer]`, and `#[route]` all register into the same builder in the end. If an attribute includes an explicit path, that path is used instead of the module-derived path for that item:
+Apply `#[path_param]` to a single-field tuple struct inside the module that should become dynamic. The macro changes that module's segment to a parameter and defines the type used to read it. The snake-cased struct name becomes the parameter name.
+
+```text
+src/
+  app.rs                  # `mod posts;`
+  app/
+    posts.rs              # `mod post_id;`, route prefix /posts
+    posts/
+      post_id.rs          # route /posts/{post_id}
+```
+
+```rust
+// src/app/posts/post_id.rs
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{page, path_param},
+    view::view,
+};
+
+#[path_param(error = bad_request)]
+struct PostId(u64);
+
+#[page]
+async fn post(cx: &Cx) -> Result {
+    let post_id = path_param::<PostId>(cx)?;
+    view! { <h1>"Post " (post_id)</h1> }
+}
+```
+
+This page serves `/posts/{post_id}`. A request for `/posts/42` parses `42` with `u64::from_str`. A failed parse returns `400 Bad Request` because the declaration uses `error = bad_request`.
+
+The parameter name comes from `PostId`, not from the `post_id.rs` filename. The file could be named `id.rs` and would still contribute `{post_id}`.
+
+`path_param::<T>(cx)` returns a request-scoped value:
+
+- `#[path_param] struct Slug(str);` returns the percent-decoded segment as `&str` and cannot fail.
+- Any other inner type must implement `FromStr`. Without `error = ...`, the function returns `Result<&T, &T::Err>`.
+- `error = bad_request`, `not_found`, `unauthorized`, `forbidden`, `redirect(...)`, or `redirect_permanent(...)` maps a parse failure to that router error.
+
+Parsing occurs once per request. Later calls return the memoized result.
+
+A module contributes one segment, so it can declare one `#[path_param]`. Use nested modules for multiple parameters:
+
+| Module | Route path |
+|---|---|
+| `app::organizations::organization_id` | `/organizations/{organization_id}` |
+| `app::organizations::organization_id::users::user_id` | `/organizations/{organization_id}/users/{user_id}` |
+
+Handlers and layouts in descendant modules can read parameters declared by ancestor modules if the Rust types are visible there.
+
+# Query parameters
+
+Query parameters do not affect module-derived paths. Declare a named-field struct with `#[query_params]`, then read it from any handler that takes `cx: &Cx`.
 
 ```rust
 # use topcoat::{
 #     Result,
-#     context::CxBuilder,
-#     router::{Body, Next, Response, layer, layout, page, route},
+#     context::Cx,
+#     router::{page, query_params},
 #     view::view,
 # };
-#[page("/")]
-async fn home() -> Result {
-    view! { <h1>"Home"</h1> }
+#[query_params(error = bad_request)]
+struct PostsQuery {
+    page: Option<u32>,
+    q: Option<String>,
 }
 
-#[layout("/admin")]
-async fn admin_layout(slot: Result) -> Result {
-    view! { <main>(slot?)</main> }
-}
-
-#[layer("/admin")]
-async fn admin_layer(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
-    next.run(cx, body).await
-}
-
-#[route(GET "/api/health")]
-async fn health() -> Result<&'static str> {
-    Ok("ok")
+// In src/app/posts.rs, this serves /posts and accepts
+// requests such as /posts?page=2&q=rust.
+#[page]
+async fn posts(cx: &Cx) -> Result {
+    let query = query_params::<PostsQuery>(cx)?;
+    view! {
+        <p>"page: " (query.page.unwrap_or(1))</p>
+        <p>"search: " (query.q.as_deref().unwrap_or(""))</p>
+    }
 }
 ```
 
-# Renaming a static segment
+`#[query_params]` derives `serde::Deserialize`. Use `Option<T>` for optional keys. Parsing occurs once per request and returns a reference to the memoized struct.
 
-`segment!(rename = "name")` overrides the URL with the given literal (used as-is, no kebab-casing).
+# Segment overrides
+
+`segment!(...)` changes the enclosing module's segment. It accepts `kind` and `rename`, each at most once:
+
+| Declaration | Result |
+|---|---|
+| none in `blog_posts` | `/blog-posts` |
+| `segment!(rename = "articles")` | `/articles` |
+| `segment!(kind = Group)` | no served URL segment |
+| `segment!(kind = Param, rename = "id")` | `/{id}` |
+| `segment!(kind = CatchAll, rename = "path")` | `/{*path}` |
+
+`Static` is the default kind for regular modules. `Group` is the default for modules whose names start with `_`. A rename is used as written; Topcoat does not kebab-case it.
+
+`#[path_param]` emits a `Param` segment override, so do not combine it with `segment!` in the same module. A manual `Param` override creates the route capture but does not define a typed accessor.
+
+# Catch-all parameters
+
+A `CatchAll` segment captures one or more remaining URL segments, including their `/` separators. It is the last served segment in a route.
 
 ```rust
-// src/app/blog_post.rs
-topcoat::router::segment!(rename = "articles");
-// Route: /articles instead of /blog-post
+// src/app/docs/path.rs: /docs/{*path}
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{page, raw_path_params, segment},
+    view::view,
+};
+
+segment!(kind = CatchAll, rename = "path");
+
+#[page]
+async fn document(cx: &Cx) -> Result {
+    let path = raw_path_params(cx)
+        .iter()
+        .find_map(|(name, value)| (name == "path").then_some(value))
+        .expect("route declares {*path}");
+
+    view! { <p>"Document: " (path)</p> }
+}
 ```
+
+For `/docs/guides/start`, `path` is `"guides/start"`. `/docs` does not match because a catch-all requires a non-empty remainder. Captured values are percent-decoded before the handler reads them.
 
 # Groups
 
-Modules prefixed with `_` are **groups**. They organize code and can hold shared layouts or layers, but they do not add a path segment to the served URL.
-
-```text
-app.rs                 # layout at /
-app/
-  _marketing.rs        # layout wrapping marketing pages (no URL segment)
-  _marketing/
-    pricing.rs         # /pricing
-    features.rs        # /features
-  _docs.rs             # layout wrapping docs pages (no URL segment)
-  _docs/
-    getting_started.rs # /getting-started
-```
-
-Both `pricing` and `getting_started` are top-level routes, but they can have different layouts through their respective group module files.
-
-You can also turn a regular module into a group with `segment!(kind = Group)`:
-
-```rust
-// src/app/marketing.rs
-topcoat::router::segment!(kind = Group);
-// `marketing` now contributes no URL segment.
-```
-
-Or turn a group module into a regular static path segment:
-
-```rust
-// src/app/_group.rs
-topcoat::router::segment!(kind = Static);
-// Module now reachable as `/group`.
-```
-
-The `_` prefix can also act as a naming convention for route-specific utilities. For example, a `_components` module for shared UI fragments:
+A module whose name starts with `_` contributes a logical group segment but no served URL segment. Layouts and layers still use the group when matching descendants.
 
 ```text
 app.rs
 app/
-  _components.rs       # exports shared components, no route
-  _components/
-    header.rs
-    footer.rs
-  about.rs             # /about: can use app::_components::header
-  contact.rs           # /contact
+  _marketing.rs        # layout for this group
+  _marketing/
+    pricing.rs         # /pricing
+    features.rs        # /features
+  _docs.rs             # a different layout
+  _docs/
+    getting_started.rs # /getting-started
 ```
+
+The two groups can apply different layouts to top-level URLs.
+
+Use an explicit kind when the module name should not select the default:
+
+```rust
+// src/app/marketing.rs: hide `marketing` from served URLs.
+topcoat::router::segment!(kind = Group);
+```
+
+```rust
+// src/app/_internal.rs: serve the module at /internal.
+topcoat::router::segment!(kind = Static);
+```
+
+Group names remain part of Topcoat's logical paths. A layout or layer in `_marketing` applies only to descendants of `_marketing`, even though the group name is absent from request URLs.
+
+# Explicit paths
+
+Adding a path string to `#[page]`, `#[layout]`, `#[layer]`, or `#[route]` disables module path derivation for that item. `segment!` declarations do not alter explicit paths.
+
+`module_router!()` discovers module-derived handlers. Register an explicit-path handler by name:
+
+```rust
+# use topcoat::{Result, router::page, view::view};
+#[page("/legacy")]
+async fn legacy() -> Result {
+    view! { <h1>"Legacy"</h1> }
+}
+
+pub fn router() -> topcoat::router::Router {
+    topcoat::router::module_router!()
+        .page(legacy)
+        .build()
+}
+```
+
+To discover all explicit-path handlers too, call `RouterBuilderDiscoverExt::discover` on the returned builder:
+
+```rust
+use topcoat::router::{Router, RouterBuilderDiscoverExt};
+
+pub fn router() -> Router {
+    topcoat::router::module_router!().discover().build()
+}
+```
+
+# Conflicts
+
+Handlers in one module share a derived path. They may serve different HTTP methods, but overlapping methods at the same served path are rejected when the router is built. A specific-method route may share a path with a `*` route and takes precedence.
+
+`module_router!` rejects two module-derived layouts or two module-derived layers at the same logical path because link-time discovery does not define their order. To run several layers at one path, register them explicitly with `RouterBuilder::layer`, which gives their order meaning.

--- a/crates/topcoat-router/macro/docs/path_param.md
+++ b/crates/topcoat-router/macro/docs/path_param.md
@@ -12,7 +12,7 @@ struct PostId(uuid::Uuid);
 
 [`path_param::<T>(cx)`](fn.path_param.html) returns the parameter. The return type follows the inner type:
 
-- **`str`**: returns the raw segment as a `&str` borrowed from the request (no parsing, cannot fail).
+- **`str`**: returns the percent-decoded segment as a `&str` borrowed from the request (no parsing, cannot fail).
 - **Anything else**: parses the segment with [`FromStr`](core::str::FromStr) and returns `Result<&T, &<T as FromStr>::Err>`: a reference to the parsed value, or to the parse error.
 
 Parsing runs at most once per request; the result is then memoized.
@@ -61,7 +61,11 @@ The parameter's name has to line up with a `{name}` segment in the route's URL. 
 
 - **Explicit path**: write the placeholder yourself, so `PostId` must appear as `{post_id}`:
   `#[page("/posts/{post_id}")]`.
-- **[`module_router!`](../router/macro.module_router.html)**: defining a `#[path_param]` inside a module turns that module's own segment into the parameter, so there is no placeholder to write. A `PostId` in `src/app/posts/id.rs` makes the `id` module render as `{post_id}`.
+- **[`module_router!`](../router/macro.module_router.html)**: defining a `#[path_param]` inside a non-root route module turns that module's own segment into the parameter, so there is no placeholder to write. A `PostId` in `src/app/posts/id.rs` makes the `id` module render as `{post_id}`.
+
+A module contributes one path segment, so it can contain one `#[path_param]`. Put additional parameters in descendant modules. Pages and layouts in those descendants can read parameters from ancestor modules when the parameter types are visible through normal Rust module visibility.
+
+`module_router!()` discovers handlers without explicit paths. If a page uses an explicit path, register it by name on the returned builder or call `RouterBuilderDiscoverExt::discover`; see the module-router documentation.
 
 # Examples
 
@@ -91,7 +95,7 @@ async fn post_page(cx: &Cx) -> Result {
 
 ```rust
 # use topcoat::{context::Cx, Result, router::{page, path_param}, view::view};
-// A `str` inner type skips parsing and borrows the raw segment.
+// A `str` inner type skips FromStr parsing and borrows the decoded segment.
 #[path_param]
 struct Slug(str);
 

--- a/crates/topcoat-router/macro/docs/segment.md
+++ b/crates/topcoat-router/macro/docs/segment.md
@@ -1,6 +1,6 @@
 Customizes how a module contributes to module-router URLs.
 
-`segment!(...)` is placed at the top of a module to override the URL segment the module contributes to a [`module_router!`](macro.module_router.html): by default the kebab-cased module name, or no segment for `_`-prefixed modules (groups). It has no effect on a regular [`Router`](struct.Router.html), nor on items whose attribute carries an explicit path.
+`segment!(...)` is placed at the top of a non-root route module to override the URL segment the module contributes to a [`module_router!`](macro.module_router.html): by default the kebab-cased module name, or no segment for `_`-prefixed modules (groups). The module containing `module_router!` is the route root and contributes no segment. `segment!` has no effect on a regular [`Router`](struct.Router.html), nor on items whose attribute carries an explicit path.
 
 # Attributes
 
@@ -12,7 +12,9 @@ The macro takes comma-separated `key = value` attributes, each at most once:
 - `kind = Param`: a dynamic `{name}` parameter, matching one segment.
 - `kind = CatchAll`: a wildcard `{*name}` tail, matching all remaining segments.
 
-A `Param` or `CatchAll` segment without a `rename` is named after the module, as-is. Declaring a [`#[path_param]`](attr.path_param.html) in a module emits `segment!(kind = Param, rename = ...)` automatically, so a module usually becomes a parameter that way rather than by hand.
+A `Param` or `CatchAll` segment without a `rename` is named after the module, as-is. Declaring a [`#[path_param]`](attr.path_param.html) in a module emits `segment!(kind = Param, rename = ...)` automatically, so do not also call `segment!` in that module. A manual `Param` or `CatchAll` declaration creates a captured segment but no typed accessor; read it through [`raw_path_params`](fn.raw_path_params.html).
+
+A `CatchAll` matches one or more remaining URL segments, including `/` separators, and must be the last served segment in the path.
 
 # Examples
 

--- a/crates/topcoat/docs/router.md
+++ b/crates/topcoat/docs/router.md
@@ -7,11 +7,11 @@ Handlers register in two ways: **manually**, listing each item on the builder, o
 Explicit route paths use Topcoat's [`Path`] syntax:
 
 - `/users` for static segments.
-- `/users/{id}` for dynamic parameters.
-- `/docs/{*path}` for wildcard tails.
+- `/users/{id}` for a dynamic parameter that matches one non-empty segment.
+- `/docs/{*path}` for a catch-all parameter that matches one or more remaining segments.
 - `/(marketing)/pricing` for groups. Groups participate in layout and layer matching but are stripped from the served URL, so this example serves `/pricing`.
 
-The root path is `/`. Non-root paths must start with `/` and may not contain empty segments.
+The root path is `/`. Non-root paths must start with `/` and may not contain empty segments. Parameter and group names must start with an ASCII letter or `_` and contain only ASCII letters, digits, and underscores. Captured parameter values are percent-decoded after the router matches the path.
 
 # Pages
 
@@ -128,38 +128,65 @@ The context and the body parameter are both optional and may appear in either or
 
 # Path and query parameters
 
-Two attribute macros declare typed structs for reading values out of a request. You declare a struct, then read it with a free function from any handler that has a `cx`:
+Path and query values are read from [`Cx`](crate::context::Cx), not injected as handler arguments. This keeps the handler signature limited to request context and body parsing, while allowing helper functions and layouts to read the same parameters.
 
-- [`#[path_param]`](macro@path_param): one dynamic path segment (like the `{post_id}` in `/posts/{post_id}`), read with [`path_param::<T>(cx)`](fn@path_param).
-- [`#[query_params]`](macro@query_params): the request's query string deserialized into a struct, read with [`query_params::<T>(cx)`](fn@query_params).
+## Path parameters
 
-Both parse lazily and memoize the result for the rest of the request.
+Apply [`#[path_param]`](macro@path_param) to a tuple struct with one field. The snake-cased struct name is the parameter name, so `PostId` reads `{post_id}`. The inner type controls parsing:
+
+- `str` returns the percent-decoded segment as `&str`.
+- Any other type is parsed with [`FromStr`](std::str::FromStr). The default return type is `Result<&T, &T::Err>`.
+- `error = bad_request`, `not_found`, `unauthorized`, `forbidden`, `redirect(...)`, or `redirect_permanent(...)` maps a parse failure to that router error.
 
 ```rust
 use topcoat::{
     Result,
     context::Cx,
-    router::{page, path_param, query_params},
+    router::{page, path_param},
     view::view,
 };
 
 #[path_param(error = bad_request)]
-struct PostId(uuid::Uuid);
-
-#[query_params(error = bad_request)]
-struct PostQuery {
-    preview: Option<bool>,
-}
+struct PostId(u64);
 
 #[page("/posts/{post_id}")]
 async fn post(cx: &Cx) -> Result {
     let post_id = path_param::<PostId>(cx)?;
-    let query = query_params::<PostQuery>(cx)?;
-    view! { /* ... */ }
+    view! { <h1>"Post " (post_id)</h1> }
 }
 ```
 
-See [`#[path_param]`](macro@path_param) and [`#[query_params]`](macro@query_params) for details.
+Parsing occurs once per request and the result is memoized. With [`module_router!`], declaring `#[path_param]` inside a non-root route module also changes that module's segment to the parameter. See [`module_router!`] for module structure, nested parameters, and catch-all parameters.
+
+## Query parameters
+
+Apply [`#[query_params]`](macro@query_params) to a struct with named fields. The macro derives `serde::Deserialize`, and [`query_params::<T>(cx)`](fn@query_params) deserializes the request query string into that struct. Use `Option<T>` for keys that may be absent.
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{page, query_params},
+    view::view,
+};
+
+#[query_params(error = bad_request)]
+struct PostsQuery {
+    page: Option<u32>,
+    q: Option<String>,
+}
+
+#[page("/posts")]
+async fn posts(cx: &Cx) -> Result {
+    let query = query_params::<PostsQuery>(cx)?;
+    view! {
+        <p>"page: " (query.page.unwrap_or(1))</p>
+        <p>"search: " (query.q.as_deref().unwrap_or(""))</p>
+    }
+}
+```
+
+Query parsing also occurs once per request and returns a reference to the memoized value. A query struct is independent of the matched route, so any handler with `cx: &Cx` can read it. See [`#[query_params]`](macro@query_params) for error handling and redirecting after invalid input.
 
 # Errors
 


### PR DESCRIPTION
## Summary

- Document module discovery, derived paths, explicit path registration, and route conflicts
- Explain dynamic, query, group, segment override, and catch-all parameter behavior
- Clarify percent-decoding, memoization, and nested module parameters

## Testing

Not run (not requested)