### PR TITLE
feat: add static site export

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 
 **Start here**
 - [Getting started](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat/docs/getting_started.md): create a new project, install the CLI, run the dev server.
+- [Static export](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat/docs/export.md): render a site to HTML files for serverless hosting.
 - [Source code formatting](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat-cli/docs/fmt.md): `topcoat fmt` for macro bodies.
 
 **Rendering**
@@ -242,7 +243,6 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 Planned features we'd like to bring to Topcoat. Have an idea? [Open an issue](https://github.com/tokio-rs/topcoat/issues).
 
 - [ ] `topcoat new` CLI command to bootstrap pre-configured projects
-- [ ] Static export
 - [ ] (More) reactivity (`topcoat-runtime`)
 - [ ] More Topcoat UI components, full "blocks" e.g. sign-in form
 - [ ] Emailing
@@ -251,7 +251,6 @@ Planned features we'd like to bring to Topcoat. Have an idea? [Open an issue](ht
 - [ ] `OpenAPI` endpoints
 - [ ] Sitemaps
 - [ ] Docs for how to deploy Topcoat
-- [ ] Pre-rendering for static pages
 - [ ] Streaming SSR / Suspense
 - [ ] Client-side navigation + prefetching
 - [ ] `WebSockets`

--- a/crates/topcoat-asset/src/router.rs
+++ b/crates/topcoat-asset/src/router.rs
@@ -117,7 +117,10 @@ pub trait RouterBuilderAssetExt {
 impl RouterBuilderAssetExt for RouterBuilder {
     fn assets(mut self, bundle: AssetBundle) -> Self {
         for asset in bundle.assets() {
-            self = self.route(AssetRoute::new(asset));
+            let route = AssetRoute::new(asset);
+            self = self
+                .static_file(route.path().to_matchit_path(), asset.path())
+                .route(route);
         }
 
         self = self.app_context(bundle);

--- a/crates/topcoat-cli/src/export.rs
+++ b/crates/topcoat-cli/src/export.rs
@@ -1,0 +1,166 @@
+use std::error::Error;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::Args;
+use console::style;
+use tokio::process::Command;
+
+use crate::cargo::{BuildFlags, BuildOpts};
+
+const INTERNAL_COMMAND_ENV: &str = "TOPCOAT_INTERNAL_COMMAND";
+const EXPORT_PROTOCOL_ENV: &str = "TOPCOAT_EXPORT_PROTOCOL";
+const EXPORT_OUT_ENV: &str = "TOPCOAT_EXPORT_OUT";
+const EXPORT_PATH_STYLE_ENV: &str = "TOPCOAT_EXPORT_PATH_STYLE";
+
+#[derive(Args)]
+pub struct ExportCommand {
+    #[command(flatten)]
+    build: BuildFlags,
+    /// Output directory
+    #[arg(short, long, default_value = "dist")]
+    out: PathBuf,
+    /// Write `/about` to `about.html` instead of `about/index.html`
+    #[arg(long)]
+    html_files: bool,
+}
+
+impl ExportCommand {
+    pub async fn run(self) {
+        if let Err(error) = self.try_run().await {
+            eprintln!(
+                "{}",
+                style(format!("static export failed: {error}")).red().bold()
+            );
+            std::process::exit(1);
+        }
+    }
+
+    async fn try_run(self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let opts: BuildOpts = self.build.into();
+        let out_dir = safe_output_path(&self.out)?;
+
+        eprintln!("  {}", style("building application...").dim());
+        let (executable, bytes) = crate::cargo::build_and_read(&opts, |_, _| {}).await?;
+
+        eprintln!("  {}", style("bundling assets...").dim());
+        crate::asset::run_bundle(&bytes, None).await?;
+
+        let staging = staging_path(&out_dir)?;
+        let path_style = if self.html_files {
+            "html-file"
+        } else {
+            "directory"
+        };
+
+        eprintln!("  {}", style("rendering static pages...").dim());
+        let status = Command::new(&executable)
+            .env(INTERNAL_COMMAND_ENV, "export")
+            .env(EXPORT_PROTOCOL_ENV, "1")
+            .env(EXPORT_OUT_ENV, &staging)
+            .env(EXPORT_PATH_STYLE_ENV, path_style)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .await?;
+
+        if !status.success() {
+            remove_path_if_present(&staging)?;
+            return Err(format!("application exited with {status}").into());
+        }
+
+        publish_staging(&staging, &out_dir)?;
+        println!("exported site to {}", out_dir.display());
+        Ok(())
+    }
+}
+
+fn safe_output_path(path: &Path) -> Result<PathBuf, io::Error> {
+    let path = std::path::absolute(path)?;
+    let current_dir = std::env::current_dir()?.canonicalize()?;
+    let comparable = if path.exists() {
+        path.canonicalize()?
+    } else {
+        path.clone()
+    };
+    if comparable == current_dir || current_dir.starts_with(&comparable) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to replace `{}` because it contains the current workspace",
+                path.display()
+            ),
+        ));
+    }
+    if path.parent().is_none() || path.file_name().is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("`{}` is not a directory path", path.display()),
+        ));
+    }
+    Ok(path)
+}
+
+fn staging_path(out_dir: &Path) -> Result<PathBuf, io::Error> {
+    let parent = out_dir.parent().expect("output path has a parent");
+    std::fs::create_dir_all(parent)?;
+    let file_name = out_dir
+        .file_name()
+        .expect("output path has a file name")
+        .to_string_lossy();
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = parent.join(format!(
+        ".{file_name}.topcoat-export-{}-{nonce}",
+        std::process::id()
+    ));
+    if path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("staging path `{}` already exists", path.display()),
+        ));
+    }
+    Ok(path)
+}
+
+fn publish_staging(staging: &Path, out_dir: &Path) -> Result<(), io::Error> {
+    if !out_dir.exists() {
+        return std::fs::rename(staging, out_dir);
+    }
+
+    let mut backup_name = OsString::from(".");
+    backup_name.push(out_dir.file_name().expect("output path has a file name"));
+    backup_name.push(format!(".topcoat-backup-{}", std::process::id()));
+    let backup = out_dir
+        .parent()
+        .expect("output path has a parent")
+        .join(backup_name);
+    if backup.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("backup path `{}` already exists", backup.display()),
+        ));
+    }
+
+    std::fs::rename(out_dir, &backup)?;
+    if let Err(error) = std::fs::rename(staging, out_dir) {
+        let _ = std::fs::rename(&backup, out_dir);
+        return Err(error);
+    }
+    remove_path_if_present(&backup)
+}
+
+fn remove_path_if_present(path: &Path) -> Result<(), io::Error> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => std::fs::remove_dir_all(path),
+        Ok(_) => std::fs::remove_file(path),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/topcoat-cli/src/lib.rs
+++ b/crates/topcoat-cli/src/lib.rs
@@ -3,6 +3,7 @@
 mod asset;
 mod cargo;
 mod dev;
+mod export;
 mod fmt;
 mod ui;
 
@@ -21,6 +22,8 @@ enum Command {
     Dev(dev::DevCommand),
     /// Format topcoat `view!` macros
     Fmt(fmt::FmtCommand),
+    /// Build the application and export it as a static site
+    Export(export::ExportCommand),
     /// Inspect assets embedded in the binary
     Asset(asset::AssetCommand),
     /// Manage premade UI components in your project
@@ -33,6 +36,7 @@ pub async fn run() {
         Command::Ui(cmd) => cmd.run(),
         Command::Fmt(cmd) => cmd.run().await,
         Command::Dev(cmd) => cmd.run().await,
+        Command::Export(cmd) => cmd.run().await,
         Command::Asset(cmd) => cmd.run().await,
     }
 }

--- a/crates/topcoat-router/docs/module_router.md
+++ b/crates/topcoat-router/docs/module_router.md
@@ -183,7 +183,8 @@ async fn posts(cx: &Cx) -> Result {
 
 # Segment overrides
 
-`segment!(...)` changes the enclosing module's segment. It accepts `kind` and `rename`, each at most once:
+`segment!(...)` changes the enclosing module's segment. It accepts `kind`,
+`rename`, and `generate_static`, each at most once:
 
 | Declaration | Result |
 |---|---|
@@ -196,6 +197,43 @@ async fn posts(cx: &Cx) -> Result {
 `Static` is the default kind for regular modules. `Group` is the default for modules whose names start with `_`. A rename is used as written; Topcoat does not kebab-case it.
 
 `#[path_param]` emits a `Param` segment override, so do not combine it with `segment!` in the same module. A manual `Param` override creates the route capture but does not define a typed accessor.
+
+For static export, `generate_static` enumerates a dynamic segment:
+
+```rust
+# use topcoat::{Result, context::Cx};
+async fn generate_ids(_cx: &Cx) -> Result<Vec<String>> {
+    Ok(vec!["one".into(), "two".into()])
+}
+
+topcoat::router::segment!(
+    kind = Param,
+    rename = "id",
+    generate_static = generate_ids,
+);
+```
+
+`Param` generators return `Result<Vec<String>>`. `CatchAll` generators return
+`Result<Vec<Vec<String>>>`, where each inner vector is a non-empty sequence of
+path components.
+
+A typed `#[path_param]` can declare the generator directly. It returns values
+of the parameter's inner type:
+
+```rust
+# use topcoat::{Result, context::Cx, router::path_param};
+async fn generate_post_ids(_cx: &Cx) -> Result<Vec<u64>> {
+    Ok(vec![1, 2, 3])
+}
+
+#[path_param(generate_static = generate_post_ids)]
+struct PostId(u64);
+```
+
+Generators run from parent segments to child segments. The `Cx` passed to a
+child contains app context and its generated ancestor path parameters. A
+dynamic module page without a generator for every dynamic segment causes
+static export to fail.
 
 # Catch-all parameters
 
@@ -260,6 +298,10 @@ Group names remain part of Topcoat's logical paths. A layout or layer in `_marke
 # Explicit paths
 
 Adding a path string to `#[page]`, `#[layout]`, `#[layer]`, or `#[route]` disables module path derivation for that item. `segment!` declarations do not alter explicit paths.
+
+An explicit dynamic page also does not use module segment generators. Declare
+complete parameter sets on that page with
+`#[page("/posts/{post_id}", generate_static = function)]`.
 
 `module_router!()` discovers module-derived handlers. Register an explicit-path handler by name:
 

--- a/crates/topcoat-router/grammar/src/error_attr.rs
+++ b/crates/topcoat-router/grammar/src/error_attr.rs
@@ -31,6 +31,11 @@ pub struct ErrorAttr {
 }
 
 impl ErrorAttr {
+    /// Returns whether the input begins with an `error` argument.
+    pub fn peek(input: ParseStream) -> bool {
+        input.peek(kw::error)
+    }
+
     /// The span of the constructor name, for attaching validation errors.
     pub fn span(&self) -> Span {
         self.kind.keyword().span()

--- a/crates/topcoat-router/grammar/src/method.rs
+++ b/crates/topcoat-router/grammar/src/method.rs
@@ -23,6 +23,18 @@ pub enum Methods {
     Any(Token![*]),
 }
 
+impl Methods {
+    /// Returns whether this declaration accepts `method`.
+    #[must_use]
+    pub fn contains(&self, method: &str) -> bool {
+        match self {
+            Self::Any(_) => true,
+            Self::One(value) => value == method,
+            Self::Set { items, .. } => items.iter().any(|value| value == method),
+        }
+    }
+}
+
 impl Parse for Methods {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let lookahead = input.lookahead1();

--- a/crates/topcoat-router/grammar/src/page.rs
+++ b/crates/topcoat-router/grammar/src/page.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{
-    ItemFn, LitStr, ReturnType, Visibility,
+    ItemFn, LitStr, Path, ReturnType, Token, Visibility,
     parse::{Parse, ParseStream},
     parse_quote,
     spanned::Spanned,
@@ -18,15 +18,34 @@ pub struct PageAttr {
     /// The declared HTTP methods; the page serves `GET` when omitted.
     methods: Option<Methods>,
     path: Option<LitStr>,
+    generate_static: Option<Path>,
 }
 
 impl Parse for PageAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let methods = Methods::parse_option(input)?;
+        let path = input.peek(LitStr).then(|| input.parse()).transpose()?;
+        let generate_static = if input.is_empty() {
+            None
+        } else {
+            input.parse::<Token![,]>()?;
+            input.parse::<kw::generate_static>()?;
+            input.parse::<Token![=]>()?;
+            Some(input.parse()?)
+        };
+        if !input.is_empty() {
+            return Err(input.error("unexpected page attribute argument"));
+        }
         Ok(Self {
-            methods: Methods::parse_option(input)?,
-            path: input.peek(LitStr).then(|| input.parse()).transpose()?,
+            methods,
+            path,
+            generate_static,
         })
     }
+}
+
+mod kw {
+    syn::custom_keyword!(generate_static);
 }
 
 pub struct PageItem {
@@ -57,9 +76,38 @@ impl Parse for PageItem {
 pub struct Page(PageAttr, PageItem);
 
 impl Page {
-    #[must_use]
-    pub fn new(attr: PageAttr, item: PageItem) -> Self {
-        Self(attr, item)
+    /// Combines a parsed attribute and page item.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `generate_static` is used without a dynamic
+    /// explicit path or on a page that does not accept GET.
+    pub fn new(attr: PageAttr, item: PageItem) -> syn::Result<Self> {
+        if let Some(generate_static) = &attr.generate_static {
+            let Some(path) = &attr.path else {
+                return Err(syn::Error::new_spanned(
+                    generate_static,
+                    "`generate_static` on `#[page]` requires an explicit path",
+                ));
+            };
+            if !path.value().contains('{') {
+                return Err(syn::Error::new_spanned(
+                    generate_static,
+                    "`generate_static` requires a dynamic page path",
+                ));
+            }
+            if attr
+                .methods
+                .as_ref()
+                .is_some_and(|methods| !methods.contains("GET"))
+            {
+                return Err(syn::Error::new_spanned(
+                    generate_static,
+                    "`generate_static` requires a page that accepts GET",
+                ));
+            }
+        }
+        Ok(Self(attr, item))
     }
 
     /// Parses a page attribute and item from token streams.
@@ -70,7 +118,7 @@ impl Page {
     /// [`PageAttr`] or [`PageItem`], or if the item is not a valid page
     /// handler.
     pub fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<Self> {
-        Ok(Self::new(syn::parse2(attr)?, syn::parse2(item)?))
+        Self::new(syn::parse2(attr)?, syn::parse2(item)?)
     }
 }
 
@@ -157,12 +205,32 @@ impl ToTokens for Page {
             ToTokens::to_token_stream,
         );
         let erased = if let Some(path) = attr.path.as_ref() {
+            let constructor = if let Some(generate_static) = attr.generate_static.as_ref() {
+                quote! {
+                    #topcoat_router::PageFn::const_new_with_static_params(
+                        #methods,
+                        ::std::borrow::Cow::Borrowed(#topcoat_router::Path::new(#path)),
+                        #render,
+                        #topcoat_router::StaticParamsGenerator::new(|cx| {
+                        ::std::boxed::Box::pin(async move {
+                            let values: ::std::vec::Vec<#topcoat_router::StaticParams> =
+                                #generate_static(cx).await?;
+                            Ok(values)
+                        })
+                        }),
+                    )
+                }
+            } else {
+                quote! {
+                    #topcoat_router::PageFn::const_new(
+                        #methods,
+                        ::std::borrow::Cow::Borrowed(#topcoat_router::Path::new(#path)),
+                        #render,
+                    )
+                }
+            };
             quote! {
-                const ERASED: #topcoat_router::PageFn = #topcoat_router::PageFn::const_new(
-                    #methods,
-                    ::std::borrow::Cow::Borrowed(#topcoat_router::Path::new(#path)),
-                    #render,
-                );
+                const ERASED: #topcoat_router::PageFn = #constructor;
 
                 impl ::core::convert::From<#ident> for #topcoat_router::PageFn {
                     fn from(_: #ident) -> Self {

--- a/crates/topcoat-router/grammar/src/path_param.rs
+++ b/crates/topcoat-router/grammar/src/path_param.rs
@@ -2,28 +2,79 @@ use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{
-    Data, DeriveInput, Fields, Type,
+    Data, DeriveInput, Fields, Path, Token, Type,
     parse::{Parse, ParseStream},
 };
 use topcoat_core_grammar::paths::{
-    topcoat_context, topcoat_context_macro, topcoat_router, topcoat_router_macro,
+    topcoat_context, topcoat_context_macro, topcoat_error, topcoat_router, topcoat_router_macro,
 };
 
 use super::error_attr::ErrorAttr;
 
 pub struct PathParamAttr {
     error: Option<ErrorAttr>,
+    generate_static: Option<Path>,
 }
 
 impl Parse for PathParamAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = input.parse_terminated(PathParamAttrItem::parse, Token![,])?;
+        let mut error = None;
+        let mut generate_static = None;
+        for attr in attrs {
+            match attr {
+                PathParamAttrItem::Error(value) => {
+                    if error.replace(value).is_some() {
+                        return Err(syn::Error::new(
+                            proc_macro2::Span::call_site(),
+                            "duplicate attribute `error`",
+                        ));
+                    }
+                }
+                PathParamAttrItem::GenerateStatic { value, .. } => {
+                    if generate_static.replace(value).is_some() {
+                        return Err(syn::Error::new(
+                            proc_macro2::Span::call_site(),
+                            "duplicate attribute `generate_static`",
+                        ));
+                    }
+                }
+            }
+        }
         Ok(Self {
-            error: if input.is_empty() {
-                None
-            } else {
-                Some(input.parse()?)
-            },
+            error,
+            generate_static,
         })
+    }
+}
+
+mod kw {
+    syn::custom_keyword!(generate_static);
+}
+
+#[allow(dead_code, reason = "tokens are retained for parsing diagnostics")]
+enum PathParamAttrItem {
+    Error(ErrorAttr),
+    GenerateStatic {
+        generate_static_kw: kw::generate_static,
+        eq_token: Token![=],
+        value: Path,
+    },
+}
+
+impl Parse for PathParamAttrItem {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if ErrorAttr::peek(input) {
+            Ok(Self::Error(input.parse()?))
+        } else if input.peek(kw::generate_static) {
+            Ok(Self::GenerateStatic {
+                generate_static_kw: input.parse()?,
+                eq_token: input.parse()?,
+                value: input.parse()?,
+            })
+        } else {
+            Err(input.lookahead1().error())
+        }
     }
 }
 
@@ -88,6 +139,14 @@ impl PathParam {
                      which borrows the raw segment and cannot fail",
             ));
         }
+        if let Some(generate_static) = &attr.generate_static
+            && !item.item.generics.params.is_empty()
+        {
+            return Err(syn::Error::new_spanned(
+                generate_static,
+                "`generate_static` cannot be used on a generic path parameter",
+            ));
+        }
         Ok(Self(attr, item))
     }
 
@@ -124,6 +183,46 @@ impl ToTokens for PathParam {
         let inner_ty = &self.1.inner_ty;
         let name_string = ident.to_string().to_snake_case();
         let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+        let static_segment = self
+            .0
+            .generate_static
+            .as_ref()
+            .filter(|_| cfg!(feature = "discover"))
+            .map(|generate_static| {
+                let convert = if borrows_raw_segment {
+                    quote! {
+                        let values: ::std::vec::Vec<::std::string::String> =
+                            #generate_static(cx).await?;
+                        Ok(values)
+                    }
+                } else {
+                    quote! {
+                        let values: ::std::vec::Vec<#inner_ty> = #generate_static(cx).await?;
+                        Ok(values
+                            .into_iter()
+                            .map(|value| ::std::string::ToString::to_string(&value))
+                            .collect())
+                    }
+                };
+                quote! {
+                    async fn __topcoat_generate_static(
+                        cx: &#topcoat_context::Cx,
+                    ) -> #topcoat_error::Result<::std::vec::Vec<::std::string::String>> {
+                        #convert
+                    }
+
+                    #topcoat_router_macro::segment!(
+                        kind = Param,
+                        rename = #name_string,
+                        generate_static = __topcoat_generate_static,
+                    );
+                }
+            });
+        let static_segment = static_segment.unwrap_or_else(|| {
+            quote! {
+                #topcoat_router_macro::segment!(kind = Param, rename = #name_string);
+            }
+        });
 
         let (output_ty, path_param_fn) = if borrows_raw_segment {
             (
@@ -189,7 +288,7 @@ impl ToTokens for PathParam {
                 #path_param_fn
             }
 
-            #topcoat_router_macro::segment!(kind = Param, rename = #name_string);
+            #static_segment
         }
         .to_tokens(tokens);
     }

--- a/crates/topcoat-router/grammar/src/segment.rs
+++ b/crates/topcoat-router/grammar/src/segment.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::{
-    Ident, LitStr, Token,
+    Ident, LitStr, Path, Token,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
 };
@@ -21,6 +21,10 @@ impl Segment {
 
     fn find_rename(&self) -> Option<&LitStr> {
         self.attrs.iter().find_map(SegmentAttr::as_rename)
+    }
+
+    fn find_generate_static(&self) -> Option<&Path> {
+        self.attrs.iter().find_map(SegmentAttr::as_generate_static)
     }
 }
 
@@ -40,6 +44,21 @@ impl Parse for Segment {
             }
         }
 
+        if let Some(generate_static) = attrs.iter().find_map(SegmentAttr::as_generate_static) {
+            let Some(kind) = attrs.iter().find_map(SegmentAttr::as_kind) else {
+                return Err(syn::Error::new_spanned(
+                    generate_static,
+                    "`generate_static` requires `kind = Param` or `kind = CatchAll`",
+                ));
+            };
+            if kind != "Param" && kind != "CatchAll" {
+                return Err(syn::Error::new_spanned(
+                    kind,
+                    "`generate_static` is only valid for `Param` and `CatchAll` segments",
+                ));
+            }
+        }
+
         Ok(Self { attrs })
     }
 }
@@ -49,18 +68,53 @@ impl ToTokens for Segment {
         if cfg!(feature = "discover") {
             let kind = self.find_kind();
             let rename = self.find_rename();
+            let generate_static = self.find_generate_static();
+            let generate_static_kind = kind.map(ToString::to_string);
 
             let kind =
                 QuoteOption::new(kind.map(|kind| quote! { #topcoat_router::SegmentKind::#kind }));
             let rename = QuoteOption::new(
                 rename.map(|rename| quote! { ::std::borrow::Cow::Borrowed(#rename) }),
             );
+            let generate_static = QuoteOption::new(generate_static.map(|generate_static| {
+                match generate_static_kind
+                    .as_deref()
+                    .expect("validated generate_static kind")
+                {
+                    "Param" => quote! {
+                        #topcoat_router::StaticSegmentGenerator::new(|cx| {
+                            ::std::boxed::Box::pin(async move {
+                                let values: ::std::vec::Vec<::std::string::String> =
+                                    #generate_static(cx).await?;
+                                Ok(values
+                                    .into_iter()
+                                    .map(#topcoat_router::StaticSegmentValue::param)
+                                    .collect())
+                            })
+                        })
+                    },
+                    "CatchAll" => quote! {
+                        #topcoat_router::StaticSegmentGenerator::new(|cx| {
+                            ::std::boxed::Box::pin(async move {
+                                let values: ::std::vec::Vec<::std::vec::Vec<::std::string::String>> =
+                                    #generate_static(cx).await?;
+                                Ok(values
+                                    .into_iter()
+                                    .map(#topcoat_router::StaticSegmentValue::catch_all)
+                                    .collect())
+                            })
+                        })
+                    },
+                    _ => unreachable!("validated generate_static kind"),
+                }
+            }));
             quote! {
                 #topcoat_inventory::submit! {
                     #topcoat_router::Segment::new(
                         module_path!(),
                         #kind,
                         #rename,
+                        #generate_static,
                     )
                 }
             }
@@ -74,6 +128,7 @@ mod kw {
 
     custom_keyword!(kind);
     custom_keyword!(rename);
+    custom_keyword!(generate_static);
 }
 
 #[allow(
@@ -91,6 +146,11 @@ pub enum SegmentAttr {
         eq_token: Token![=],
         value: LitStr,
     },
+    GenerateStatic {
+        generate_static_kw: kw::generate_static,
+        eq_token: Token![=],
+        value: Path,
+    },
 }
 
 impl SegmentAttr {
@@ -98,6 +158,7 @@ impl SegmentAttr {
         match self {
             Self::Kind { .. } => "kind",
             Self::Rename { .. } => "rename",
+            Self::GenerateStatic { .. } => "generate_static",
         }
     }
 
@@ -105,20 +166,30 @@ impl SegmentAttr {
         match self {
             Self::Kind { kind_kw, .. } => kind_kw.span,
             Self::Rename { rename_kw, .. } => rename_kw.span,
+            Self::GenerateStatic {
+                generate_static_kw, ..
+            } => generate_static_kw.span,
         }
     }
 
     fn as_kind(&self) -> Option<&Ident> {
         match self {
             Self::Kind { value, .. } => Some(value),
-            Self::Rename { .. } => None,
+            Self::Rename { .. } | Self::GenerateStatic { .. } => None,
         }
     }
 
     fn as_rename(&self) -> Option<&LitStr> {
         match self {
             Self::Rename { value, .. } => Some(value),
-            Self::Kind { .. } => None,
+            Self::Kind { .. } | Self::GenerateStatic { .. } => None,
+        }
+    }
+
+    fn as_generate_static(&self) -> Option<&Path> {
+        match self {
+            Self::GenerateStatic { value, .. } => Some(value),
+            Self::Kind { .. } | Self::Rename { .. } => None,
         }
     }
 }
@@ -135,6 +206,12 @@ impl Parse for SegmentAttr {
         } else if lookahead.peek(kw::rename) {
             Ok(Self::Rename {
                 rename_kw: input.parse()?,
+                eq_token: input.parse()?,
+                value: input.parse()?,
+            })
+        } else if lookahead.peek(kw::generate_static) {
+            Ok(Self::GenerateStatic {
+                generate_static_kw: input.parse()?,
                 eq_token: input.parse()?,
                 value: input.parse()?,
             })

--- a/crates/topcoat-router/macro/docs/page.md
+++ b/crates/topcoat-router/macro/docs/page.md
@@ -8,6 +8,38 @@ Path strings are Topcoat [`Path`](struct.Path.html)s: literal segments (`users`)
 
 A page registers like any other handler: pass the function name to [`RouterBuilder::page`](struct.RouterBuilder.html#method.page), or let [`discover`](trait.RouterBuilderDiscoverExt.html) or [`module_router!`](macro.module_router.html) collect it automatically.
 
+# Static generation for explicit paths
+
+A fixed GET page is selected for static export automatically. For an explicit
+dynamic path, add `generate_static = function` after the path. The async
+function takes `&Cx` and returns `Result<Vec<StaticParams>>`, with one complete
+parameter set per concrete URL:
+
+```rust
+# use topcoat::{
+#     Result,
+#     context::Cx,
+#     router::{StaticParams, page},
+#     view::view,
+# };
+async fn generate_posts(_cx: &Cx) -> Result<Vec<StaticParams>> {
+    Ok(vec![
+        StaticParams::new().param("post_id", 1),
+        StaticParams::new().param("post_id", 2),
+    ])
+}
+
+#[page("/posts/{post_id}", generate_static = generate_posts)]
+async fn post() -> Result {
+    view! { <h1>"Post"</h1> }
+}
+```
+
+Every parameter in the path must be supplied. Use `StaticParams::param` for
+ordinary parameters and `StaticParams::catch_all` for wildcard tails.
+Module-derived dynamic pages put `generate_static` on their `segment!` or
+`#[path_param]` declarations instead.
+
 # Handler signature
 
 The function is `async` and returns [`Result`](../type.Result.html). It may take [`cx: &Cx`](../context/struct.Cx.html), one request body parameter implementing [`FromRequest`](trait.FromRequest.html), both, or neither. The body parameter may use a destructuring pattern such as `Json(input): Json<T>`. The parameters may appear in either order, but there can be at most one body parameter, because the body is a stream that can only be consumed once.

--- a/crates/topcoat-router/macro/docs/path_param.md
+++ b/crates/topcoat-router/macro/docs/path_param.md
@@ -8,6 +8,23 @@ Apply `#[path_param]` to a single-field tuple struct. The struct name, snake-cas
 struct PostId(uuid::Uuid);
 ```
 
+# Static generation
+
+For a module-derived dynamic route, `generate_static = function` enumerates
+the values rendered by a static export. The async function takes `&Cx` and
+returns `Result<Vec<T>>`, where `T` is the path parameter's inner type. A `str`
+parameter uses `Result<Vec<String>>`.
+
+```rust
+# use topcoat::{Result, context::Cx, router::path_param};
+async fn generate_post_ids(_cx: &Cx) -> Result<Vec<u64>> {
+    Ok(vec![1, 2, 3])
+}
+
+#[path_param(error = not_found, generate_static = generate_post_ids)]
+struct PostId(u64);
+```
+
 # Reading the value
 
 [`path_param::<T>(cx)`](fn.path_param.html) returns the parameter. The return type follows the inner type:
@@ -67,6 +84,10 @@ A module contributes one path segment, so it can contain one `#[path_param]`. Pu
 
 `module_router!()` discovers handlers without explicit paths. If a page uses an explicit path, register it by name on the returned builder or call `RouterBuilderDiscoverExt::discover`; see the module-router documentation.
 
+`generate_static` on `#[path_param]` applies only to the module segment it
+declares. An explicit dynamic `#[page("/posts/{post_id}")]` declares its
+complete parameter sets with page-level `generate_static` instead.
+
 # Examples
 
 ## Module router
@@ -111,3 +132,4 @@ async fn show(cx: &Cx) -> Result {
 - The struct must be a tuple struct with exactly one field.
 - A non-`str` inner type must implement [`FromStr`](core::str::FromStr), and its parsed `Result` must be `Send + Sync + 'static` so it can be [memoized](../topcoat_core_macro/attr.memoize.html) for the request.
 - `error = ...` requires a parsed inner type; a `str` parameter cannot fail.
+- `generate_static` cannot be used on a generic path parameter.

--- a/crates/topcoat-router/macro/docs/segment.md
+++ b/crates/topcoat-router/macro/docs/segment.md
@@ -11,10 +11,18 @@ The macro takes comma-separated `key = value` attributes, each at most once:
 - `kind = Group`: no URL segment, though the module can still hold shared layouts and layers; the default for `_`-prefixed modules.
 - `kind = Param`: a dynamic `{name}` parameter, matching one segment.
 - `kind = CatchAll`: a wildcard `{*name}` tail, matching all remaining segments.
+- `generate_static = function`: enumerates this dynamic segment during a static export.
 
 A `Param` or `CatchAll` segment without a `rename` is named after the module, as-is. Declaring a [`#[path_param]`](attr.path_param.html) in a module emits `segment!(kind = Param, rename = ...)` automatically, so do not also call `segment!` in that module. A manual `Param` or `CatchAll` declaration creates a captured segment but no typed accessor; read it through [`raw_path_params`](fn.raw_path_params.html).
 
 A `CatchAll` matches one or more remaining URL segments, including `/` separators, and must be the last served segment in the path.
+
+`generate_static` requires `kind = Param` or `kind = CatchAll`. A `Param`
+generator is an async function taking `&Cx` and returning
+`Result<Vec<String>>`. A `CatchAll` generator returns
+`Result<Vec<Vec<String>>>`, where every inner vector is one non-empty sequence
+of path components. A child generator's context contains the concrete ancestor
+path and its generated path parameters.
 
 # Examples
 
@@ -41,4 +49,19 @@ topcoat::router::segment!(kind = Param);
 ```rust
 // src/app/docs/rest.rs: pages in this module serve `/docs/{*path}`.
 topcoat::router::segment!(kind = CatchAll, rename = "path");
+```
+
+Static parameter:
+
+```rust
+# use topcoat::{Result, context::Cx};
+async fn generate_ids(_cx: &Cx) -> Result<Vec<String>> {
+    Ok(vec!["one".into(), "two".into()])
+}
+
+topcoat::router::segment!(
+    kind = Param,
+    rename = "id",
+    generate_static = generate_ids,
+);
 ```

--- a/crates/topcoat-router/macro/tests/static_export.rs
+++ b/crates/topcoat-router/macro/tests/static_export.rs
@@ -1,0 +1,210 @@
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{Router, StaticParams, is_static_export, page, raw_path_params},
+    view::view,
+};
+
+mod app {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    static PRODUCT_GENERATIONS: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn router() -> Router {
+        topcoat::router::module_router!().build()
+    }
+
+    pub fn reset_generation_count() {
+        PRODUCT_GENERATIONS.store(0, Ordering::Relaxed);
+    }
+
+    pub fn generation_count() -> usize {
+        PRODUCT_GENERATIONS.load(Ordering::Relaxed)
+    }
+
+    #[page]
+    async fn home(cx: &Cx) -> Result {
+        view! { <p>"home " (is_static_export(cx))</p> }
+    }
+
+    mod products {
+        pub mod product_id {
+            use super::super::*;
+            use topcoat::router::path_param;
+
+            #[allow(clippy::unused_async)]
+            async fn generate_product_ids(_cx: &Cx) -> Result<Vec<u32>> {
+                PRODUCT_GENERATIONS.fetch_add(1, Ordering::Relaxed);
+                Ok(vec![7, 42])
+            }
+
+            #[path_param(generate_static = generate_product_ids)]
+            pub(super) struct ProductId(u32);
+
+            #[page]
+            async fn product(cx: &Cx) -> Result {
+                let product_id = path_param::<ProductId>(cx).unwrap();
+                view! { <p>"product " (product_id)</p> }
+            }
+
+            mod reviews {
+                mod review_id {
+                    use super::super::super::super::*;
+                    use super::super::ProductId;
+                    use topcoat::router::path_param;
+
+                    #[allow(clippy::unused_async)]
+                    async fn generate_review_ids(cx: &Cx) -> Result<Vec<u32>> {
+                        let product_id = path_param::<ProductId>(cx).unwrap();
+                        Ok(vec![*product_id * 10])
+                    }
+
+                    #[path_param(generate_static = generate_review_ids)]
+                    struct ReviewId(u32);
+
+                    #[page]
+                    async fn review(cx: &Cx) -> Result {
+                        let review_id = path_param::<ReviewId>(cx).unwrap();
+                        view! { <p>"review " (review_id)</p> }
+                    }
+                }
+            }
+        }
+    }
+
+    mod docs {
+        mod rest {
+            use super::super::*;
+
+            #[allow(clippy::unused_async)]
+            async fn generate_docs(_cx: &Cx) -> Result<Vec<Vec<String>>> {
+                Ok(vec![
+                    vec!["guide".into(), "start".into()],
+                    vec!["reference".into()],
+                ])
+            }
+
+            topcoat::router::segment!(
+                kind = CatchAll,
+                rename = "path",
+                generate_static = generate_docs,
+            );
+
+            #[page]
+            async fn document(cx: &Cx) -> Result {
+                let path = raw_path_params(cx)
+                    .iter()
+                    .find_map(|(name, value)| (name == "path").then_some(value))
+                    .unwrap();
+                view! { <p>(path)</p> }
+            }
+        }
+    }
+}
+
+#[allow(clippy::unused_async)]
+async fn generate_catalog(_cx: &Cx) -> Result<Vec<StaticParams>> {
+    Ok(vec![
+        StaticParams::new()
+            .param("category", "books")
+            .catch_all("slug", ["rust", "async"]),
+        StaticParams::new()
+            .param("category", "home and garden")
+            .catch_all("slug", ["lighting"]),
+    ])
+}
+
+#[page(
+    "/catalog/{category}/{*slug}",
+    generate_static = generate_catalog
+)]
+async fn catalog(cx: &Cx) -> Result {
+    view! { <p>(is_static_export(cx))</p> }
+}
+
+#[page("/missing/{value}")]
+async fn missing_generator() -> Result {
+    view! { <p>"missing"</p> }
+}
+
+#[allow(clippy::unused_async)]
+async fn generate_featured(_cx: &Cx) -> Result<Vec<StaticParams>> {
+    Ok(vec![StaticParams::new().param("slug", "featured")])
+}
+
+#[page("/blog/{slug}", generate_static = generate_featured)]
+async fn dynamic_blog_post() -> Result {
+    view! { <p>"dynamic"</p> }
+}
+
+#[page("/blog/featured")]
+async fn fixed_blog_post() -> Result {
+    view! { <p>"fixed"</p> }
+}
+
+#[tokio::test]
+async fn module_segments_generate_concrete_static_paths() {
+    app::reset_generation_count();
+    let paths = app::router().generate_static_paths().await.unwrap();
+    let paths: Vec<_> = paths
+        .iter()
+        .map(topcoat::router::StaticPath::url_path)
+        .collect();
+    assert_eq!(
+        paths,
+        [
+            "/",
+            "/docs/guide/start",
+            "/docs/reference",
+            "/products/42",
+            "/products/42/reviews/420",
+            "/products/7",
+            "/products/7/reviews/70",
+        ]
+    );
+    assert_eq!(app::generation_count(), 1);
+}
+
+#[tokio::test]
+async fn explicit_pages_generate_complete_parameter_sets() {
+    let router = Router::builder().page(catalog).build();
+    let paths = router.generate_static_paths().await.unwrap();
+    let paths: Vec<_> = paths
+        .iter()
+        .map(topcoat::router::StaticPath::url_path)
+        .collect();
+    assert_eq!(
+        paths,
+        [
+            "/catalog/books/rust/async",
+            "/catalog/home%20and%20garden/lighting",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn explicit_dynamic_pages_require_a_generator() {
+    let router = Router::builder().page(missing_generator).build();
+    let error = router.generate_static_paths().await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("requires `generate_static` on `#[page]`")
+    );
+}
+
+#[tokio::test]
+async fn duplicate_concrete_urls_are_rejected() {
+    let router = Router::builder()
+        .page(dynamic_blog_post)
+        .page(fixed_blog_post)
+        .build();
+    let error = router.generate_static_paths().await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("multiple pages generate the static URL `/blog/featured`")
+    );
+}

--- a/crates/topcoat-router/src/lib.rs
+++ b/crates/topcoat-router/src/lib.rs
@@ -21,6 +21,7 @@ mod route;
 mod router;
 mod serve;
 mod service;
+mod static_export;
 #[cfg(feature = "tower")]
 pub mod tower;
 
@@ -44,5 +45,6 @@ pub use route::*;
 pub use router::*;
 pub use serve::*;
 pub use service::*;
+pub use static_export::*;
 
 pub use http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header};

--- a/crates/topcoat-router/src/module/page.rs
+++ b/crates/topcoat-router/src/module/page.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
-use crate::{LayoutFn, LayoutRenderFn, OwnedMethods, PageFn, PageRenderFn, Path};
+use crate::{
+    LayoutFn, LayoutRenderFn, OwnedMethods, PageFn, PageRenderFn, Path, StaticPageSegment,
+};
 
 /// A page discovered by the module router, produced by the `#[page]` macro.
 ///
@@ -36,6 +38,15 @@ impl ModulePageFn {
     #[must_use]
     pub fn into_page(self, path: Cow<'static, Path>) -> PageFn {
         PageFn::new(self.methods, path, self.render)
+    }
+
+    #[must_use]
+    pub(crate) fn into_page_with_static_segments(
+        self,
+        path: Cow<'static, Path>,
+        static_segments: Vec<StaticPageSegment>,
+    ) -> PageFn {
+        PageFn::new(self.methods, path, self.render).with_static_segments(static_segments)
     }
 
     /// Returns the module path used to derive the URL.

--- a/crates/topcoat-router/src/module/router.rs
+++ b/crates/topcoat-router/src/module/router.rs
@@ -4,7 +4,7 @@ use heck::ToKebabCase;
 
 use crate::{
     ModuleLayerFn, ModuleLayoutFn, ModulePageFn, ModuleRouteFn, PathBuf, PathSegment,
-    RouterBuilder, Segment, SegmentKind, Segments,
+    RouterBuilder, Segment, SegmentKind, Segments, StaticPageSegment,
 };
 
 /// The module-based router builder, created by the `module_router!` macro.
@@ -82,11 +82,17 @@ impl ModuleRouterBuilder {
     /// segment overrides and defaults (kebab-case for static, `_` prefix for
     /// groups) to build the final route path.
     fn module_path_to_path(&self, module_path: &'static str) -> PathBuf {
+        self.resolve_module_path(module_path).0
+    }
+
+    /// Converts a module path to its route and static-expansion segments.
+    fn resolve_module_path(&self, module_path: &'static str) -> (PathBuf, Vec<StaticPageSegment>) {
         let relative = self.relative_module_path(module_path);
         let mut path_buf = PathBuf::new();
+        let mut static_segments = Vec::new();
 
         if relative.is_empty() {
-            return path_buf;
+            return (path_buf, static_segments);
         }
 
         // Iterate over the module structure. At each module level, check if there is a matching
@@ -129,8 +135,21 @@ impl ModuleRouterBuilder {
             };
 
             path_buf += path_segment;
+            let generator = segment.and_then(Segment::generate_static);
+            static_segments.push(match kind {
+                SegmentKind::Static => StaticPageSegment::Static(name.into_owned()),
+                SegmentKind::Group => StaticPageSegment::Group,
+                SegmentKind::Param => StaticPageSegment::Param {
+                    name: Cow::Owned(name.into_owned()),
+                    generator,
+                },
+                SegmentKind::CatchAll => StaticPageSegment::CatchAll {
+                    name: Cow::Owned(name.into_owned()),
+                    generator,
+                },
+            });
         }
-        path_buf
+        (path_buf, static_segments)
     }
 
     /// Registers a [`ModulePageFn`], computing its route path from the module path.
@@ -142,7 +161,8 @@ impl ModuleRouterBuilder {
     pub fn page(mut self, page: impl Into<ModulePageFn>) -> Self {
         let page = page.into();
         let module_path = page.module_path();
-        let page = page.into_page(Cow::Owned(self.module_path_to_path(module_path)));
+        let (path, static_segments) = self.resolve_module_path(module_path);
+        let page = page.into_page_with_static_segments(Cow::Owned(path), static_segments);
         self.inner = self.inner.page(page);
         self
     }
@@ -401,6 +421,7 @@ mod tests {
             "app::users::id",
             Some(SegmentKind::Param),
             None,
+            None,
         ));
         assert_eq!(
             builder.module_path_to_path("app::users::id").to_string(),
@@ -413,6 +434,7 @@ mod tests {
         let builder = builder_with(Segment::new(
             "app::files::rest",
             Some(SegmentKind::CatchAll),
+            None,
             None,
         ));
         assert_eq!(
@@ -427,6 +449,7 @@ mod tests {
             "app::marketing",
             Some(SegmentKind::Group),
             None,
+            None,
         ));
         let path = builder.module_path_to_path("app::marketing::pricing");
         assert_eq!(path.to_string(), "/(marketing)/pricing");
@@ -436,7 +459,12 @@ mod tests {
     #[test]
     fn override_kind_static_promotes_group_module() {
         // A `_`-prefixed module forced back to a static URL segment.
-        let builder = builder_with(Segment::new("app::_group", Some(SegmentKind::Static), None));
+        let builder = builder_with(Segment::new(
+            "app::_group",
+            Some(SegmentKind::Static),
+            None,
+            None,
+        ));
         assert_eq!(
             builder.module_path_to_path("app::_group").to_string(),
             "/group"
@@ -450,6 +478,7 @@ mod tests {
             "app::blog_post",
             None,
             Some("articles".into()),
+            None,
         ));
         assert_eq!(
             builder.module_path_to_path("app::blog_post").to_string(),
@@ -459,7 +488,12 @@ mod tests {
 
     #[test]
     fn override_applies_at_intermediate_segment() {
-        let builder = builder_with(Segment::new("app::users", Some(SegmentKind::Param), None));
+        let builder = builder_with(Segment::new(
+            "app::users",
+            Some(SegmentKind::Param),
+            None,
+            None,
+        ));
         assert_eq!(
             builder.module_path_to_path("app::users::posts").to_string(),
             "/{users}/posts"
@@ -474,6 +508,7 @@ mod tests {
         let _ = builder().page(page_at("app::home")).segment(Segment::new(
             "app::users",
             Some(SegmentKind::Param),
+            None,
             None,
         ));
     }

--- a/crates/topcoat-router/src/module/segment.rs
+++ b/crates/topcoat-router/src/module/segment.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
+use crate::StaticSegmentGenerator;
+
 /// The kind of a module-router path segment, set via the `segment!` macro.
 ///
 /// When using the module router, each module maps to a URL segment. By default,
@@ -48,6 +50,8 @@ pub struct Segment {
     kind: Option<SegmentKind>,
     /// Overridden URL name, or `None` to derive from the module name.
     rename: Option<Cow<'static, str>>,
+    /// Generator used to enumerate this dynamic segment during static export.
+    generate_static: Option<StaticSegmentGenerator>,
 }
 
 impl Segment {
@@ -57,11 +61,13 @@ impl Segment {
         module_path: &'static str,
         kind: Option<SegmentKind>,
         rename: Option<Cow<'static, str>>,
+        generate_static: Option<StaticSegmentGenerator>,
     ) -> Self {
         Self {
             module_path,
             kind,
             rename,
+            generate_static,
         }
     }
 
@@ -81,6 +87,12 @@ impl Segment {
     #[must_use]
     pub fn rename(&self) -> Option<&str> {
         self.rename.as_deref()
+    }
+
+    /// Returns the static value generator declared for this segment.
+    #[must_use]
+    pub fn generate_static(&self) -> Option<StaticSegmentGenerator> {
+        self.generate_static
     }
 }
 
@@ -125,7 +137,7 @@ mod tests {
     use super::*;
 
     fn test_segment() -> Segment {
-        Segment::new("my_crate::test", Some(SegmentKind::Static), None)
+        Segment::new("my_crate::test", Some(SegmentKind::Static), None, None)
     }
 
     #[test]

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -4,7 +4,10 @@ use std::pin::Pin;
 use topcoat_core::{context::Cx, error::Result};
 use topcoat_view::View;
 
-use crate::{Body, IntoResponse, Methods, OwnedMethods, Path, Route, RouteFuture};
+use crate::{
+    Body, IntoResponse, Methods, OwnedMethods, Path, Route, RouteFuture, StaticPageSegment,
+    StaticPageSource, StaticParamsGenerator,
+};
 
 /// The async render function backing a [`PageFn`].
 pub type PageRenderFn = for<'cx> fn(
@@ -30,6 +33,8 @@ pub struct PageFn {
     path: Cow<'static, Path>,
     /// The async render function that produces the page [`View`].
     render: PageRenderFn,
+    /// The generator used to enumerate this page during a static export.
+    pub(crate) static_source: Option<StaticPageSource>,
 }
 
 impl PageFn {
@@ -56,7 +61,40 @@ impl PageFn {
             methods,
             path,
             render,
+            static_source: None,
         }
+    }
+
+    /// Attaches a complete static-parameter generator to an explicitly pathed
+    /// page.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_static_params(mut self, generator: StaticParamsGenerator) -> Self {
+        self.static_source = Some(StaticPageSource::Explicit(generator));
+        self
+    }
+
+    /// Const-context constructor for a page carrying a complete static
+    /// parameter generator.
+    #[doc(hidden)]
+    pub const fn const_new_with_static_params(
+        methods: OwnedMethods,
+        path: Cow<'static, Path>,
+        render: PageRenderFn,
+        generator: StaticParamsGenerator,
+    ) -> Self {
+        Self {
+            methods,
+            path,
+            render,
+            static_source: Some(StaticPageSource::Explicit(generator)),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn with_static_segments(mut self, segments: Vec<StaticPageSegment>) -> Self {
+        self.static_source = Some(StaticPageSource::Module(segments));
+        self
     }
 
     /// Returns the HTTP methods this page responds to.

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -7,7 +7,8 @@ use topcoat_core::context::{ContextMap, CxBuilder};
 
 use crate::{
     Endpoint, Layer, LayerId, Layers, LayoutFn, Methods, Next, PageFn, PageWithLayouts,
-    PathSegment, RawPathParams, Request, Response, Route, Terminal, error::respond,
+    PathSegment, RawPathParams, Request, Response, Route, StaticExportMarker, StaticFile,
+    StaticPage, Terminal, error::respond,
 };
 
 /// A finalized Topcoat routing table.
@@ -40,7 +41,11 @@ pub struct Router {
     layers: Layers,
     /// The values shared by every request, read back via
     /// [`app_context`](topcoat_core::context::app_context).
-    app_context: Arc<ContextMap>,
+    pub(crate) app_context: Arc<ContextMap>,
+    /// The GET pages that can be selected for a static export.
+    pub(crate) static_pages: Vec<StaticPage>,
+    /// Files copied verbatim into a static export.
+    pub(crate) static_files: Vec<StaticFile>,
     /// The compression applied to responses on their way out.
     #[cfg(feature = "compression")]
     compression: crate::Compression,
@@ -62,6 +67,7 @@ impl Router {
     /// header) when the path matches but no route accepts the method.
     pub async fn handle(&self, request: Request) -> Response {
         let (parts, body) = request.into_parts();
+        let static_export = parts.extensions.get::<StaticExportMarker>().copied();
 
         // Resolve the layer stack and the chain's terminal. A matched path
         // reuses its endpoint's precomputed layer stack, whether the method
@@ -95,6 +101,9 @@ impl Router {
         let mut cx = CxBuilder::new(self.app_context.clone());
         cx.insert(path_params);
         cx.insert(parts);
+        if let Some(static_export) = static_export {
+            cx.insert(static_export);
+        }
 
         let next = Next::new(&self.layers, layers, terminal);
         let response = next.run(&mut cx, body).await;
@@ -150,6 +159,7 @@ pub struct RouterBuilder {
     layouts: Vec<LayoutFn>,
     layers: Layers,
     context: ContextMap,
+    static_files: Vec<StaticFile>,
     #[cfg(feature = "compression")]
     compression: crate::Compression,
 }
@@ -167,6 +177,7 @@ impl RouterBuilder {
             layouts: Vec::new(),
             layers: Layers::default(),
             context,
+            static_files: Vec::new(),
             #[cfg(feature = "compression")]
             compression: crate::Compression::new(),
         }
@@ -211,6 +222,22 @@ impl RouterBuilder {
     #[must_use]
     pub fn page(mut self, page: impl Into<PageFn>) -> Self {
         self.pages.push(page.into());
+        self
+    }
+
+    /// Registers a file to copy verbatim into a static export.
+    ///
+    /// Router integrations such as Topcoat assets use this alongside their
+    /// HTTP routes so the same public URL is available without a server.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn static_file(
+        mut self,
+        url_path: impl Into<String>,
+        source_path: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        self.static_files
+            .push(StaticFile::new(url_path, source_path));
         self
     }
 
@@ -421,13 +448,26 @@ impl RouterBuilder {
             layouts,
             layers,
             context,
+            static_files,
             #[cfg(feature = "compression")]
             compression,
         } = self;
 
+        let mut static_pages = Vec::new();
+
         // Wire each page to the layouts whose path is a prefix of the page's,
         // ordered from least- to most-specific so the page nests innermost.
         for page in pages {
+            let serves_get = match page.methods() {
+                Methods::Any => true,
+                Methods::Only(methods) => methods.contains(&http::Method::GET),
+            };
+            if serves_get {
+                static_pages.push(StaticPage::new(
+                    page.path().to_owned(),
+                    page.static_source.clone(),
+                ));
+            }
             let mut matching: Vec<LayoutFn> = layouts
                 .iter()
                 .filter(|layout| page.path().starts_with(layout.path()))
@@ -526,6 +566,8 @@ impl RouterBuilder {
             endpoints,
             layers,
             app_context: Arc::new(context),
+            static_pages,
+            static_files,
             #[cfg(feature = "compression")]
             compression,
         }

--- a/crates/topcoat-router/src/service.rs
+++ b/crates/topcoat-router/src/service.rs
@@ -56,6 +56,12 @@ impl RouterService {
         self.shutdown_timeout = timeout;
         self
     }
+
+    /// Returns the router wrapped by this service.
+    #[must_use]
+    pub fn router(&self) -> &Router {
+        &self.router
+    }
 }
 
 impl From<Router> for RouterService {

--- a/crates/topcoat-router/src/static_export.rs
+++ b/crates/topcoat-router/src/static_export.rs
@@ -1,0 +1,607 @@
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::future::Future;
+use std::path::{Path as FsPath, PathBuf as FsPathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use http::Method;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use topcoat_core::context::{Cx, CxBuilder, try_request_context};
+use topcoat_core::error::Result;
+
+use crate::{Body, Path, PathBuf, PathSegment, RawPathParams, Request, Router};
+
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'\\')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+/// Marks a request context created while statically exporting a page.
+#[derive(Debug, Clone, Copy)]
+pub struct StaticExportMarker;
+
+/// Returns whether `cx` belongs to a static export.
+#[must_use]
+pub fn is_static_export(cx: &Cx) -> bool {
+    try_request_context::<StaticExportMarker>(cx).is_some()
+}
+
+/// One generated value for a dynamic route segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticSegmentValue {
+    components: Box<[String]>,
+}
+
+impl StaticSegmentValue {
+    /// Creates a value for an ordinary one-component path parameter.
+    #[must_use]
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "owned values make the builder and iterator adapters ergonomic"
+    )]
+    pub fn param(value: impl ToString) -> Self {
+        Self {
+            components: vec![value.to_string()].into_boxed_slice(),
+        }
+    }
+
+    /// Creates a value for a catch-all parameter.
+    #[must_use]
+    pub fn catch_all(values: impl IntoIterator<Item = impl ToString>) -> Self {
+        Self {
+            components: values.into_iter().map(|value| value.to_string()).collect(),
+        }
+    }
+
+    fn components(&self) -> &[String] {
+        &self.components
+    }
+}
+
+/// A named collection of values used to expand an explicitly pathed page.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StaticParams {
+    values: Vec<(Cow<'static, str>, StaticSegmentValue)>,
+}
+
+impl StaticParams {
+    /// Creates an empty parameter collection.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds an ordinary one-component path parameter.
+    #[must_use]
+    pub fn param(mut self, name: impl Into<Cow<'static, str>>, value: impl ToString) -> Self {
+        self.values
+            .push((name.into(), StaticSegmentValue::param(value)));
+        self
+    }
+
+    /// Adds a catch-all path parameter.
+    #[must_use]
+    pub fn catch_all(
+        mut self,
+        name: impl Into<Cow<'static, str>>,
+        values: impl IntoIterator<Item = impl ToString>,
+    ) -> Self {
+        self.values
+            .push((name.into(), StaticSegmentValue::catch_all(values)));
+        self
+    }
+
+    fn into_map(
+        self,
+        route: &Path,
+    ) -> std::result::Result<HashMap<Cow<'static, str>, StaticSegmentValue>, StaticExportError>
+    {
+        let mut values = HashMap::new();
+        for (name, value) in self.values {
+            if values.insert(name.clone(), value).is_some() {
+                return Err(StaticExportError::new(format!(
+                    "static parameters for route `{route}` contain duplicate `{name}` values"
+                )));
+            }
+        }
+        Ok(values)
+    }
+}
+
+/// Future returned by an erased static segment generator.
+pub type StaticSegmentGeneratorFuture<'cx> =
+    Pin<Box<dyn Future<Output = Result<Vec<StaticSegmentValue>>> + Send + 'cx>>;
+
+/// Erased async function that generates the values of one dynamic segment.
+#[derive(Clone, Copy)]
+pub struct StaticSegmentGenerator {
+    handler: for<'cx> fn(&'cx Cx) -> StaticSegmentGeneratorFuture<'cx>,
+}
+
+impl StaticSegmentGenerator {
+    /// Creates a generator from a macro-generated adapter.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn new(handler: for<'cx> fn(&'cx Cx) -> StaticSegmentGeneratorFuture<'cx>) -> Self {
+        Self { handler }
+    }
+
+    async fn generate(&self, cx: &Cx) -> Result<Vec<StaticSegmentValue>> {
+        (self.handler)(cx).await
+    }
+
+    fn identity(self) -> usize {
+        self.handler as usize
+    }
+}
+
+impl fmt::Debug for StaticSegmentGenerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StaticSegmentGenerator")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Future returned by an erased explicit-page parameter generator.
+pub type StaticParamsGeneratorFuture<'cx> =
+    Pin<Box<dyn Future<Output = Result<Vec<StaticParams>>> + Send + 'cx>>;
+
+/// Erased async function that generates complete parameter sets for a page.
+#[derive(Clone, Copy)]
+pub struct StaticParamsGenerator {
+    handler: for<'cx> fn(&'cx Cx) -> StaticParamsGeneratorFuture<'cx>,
+}
+
+impl StaticParamsGenerator {
+    /// Creates a generator from a macro-generated adapter.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn new(handler: for<'cx> fn(&'cx Cx) -> StaticParamsGeneratorFuture<'cx>) -> Self {
+        Self { handler }
+    }
+
+    async fn generate(&self, cx: &Cx) -> Result<Vec<StaticParams>> {
+        (self.handler)(cx).await
+    }
+}
+
+impl fmt::Debug for StaticParamsGenerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StaticParamsGenerator")
+            .finish_non_exhaustive()
+    }
+}
+
+/// A segment in the static expansion plan of a module-derived page.
+#[derive(Debug, Clone)]
+pub(crate) enum StaticPageSegment {
+    Static(String),
+    Group,
+    Param {
+        name: Cow<'static, str>,
+        generator: Option<StaticSegmentGenerator>,
+    },
+    CatchAll {
+        name: Cow<'static, str>,
+        generator: Option<StaticSegmentGenerator>,
+    },
+}
+
+/// How a page's concrete export URLs are generated.
+#[derive(Debug, Clone)]
+pub(crate) enum StaticPageSource {
+    Module(Vec<StaticPageSegment>),
+    Explicit(StaticParamsGenerator),
+}
+
+/// A page retained by the router for static path generation.
+#[derive(Debug, Clone)]
+pub(crate) struct StaticPage {
+    path: PathBuf,
+    source: Option<StaticPageSource>,
+}
+
+impl StaticPage {
+    pub(crate) fn new(path: PathBuf, source: Option<StaticPageSource>) -> Self {
+        Self { path, source }
+    }
+}
+
+/// A file copied verbatim into a static export.
+#[derive(Debug, Clone)]
+pub struct StaticFile {
+    url_path: String,
+    source_path: FsPathBuf,
+}
+
+impl StaticFile {
+    /// Creates a static file mounted at `url_path`.
+    #[must_use]
+    pub fn new(url_path: impl Into<String>, source_path: impl Into<FsPathBuf>) -> Self {
+        Self {
+            url_path: url_path.into(),
+            source_path: source_path.into(),
+        }
+    }
+
+    /// Returns the public URL path of the file.
+    #[must_use]
+    pub fn url_path(&self) -> &str {
+        &self.url_path
+    }
+
+    /// Returns the source file copied during export.
+    #[must_use]
+    pub fn source_path(&self) -> &FsPath {
+        &self.source_path
+    }
+}
+
+/// One concrete page URL selected for static rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticPath {
+    url_path: String,
+    route: PathBuf,
+}
+
+impl StaticPath {
+    /// Returns the concrete URL path.
+    #[must_use]
+    pub fn url_path(&self) -> &str {
+        &self.url_path
+    }
+
+    /// Returns the route pattern that generated the URL.
+    #[must_use]
+    pub fn route(&self) -> &Path {
+        &self.route
+    }
+}
+
+/// An error encountered while selecting the URLs of a static export.
+#[derive(Debug)]
+pub struct StaticExportError {
+    message: String,
+}
+
+impl StaticExportError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for StaticExportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StaticExportError {}
+
+#[derive(Clone)]
+struct Candidate {
+    components: Vec<String>,
+    params: Vec<(String, String)>,
+}
+
+impl Candidate {
+    fn root() -> Self {
+        Self {
+            components: Vec::new(),
+            params: Vec::new(),
+        }
+    }
+
+    fn url_path(&self) -> String {
+        if self.components.is_empty() {
+            return "/".to_owned();
+        }
+        let mut path = String::new();
+        for component in &self.components {
+            path.push('/');
+            path.push_str(&utf8_percent_encode(component, PATH_SEGMENT_ENCODE_SET).to_string());
+        }
+        path
+    }
+}
+
+impl Router {
+    /// Generates every concrete URL selected for static page rendering.
+    ///
+    /// Fixed GET pages are included automatically. Dynamic module-derived
+    /// pages use their segment generators, while explicitly pathed pages use
+    /// the generator declared on `#[page]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a dynamic segment has no generator, a generator
+    /// fails, generated values do not fit their route, or two pages generate
+    /// the same concrete URL.
+    pub async fn generate_static_paths(
+        &self,
+    ) -> std::result::Result<Vec<StaticPath>, StaticExportError> {
+        let mut generated = Vec::new();
+        let mut segment_cache = HashMap::new();
+
+        for page in &self.static_pages {
+            let paths = match &page.source {
+                Some(StaticPageSource::Module(segments)) => {
+                    self.expand_module_page(&page.path, segments, &mut segment_cache)
+                        .await?
+                }
+                Some(StaticPageSource::Explicit(generator)) => {
+                    self.expand_explicit_page(&page.path, *generator).await?
+                }
+                None => Self::expand_automatic_page(&page.path)?,
+            };
+            generated.extend(paths.into_iter().map(|url_path| StaticPath {
+                url_path,
+                route: page.path.clone(),
+            }));
+        }
+
+        generated.sort_by(|left, right| left.url_path.cmp(&right.url_path));
+        let mut seen = HashSet::new();
+        for path in &generated {
+            if !seen.insert(path.url_path.clone()) {
+                return Err(StaticExportError::new(format!(
+                    "multiple pages generate the static URL `{}`",
+                    path.url_path
+                )));
+            }
+        }
+        Ok(generated)
+    }
+
+    /// Returns every file registered for copying into a static export.
+    #[must_use]
+    pub fn static_files(&self) -> &[StaticFile] {
+        &self.static_files
+    }
+
+    async fn expand_module_page(
+        &self,
+        route: &Path,
+        segments: &[StaticPageSegment],
+        segment_cache: &mut HashMap<(usize, String), Vec<StaticSegmentValue>>,
+    ) -> std::result::Result<Vec<String>, StaticExportError> {
+        let mut candidates = vec![Candidate::root()];
+
+        for segment in segments {
+            match segment {
+                StaticPageSegment::Static(value) => {
+                    for candidate in &mut candidates {
+                        candidate.components.push(value.clone());
+                    }
+                }
+                StaticPageSegment::Group => {}
+                StaticPageSegment::Param { name, generator } => {
+                    candidates = self
+                        .expand_generated_segment(
+                            route,
+                            candidates,
+                            name.as_ref(),
+                            *generator,
+                            false,
+                            segment_cache,
+                        )
+                        .await?;
+                }
+                StaticPageSegment::CatchAll { name, generator } => {
+                    candidates = self
+                        .expand_generated_segment(
+                            route,
+                            candidates,
+                            name.as_ref(),
+                            *generator,
+                            true,
+                            segment_cache,
+                        )
+                        .await?;
+                }
+            }
+        }
+
+        Ok(candidates
+            .into_iter()
+            .map(|candidate| candidate.url_path())
+            .collect())
+    }
+
+    async fn expand_generated_segment(
+        &self,
+        route: &Path,
+        candidates: Vec<Candidate>,
+        name: &str,
+        generator: Option<StaticSegmentGenerator>,
+        catch_all: bool,
+        segment_cache: &mut HashMap<(usize, String), Vec<StaticSegmentValue>>,
+    ) -> std::result::Result<Vec<Candidate>, StaticExportError> {
+        let Some(generator) = generator else {
+            return Err(StaticExportError::new(format!(
+                "dynamic segment `{name}` in route `{route}` has no `generate_static` function"
+            )));
+        };
+        let mut expanded = Vec::new();
+
+        for candidate in candidates {
+            let cache_key = (generator.identity(), candidate.url_path());
+            let values = if let Some(values) = segment_cache.get(&cache_key) {
+                values.clone()
+            } else {
+                let cx = self.generator_context(&candidate);
+                let values = generator.generate(&cx).await.map_err(|error| {
+                    StaticExportError::new(format!(
+                        "failed to generate static values for `{name}` in route `{route}`: {error}"
+                    ))
+                })?;
+                segment_cache.insert(cache_key, values.clone());
+                values
+            };
+            for value in values {
+                validate_segment_value(route, name, &value, catch_all)?;
+                let mut next = candidate.clone();
+                next.components.extend(value.components().iter().cloned());
+                next.params
+                    .push((name.to_owned(), value.components().join("/")));
+                expanded.push(next);
+            }
+        }
+
+        Ok(expanded)
+    }
+
+    async fn expand_explicit_page(
+        &self,
+        route: &Path,
+        generator: StaticParamsGenerator,
+    ) -> std::result::Result<Vec<String>, StaticExportError> {
+        let cx = self.generator_context(&Candidate::root());
+        let generated = generator.generate(&cx).await.map_err(|error| {
+            StaticExportError::new(format!(
+                "failed to generate static parameters for route `{route}`: {error}"
+            ))
+        })?;
+        generated
+            .into_iter()
+            .map(|params| expand_explicit_params(route, params))
+            .collect()
+    }
+
+    fn expand_automatic_page(route: &Path) -> std::result::Result<Vec<String>, StaticExportError> {
+        let mut candidate = Candidate::root();
+        for segment in route.segments() {
+            match segment {
+                PathSegment::Static(value) => candidate.components.push(value.to_owned()),
+                PathSegment::Group(_) => {}
+                PathSegment::Param(name) | PathSegment::CatchAll(name) => {
+                    return Err(StaticExportError::new(format!(
+                        "dynamic segment `{name}` in explicit route `{route}` requires \
+                         `generate_static` on `#[page]`"
+                    )));
+                }
+            }
+        }
+        Ok(vec![candidate.url_path()])
+    }
+
+    fn generator_context(&self, candidate: &Candidate) -> Cx {
+        let uri = candidate.url_path();
+        let (parts, _) = Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .body(Body::empty())
+            .expect("generated static request must be valid")
+            .into_parts();
+        let keys = candidate
+            .params
+            .iter()
+            .map(|(name, _)| Arc::<str>::from(name.as_str()));
+        let values = candidate.params.iter().map(|(_, value)| value.as_str());
+
+        let mut cx = CxBuilder::new(self.app_context.clone());
+        cx.insert(RawPathParams::from_pairs(keys.zip(values)));
+        cx.insert(parts);
+        cx.insert(StaticExportMarker);
+        cx.build()
+    }
+}
+
+fn expand_explicit_params(
+    route: &Path,
+    params: StaticParams,
+) -> std::result::Result<String, StaticExportError> {
+    let mut values = params.into_map(route)?;
+    let mut candidate = Candidate::root();
+
+    for segment in route.segments() {
+        match segment {
+            PathSegment::Static(value) => candidate.components.push(value.to_owned()),
+            PathSegment::Group(_) => {}
+            PathSegment::Param(name) => {
+                let value = take_param(route, &mut values, name)?;
+                validate_segment_value(route, name, &value, false)?;
+                candidate
+                    .components
+                    .extend(value.components().iter().cloned());
+            }
+            PathSegment::CatchAll(name) => {
+                let value = take_param(route, &mut values, name)?;
+                validate_segment_value(route, name, &value, true)?;
+                candidate
+                    .components
+                    .extend(value.components().iter().cloned());
+            }
+        }
+    }
+
+    if let Some(name) = values.keys().next() {
+        return Err(StaticExportError::new(format!(
+            "static parameters for route `{route}` contain unknown parameter `{name}`"
+        )));
+    }
+
+    let url_path = candidate.url_path();
+    if !route.matches(&url_path) {
+        return Err(StaticExportError::new(format!(
+            "generated URL `{url_path}` does not match route `{route}`"
+        )));
+    }
+    Ok(url_path)
+}
+
+fn take_param(
+    route: &Path,
+    values: &mut HashMap<Cow<'static, str>, StaticSegmentValue>,
+    name: &str,
+) -> std::result::Result<StaticSegmentValue, StaticExportError> {
+    values.remove(name).ok_or_else(|| {
+        StaticExportError::new(format!(
+            "static parameters for route `{route}` are missing `{name}`"
+        ))
+    })
+}
+
+fn validate_segment_value(
+    route: &Path,
+    name: &str,
+    value: &StaticSegmentValue,
+    catch_all: bool,
+) -> std::result::Result<(), StaticExportError> {
+    let expected = if catch_all {
+        "one or more"
+    } else {
+        "exactly one"
+    };
+    let valid_len = if catch_all {
+        !value.components().is_empty()
+    } else {
+        value.components().len() == 1
+    };
+    if !valid_len {
+        return Err(StaticExportError::new(format!(
+            "static value for `{name}` in route `{route}` must contain {expected} path component"
+        )));
+    }
+    if value.components().iter().any(String::is_empty) {
+        return Err(StaticExportError::new(format!(
+            "static value for `{name}` in route `{route}` contains an empty path component"
+        )));
+    }
+    Ok(())
+}

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -157,7 +157,7 @@ futures-util = { workspace = true, optional = true }
 inventory = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_urlencoded.workspace = true
-tokio = { workspace = true, optional = true, features = ["macros", "net", "signal"] }
+tokio = { workspace = true, optional = true, features = ["fs", "macros", "net", "signal"] }
 tokio-tungstenite = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/topcoat/docs/export.md
+++ b/crates/topcoat/docs/export.md
@@ -1,0 +1,204 @@
+Static export renders a Topcoat application's GET pages to HTML files that can
+be hosted without a running Rust server. It uses the same router, layouts,
+layers, app context, and asset declarations as the served application.
+
+# Exporting a site
+
+Run the command from the application workspace:
+
+```text
+topcoat export
+```
+
+The default output is `dist/`. The command builds the selected application,
+bundles its assets, starts the built binary in export mode, and only replaces
+the output directory after every page succeeds.
+
+The build selection flags match the other commands that compile an app:
+
+```text
+topcoat export --release
+topcoat export --package my-site
+topcoat export --bin my-site
+topcoat export --profile production
+topcoat export --out public
+```
+
+By default, `/about` is written to `about/index.html`. Pass `--html-files` to
+write it to `about.html` instead. `/` is always `index.html`, and `/404` is
+always `404.html`. If the router has no `/404` page, Topcoat writes a minimal
+fallback `404.html`.
+
+# Fixed pages
+
+Every fixed page that accepts GET is included automatically:
+
+```rust
+# use topcoat::{Result, router::page, view::view};
+#[page("/about")]
+async fn about() -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html><body><h1>"About"</h1></body></html>
+    }
+}
+```
+
+Pages that do not accept GET are not exported. API routes declared with
+`#[route]` are also not exported.
+
+# Dynamic module routes
+
+A dynamic URL has no finite set of paths until the application supplies one.
+For a module route, add `generate_static` to every dynamic segment.
+
+A typed [`#[path_param]`](macro@crate::router::path_param) generator returns
+values of the struct's inner type:
+
+```rust
+# use topcoat::{Result, context::Cx, router::path_param};
+async fn generate_post_ids(_cx: &Cx) -> Result<Vec<u64>> {
+    Ok(vec![1, 2, 3])
+}
+
+#[path_param(generate_static = generate_post_ids)]
+struct PostId(u64);
+```
+
+If this declaration is in the module that contributes `{post_id}`, descendant
+pages are generated for `1`, `2`, and `3`. A `str` path parameter generator
+returns `Vec<String>`.
+
+A manual parameter segment uses `Vec<String>`:
+
+```rust
+# use topcoat::{Result, context::Cx};
+async fn generate_slugs(_cx: &Cx) -> Result<Vec<String>> {
+    Ok(vec!["first-post".into(), "second-post".into()])
+}
+
+topcoat::router::segment!(
+    kind = Param,
+    rename = "slug",
+    generate_static = generate_slugs,
+);
+```
+
+A catch-all generator returns one non-empty `Vec<String>` per URL. Each inner
+string is one path component:
+
+```rust
+# use topcoat::{Result, context::Cx};
+async fn generate_docs(_cx: &Cx) -> Result<Vec<Vec<String>>> {
+    Ok(vec![
+        vec!["guide".into(), "start".into()],
+        vec!["reference".into()],
+    ])
+}
+
+topcoat::router::segment!(
+    kind = CatchAll,
+    rename = "path",
+    generate_static = generate_docs,
+);
+```
+
+This generates `/guide/start` and `/reference` for that catch-all segment.
+
+Generators run from the root toward the page. A child generator is called once
+for each parameter set produced by its parents. Its `&Cx` contains app context,
+the concrete ancestor path, and ancestor path parameters, so it can query data
+for the current parent. Results shared by several descendant pages are reused
+during the export.
+
+# Dynamic explicit paths
+
+Segment declarations only affect module-derived paths. An explicit dynamic
+page instead declares one generator on `#[page]`. It returns complete
+[`StaticParams`](crate::router::StaticParams) sets:
+
+```rust
+# use topcoat::{
+#     Result,
+#     context::Cx,
+#     router::{StaticParams, page},
+#     view::view,
+# };
+async fn generate_articles(_cx: &Cx) -> Result<Vec<StaticParams>> {
+    Ok(vec![
+        StaticParams::new()
+            .param("year", 2025)
+            .catch_all("slug", ["rust", "async"]),
+        StaticParams::new()
+            .param("year", 2026)
+            .catch_all("slug", ["topcoat"]),
+    ])
+}
+
+#[page(
+    "/articles/{year}/{*slug}",
+    generate_static = generate_articles
+)]
+async fn article() -> Result {
+    view! { <h1>"Article"</h1> }
+}
+```
+
+Each set must provide every dynamic parameter exactly once and must not contain
+unknown names. `param` supplies one component; `catch_all` supplies one or more
+components. Topcoat percent-encodes generated components when it constructs the
+URL.
+
+An export fails if a GET page has a dynamic module segment without
+`generate_static`, or an explicit dynamic path has no page-level
+`generate_static`. Topcoat does not guess values and does not leave a dynamic
+server fallback in the output.
+
+# Rendering behavior
+
+Each selected URL is dispatched as a real GET request through the router. This
+means normal page rendering, layouts, layers, request context, and app context
+all apply. Use [`is_static_export`](crate::router::is_static_export) when code
+must distinguish a build-time render:
+
+```rust
+# use topcoat::{Result, context::Cx, router::is_static_export, view::view};
+# async fn example(cx: &Cx) -> Result {
+if is_static_export(cx) {
+    // Avoid request-specific work that has no meaning in a static file.
+}
+# view! {}
+# }
+```
+
+An exported response must be `200 OK`, have a `text/html` content type, and
+must not set cookies or use content encoding. A violation stops the export and
+leaves the previous output directory intact.
+
+Files registered by Topcoat's asset bundle are copied to their public,
+content-hashed URL paths. A page and a static file cannot write the same output
+path.
+
+# Calling the exporter directly
+
+The same renderer is available as an in-process API:
+
+```rust
+# use topcoat::{
+#     ExportConfig, ExportPathStyle,
+#     router::Router,
+# };
+# async fn example(router: Router) -> Result<(), topcoat::ExportError> {
+let report = topcoat::export(
+    router,
+    ExportConfig::new("dist").path_style(ExportPathStyle::Directory),
+)
+.await?;
+
+println!("rendered {} pages", report.pages());
+# Ok(())
+# }
+```
+
+The direct API writes into the configured directory. The CLI adds staging and
+atomic replacement around it.

--- a/crates/topcoat/docs/router.md
+++ b/crates/topcoat/docs/router.md
@@ -35,6 +35,11 @@ A page serves `GET` by default; naming methods before the path (`#[page(POST "/s
 
 See [`#[page]`](page) for the handler signature, module-derived paths, and using pages as components.
 
+Fixed GET pages are included in a [static export](mod@crate::export)
+automatically. An explicit dynamic path supplies complete parameter sets with
+`#[page("/users/{id}", generate_static = function)]`. Module-derived dynamic
+paths put their generators on `segment!` or `#[path_param]`.
+
 # Layouts
 
 A layout wraps pages. It receives the rendered inner page (or nested layout) as a `Result<View>`, to embed in its own view. Annotate it with [`#[layout]`](layout):

--- a/crates/topcoat/src/export.rs
+++ b/crates/topcoat/src/export.rs
@@ -1,0 +1,414 @@
+#![doc = include_str!("../docs/export.md")]
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use topcoat_router::{
+    Body, Method, Request, RouterService, StaticExportMarker, StatusCode, header, to_bytes,
+};
+
+const INTERNAL_COMMAND_ENV: &str = "TOPCOAT_INTERNAL_COMMAND";
+const EXPORT_COMMAND: &str = "export";
+const EXPORT_PROTOCOL_ENV: &str = "TOPCOAT_EXPORT_PROTOCOL";
+const EXPORT_PROTOCOL: &str = "1";
+const EXPORT_OUT_ENV: &str = "TOPCOAT_EXPORT_OUT";
+const EXPORT_PATH_STYLE_ENV: &str = "TOPCOAT_EXPORT_PATH_STYLE";
+const DEFAULT_404: &str = "<!doctype html><html><head><meta charset=\"utf-8\"><title>Not Found</title></head><body><h1>404 Not Found</h1></body></html>";
+
+/// How page URLs map to files in a static export.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ExportPathStyle {
+    /// Write `/about` to `about/index.html`.
+    #[default]
+    Directory,
+    /// Write `/about` to `about.html`.
+    HtmlFile,
+}
+
+impl ExportPathStyle {
+    fn from_env(value: &str) -> Result<Self, ExportError> {
+        match value {
+            "directory" => Ok(Self::Directory),
+            "html-file" => Ok(Self::HtmlFile),
+            _ => Err(ExportError::new(format!(
+                "{EXPORT_PATH_STYLE_ENV} must be `directory` or `html-file`, got `{value}`"
+            ))),
+        }
+    }
+}
+
+/// Configuration for rendering a router into static files.
+#[derive(Debug, Clone)]
+pub struct ExportConfig {
+    out_dir: PathBuf,
+    path_style: ExportPathStyle,
+}
+
+impl ExportConfig {
+    /// Creates an export writing into `out_dir`.
+    #[must_use]
+    pub fn new(out_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            out_dir: out_dir.into(),
+            path_style: ExportPathStyle::default(),
+        }
+    }
+
+    /// Selects how non-root page URLs map to HTML files.
+    #[must_use]
+    pub fn path_style(mut self, path_style: ExportPathStyle) -> Self {
+        self.path_style = path_style;
+        self
+    }
+
+    /// Returns the destination directory.
+    #[must_use]
+    pub fn out_dir(&self) -> &Path {
+        &self.out_dir
+    }
+}
+
+/// Summary of a completed static export.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportReport {
+    out_dir: PathBuf,
+    pages: usize,
+    files: usize,
+}
+
+impl ExportReport {
+    /// Returns the destination directory.
+    #[must_use]
+    pub fn out_dir(&self) -> &Path {
+        &self.out_dir
+    }
+
+    /// Returns the number of rendered pages, including the generated 404 page.
+    #[must_use]
+    pub fn pages(&self) -> usize {
+        self.pages
+    }
+
+    /// Returns the number of copied static files.
+    #[must_use]
+    pub fn files(&self) -> usize {
+        self.files
+    }
+}
+
+/// An error encountered while producing a static export.
+#[derive(Debug)]
+pub struct ExportError {
+    message: String,
+}
+
+impl ExportError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ExportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ExportError {}
+
+/// Renders all statically selectable pages and copies registered static files.
+///
+/// Fixed GET pages are exported automatically. Dynamic module routes must
+/// declare `generate_static` on each dynamic segment, and dynamic explicit
+/// page paths must declare `generate_static` on `#[page]`.
+///
+/// # Errors
+///
+/// Returns an error when path generation or rendering fails, a response is not
+/// exportable, an output path collides, or a filesystem operation fails.
+pub async fn export(
+    service: impl Into<RouterService>,
+    config: ExportConfig,
+) -> Result<ExportReport, ExportError> {
+    let service = service.into();
+    let router = service.router();
+    let paths = router
+        .generate_static_paths()
+        .await
+        .map_err(|error| ExportError::new(error.to_string()))?;
+
+    let mut outputs = HashMap::<PathBuf, String>::new();
+    let mut rendered_404 = false;
+    let mut page_outputs = Vec::new();
+    for path in &paths {
+        let relative = page_output_path(path.url_path(), config.path_style)?;
+        reserve_output(&mut outputs, &relative, path.url_path())?;
+        page_outputs.push((path, relative));
+        rendered_404 |= path.url_path() == "/404";
+    }
+
+    if !rendered_404 {
+        let relative = PathBuf::from("404.html");
+        reserve_output(&mut outputs, &relative, "generated 404 page")?;
+    }
+
+    let mut static_outputs = Vec::new();
+    for file in router.static_files() {
+        let relative = static_file_output_path(file.url_path())?;
+        reserve_output(&mut outputs, &relative, file.url_path())?;
+        static_outputs.push((file, relative));
+    }
+
+    tokio::fs::create_dir_all(&config.out_dir)
+        .await
+        .map_err(|error| {
+            ExportError::new(format!(
+                "failed to create export directory `{}`: {error}",
+                config.out_dir.display()
+            ))
+        })?;
+
+    for (path, relative) in page_outputs {
+        let bytes = render_page(router, path.url_path()).await?;
+        write_output(&config.out_dir, &relative, &bytes).await?;
+    }
+    if !rendered_404 {
+        write_output(
+            &config.out_dir,
+            Path::new("404.html"),
+            DEFAULT_404.as_bytes(),
+        )
+        .await?;
+    }
+
+    for (file, relative) in static_outputs {
+        let destination = config.out_dir.join(&relative);
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|error| {
+                ExportError::new(format!(
+                    "failed to create static file directory `{}`: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        tokio::fs::copy(file.source_path(), &destination)
+            .await
+            .map_err(|error| {
+                ExportError::new(format!(
+                    "failed to copy static file `{}` to `{}`: {error}",
+                    file.source_path().display(),
+                    destination.display()
+                ))
+            })?;
+    }
+
+    Ok(ExportReport {
+        out_dir: config.out_dir,
+        pages: paths.len() + usize::from(!rendered_404),
+        files: router.static_files().len(),
+    })
+}
+
+pub(crate) fn config_from_env() -> Result<Option<ExportConfig>, ExportError> {
+    match std::env::var(INTERNAL_COMMAND_ENV) {
+        Ok(command) if command == EXPORT_COMMAND => {}
+        Ok(_) | Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(error) => {
+            return Err(ExportError::new(format!(
+                "{INTERNAL_COMMAND_ENV} must be valid Unicode: {error}"
+            )));
+        }
+    }
+
+    match std::env::var(EXPORT_PROTOCOL_ENV) {
+        Ok(protocol) if protocol == EXPORT_PROTOCOL => {}
+        Ok(protocol) => {
+            return Err(ExportError::new(format!(
+                "unsupported static export protocol `{protocol}`"
+            )));
+        }
+        Err(std::env::VarError::NotPresent) => {
+            return Err(ExportError::new(format!(
+                "{EXPORT_PROTOCOL_ENV} is required for export"
+            )));
+        }
+        Err(error) => {
+            return Err(ExportError::new(format!(
+                "{EXPORT_PROTOCOL_ENV} must be valid Unicode: {error}"
+            )));
+        }
+    }
+
+    let out_dir = std::env::var_os(EXPORT_OUT_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| ExportError::new(format!("{EXPORT_OUT_ENV} is required for export")))?;
+    let path_style = match std::env::var(EXPORT_PATH_STYLE_ENV) {
+        Ok(value) => ExportPathStyle::from_env(&value)?,
+        Err(std::env::VarError::NotPresent) => ExportPathStyle::default(),
+        Err(error) => {
+            return Err(ExportError::new(format!(
+                "{EXPORT_PATH_STYLE_ENV} must be valid Unicode: {error}"
+            )));
+        }
+    };
+    Ok(Some(ExportConfig::new(out_dir).path_style(path_style)))
+}
+
+async fn render_page(
+    router: &topcoat_router::Router,
+    url_path: &str,
+) -> Result<Vec<u8>, ExportError> {
+    let mut request = Request::builder()
+        .method(Method::GET)
+        .uri(url_path)
+        .body(Body::empty())
+        .map_err(|error| {
+            ExportError::new(format!(
+                "failed to build static request for `{url_path}`: {error}"
+            ))
+        })?;
+    request.extensions_mut().insert(StaticExportMarker);
+    let response = router.handle(request).await;
+
+    if response.status() != StatusCode::OK {
+        return Err(ExportError::new(format!(
+            "static request for `{url_path}` returned {}",
+            response.status()
+        )));
+    }
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok());
+    if !content_type.is_some_and(|value| {
+        value
+            .split(';')
+            .next()
+            .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("text/html"))
+    }) {
+        return Err(ExportError::new(format!(
+            "static request for `{url_path}` must return `text/html`, got `{}`",
+            content_type.unwrap_or("<missing>")
+        )));
+    }
+    if response.headers().contains_key(header::SET_COOKIE) {
+        return Err(ExportError::new(format!(
+            "static request for `{url_path}` returned `Set-Cookie`, which cannot be exported"
+        )));
+    }
+    if response.headers().contains_key(header::CONTENT_ENCODING) {
+        return Err(ExportError::new(format!(
+            "static request for `{url_path}` returned encoded content, which cannot be exported"
+        )));
+    }
+
+    to_bytes(response.into_body(), usize::MAX)
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(|error| {
+            ExportError::new(format!(
+                "failed to read static response for `{url_path}`: {error}"
+            ))
+        })
+}
+
+fn page_output_path(url_path: &str, path_style: ExportPathStyle) -> Result<PathBuf, ExportError> {
+    if url_path == "/" {
+        return Ok(PathBuf::from("index.html"));
+    }
+    if url_path == "/404" {
+        return Ok(PathBuf::from("404.html"));
+    }
+
+    let mut path = url_to_relative_path(url_path)?;
+    match path_style {
+        ExportPathStyle::Directory => path.push("index.html"),
+        ExportPathStyle::HtmlFile => {
+            let file_name = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| ExportError::new(format!("invalid static URL `{url_path}`")))?;
+            path.set_file_name(format!("{file_name}.html"));
+        }
+    }
+    Ok(path)
+}
+
+fn static_file_output_path(url_path: &str) -> Result<PathBuf, ExportError> {
+    let path = url_to_relative_path(url_path)?;
+    if path.as_os_str().is_empty() {
+        return Err(ExportError::new(
+            "a static file cannot be registered at `/`",
+        ));
+    }
+    Ok(path)
+}
+
+fn url_to_relative_path(url_path: &str) -> Result<PathBuf, ExportError> {
+    let Some(relative) = url_path.strip_prefix('/') else {
+        return Err(ExportError::new(format!(
+            "static URL `{url_path}` must start with `/`"
+        )));
+    };
+    if relative.ends_with('/') || relative.contains('?') || relative.contains('#') {
+        return Err(ExportError::new(format!(
+            "static URL `{url_path}` is not a canonical path"
+        )));
+    }
+
+    let path = PathBuf::from(relative);
+    if path.components().any(|component| {
+        !matches!(component, Component::Normal(_))
+            || component.as_os_str() == "."
+            || component.as_os_str() == ".."
+    }) {
+        return Err(ExportError::new(format!(
+            "static URL `{url_path}` would escape the export directory"
+        )));
+    }
+    Ok(path)
+}
+
+fn reserve_output(
+    outputs: &mut HashMap<PathBuf, String>,
+    relative: &Path,
+    source: &str,
+) -> Result<(), ExportError> {
+    for (existing_path, existing_source) in &*outputs {
+        if relative == existing_path
+            || relative.starts_with(existing_path)
+            || existing_path.starts_with(relative)
+        {
+            return Err(ExportError::new(format!(
+                "static outputs `{}` and `{}` conflict; they are generated by `{existing_source}` and `{source}`",
+                existing_path.display(),
+                relative.display()
+            )));
+        }
+    }
+    outputs.insert(relative.to_owned(), source.to_owned());
+    Ok(())
+}
+
+async fn write_output(out_dir: &Path, relative: &Path, bytes: &[u8]) -> Result<(), ExportError> {
+    let destination = out_dir.join(relative);
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            ExportError::new(format!(
+                "failed to create page directory `{}`: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    tokio::fs::write(&destination, bytes)
+        .await
+        .map_err(|error| {
+            ExportError::new(format!(
+                "failed to write static page `{}`: {error}",
+                destination.display()
+            ))
+        })
+}

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -7,6 +7,9 @@ extern crate self as topcoat;
 pub mod dev;
 
 #[cfg(feature = "router")]
+pub mod export;
+
+#[cfg(feature = "router")]
 mod serve;
 
 pub use topcoat_core::error::Error;
@@ -41,6 +44,9 @@ pub mod router;
 
 #[cfg(feature = "view")]
 pub mod view;
+
+#[cfg(feature = "router")]
+pub use export::{ExportConfig, ExportError, ExportPathStyle, ExportReport, export};
 
 #[cfg(feature = "router")]
 pub use serve::{serve, serve_until, start};

--- a/crates/topcoat/src/serve.rs
+++ b/crates/topcoat/src/serve.rs
@@ -77,6 +77,14 @@ pub async fn serve_until(
 /// Returns `Err` if `HOST`/`PORT` are invalid, if binding the TCP listener
 /// fails, or if serving the router fails (see [`serve`]).
 pub async fn start(service: impl Into<RouterService>) -> Result<(), io::Error> {
+    let service = service.into();
+    if let Some(config) = crate::export::config_from_env().map_err(io::Error::other)? {
+        crate::export(service, config)
+            .await
+            .map_err(io::Error::other)?;
+        return Ok(());
+    }
+
     let host = host_from_env()?;
     let port = port_from_env()?;
     let listener = TcpListener::bind((host.as_str(), port)).await?;

--- a/crates/topcoat/tests/export.rs
+++ b/crates/topcoat/tests/export.rs
@@ -1,0 +1,128 @@
+use std::path::{Path, PathBuf};
+
+use topcoat::{
+    ExportConfig, ExportPathStyle, Result,
+    context::Cx,
+    export,
+    router::{Router, is_static_export, page},
+    view::view,
+};
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new() -> Self {
+        let path =
+            std::env::temp_dir().join(format!("topcoat-export-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[page("/")]
+async fn home(cx: &Cx) -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html><body>"export: " (is_static_export(cx))</body></html>
+    }
+}
+
+#[page("/about")]
+async fn about() -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html><body>"about"</body></html>
+    }
+}
+
+#[page("/404")]
+async fn not_found_page() -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html><body>"custom not found"</body></html>
+    }
+}
+
+#[tokio::test]
+async fn exports_pages_and_registered_static_files() {
+    let root = TestDir::new();
+    let source = root.path().join("source.txt");
+    std::fs::write(&source, "static contents").unwrap();
+    let out = root.path().join("dist");
+    let router = Router::builder()
+        .page(home)
+        .page(about)
+        .page(not_found_page)
+        .static_file("/assets/source.txt", &source)
+        .build();
+
+    let report = export(router, ExportConfig::new(&out)).await.unwrap();
+
+    assert_eq!(report.pages(), 3);
+    assert_eq!(report.files(), 1);
+    assert!(
+        std::fs::read_to_string(out.join("index.html"))
+            .unwrap()
+            .contains("export: true")
+    );
+    assert!(
+        std::fs::read_to_string(out.join("about/index.html"))
+            .unwrap()
+            .contains("about")
+    );
+    assert!(
+        std::fs::read_to_string(out.join("404.html"))
+            .unwrap()
+            .contains("custom not found")
+    );
+    assert_eq!(
+        std::fs::read_to_string(out.join("assets/source.txt")).unwrap(),
+        "static contents"
+    );
+}
+
+#[tokio::test]
+async fn html_file_style_writes_flat_page_names_and_a_default_404() {
+    let root = TestDir::new();
+    let out = root.path().join("dist");
+    let router = Router::builder().page(home).page(about).build();
+
+    let report = export(
+        router,
+        ExportConfig::new(&out).path_style(ExportPathStyle::HtmlFile),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.pages(), 3);
+    assert!(out.join("index.html").is_file());
+    assert!(out.join("about.html").is_file());
+    assert!(out.join("404.html").is_file());
+}
+
+#[tokio::test]
+async fn reports_page_and_static_file_output_collisions_before_writing() {
+    let root = TestDir::new();
+    let source = root.path().join("source.txt");
+    std::fs::write(&source, "static contents").unwrap();
+    let out = root.path().join("dist");
+    let router = Router::builder()
+        .page(about)
+        .static_file("/about", &source)
+        .build();
+
+    let error = export(router, ExportConfig::new(&out)).await.unwrap_err();
+
+    assert!(error.to_string().contains("static outputs"));
+    assert!(!out.exists());
+}


### PR DESCRIPTION
## Summary

- Add the `topcoat export` CLI command for building static sites
- Support static asset files and generated values for dynamic route segments
- Add page-level and module-router APIs for static parameter generation
- Document static export usage and route generator behavior

## Testing

Not run (not requested)