### PR TITLE
docs: document dynamic signal creation for runtime collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamic-signals"
+version = "0.4.0"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "examples/asset",
     "examples/context",
     "examples/cookie",
+    "examples/dynamic-signals",
     "examples/font",
     "examples/hello-world",
     "examples/htmx",

--- a/crates/topcoat-view/macro/Cargo.toml
+++ b/crates/topcoat-view/macro/Cargo.toml
@@ -20,7 +20,7 @@ quote.workspace = true
 syn = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
-topcoat = { workspace = true, features = ["view"] }
+topcoat = { workspace = true, features = ["runtime", "view"] }
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/topcoat-view/macro/tests/dynamic_signals.rs
+++ b/crates/topcoat-view/macro/tests/dynamic_signals.rs
@@ -1,0 +1,100 @@
+use topcoat::{
+    context::Cx,
+    runtime::{Signal, SignalDeclaration},
+    view::view,
+};
+
+fn r(v: topcoat::Result) -> String {
+    v.unwrap().render(&Cx::default())
+}
+
+/// Extracts the `id` of every `::topcoat::signal({...})` declaration comment.
+fn declared_ids(html: &str) -> Vec<String> {
+    html.match_indices("::topcoat::signal(")
+        .map(|(at, _)| {
+            let payload = &html[at..];
+            let key = "&quot;id&quot;:&quot;";
+            let start = payload.find(key).expect("declaration payload has an id") + key.len();
+            let end = payload[start..].find("&quot;").expect("id is terminated") + start;
+            payload[start..end].to_string()
+        })
+        .collect()
+}
+
+/// Signals created per element of a runtime collection are declared to the
+/// browser and captured by runtime expressions, like statement-declared ones.
+#[tokio::test]
+async fn runtime_created_signals_declare_and_capture() {
+    let defaults: Vec<f64> = vec![2.0, 4.0, 1.0];
+    let signals: Vec<Signal<f64>> = defaults.iter().map(|&v| Signal::new(v)).collect();
+
+    let cx = &Cx::default();
+    let html = r(view! {
+        cx =>
+        for signal in &signals {
+            (SignalDeclaration::new(signal))
+        }
+
+        for index in 0..defaults.len() {
+            let each = &signals[index];
+            <span>$(each.get())</span>
+        }
+
+        let first = &signals[0];
+        let second = &signals[1];
+        <p>$(first.get() + second.get())</p>
+    });
+
+    // one declaration per collection element, each with a distinct id
+    let ids = declared_ids(&html);
+    assert_eq!(ids.len(), 3);
+    for (i, id) in ids.iter().enumerate() {
+        assert!(!id.is_empty());
+        assert!(!ids[..i].contains(id), "declaration ids are distinct");
+    }
+
+    // every declared signal is hydrated again by a capturing expression
+    for id in &ids {
+        assert!(
+            html.matches(id.as_str()).count() >= 2,
+            "signal {id} is captured by at least one expression"
+        );
+        let capture = format!("cx.hydrate({{&quot;t&quot;:&quot;Signal&quot;,&quot;id&quot;:&quot;{id}&quot;}})");
+        assert!(html.contains(&capture), "signal {id} is hydrated by an expression");
+    }
+
+    // the initial render evaluated the expressions server-side; the values
+    // sit between the expression markers
+    for value in ["2", "4", "1", "6"] {
+        let rendered = format!("-->{value}<!-- ::topcoat::expr::end -->");
+        assert!(html.contains(&rendered), "server-rendered initial value {value}");
+    }
+}
+
+/// The cross-item expression captures BOTH signals it reads, not just one.
+#[tokio::test]
+async fn cross_item_expression_captures_both_signals() {
+    let signals: Vec<Signal<f64>> = vec![Signal::new(1.0), Signal::new(2.0)];
+
+    let cx = &Cx::default();
+    let html = r(view! {
+        cx =>
+        for signal in &signals {
+            (SignalDeclaration::new(signal))
+        }
+
+        let a = &signals[0];
+        let b = &signals[1];
+        <p>$(a.get() * b.get())</p>
+    });
+
+    let ids = declared_ids(&html);
+    assert_eq!(ids.len(), 2);
+    for id in &ids {
+        assert!(
+            html.matches(id.as_str()).count() >= 2,
+            "signal {id} appears in the capturing expression"
+        );
+    }
+    assert!(html.contains("-->2<!-- ::topcoat::expr::end -->"), "product evaluated server-side");
+}

--- a/crates/topcoat-view/macro/tests/mod.rs
+++ b/crates/topcoat-view/macro/tests/mod.rs
@@ -2,5 +2,6 @@ mod attributes;
 mod class;
 mod component;
 mod control_flow;
+mod dynamic_signals;
 mod props;
 mod render;

--- a/crates/topcoat/docs/runtime.md
+++ b/crates/topcoat/docs/runtime.md
@@ -150,6 +150,57 @@ view! {
 # }
 ```
 
+# Dynamic signals
+
+The `signal` statement declares one binding, which fits state the component knows about while it is written. Markup rendered from data — table rows, form builders, filter panels — needs one signal *per item*, and the number of items is only known at run time.
+
+[`Signal`] is an ordinary value, so signals can also be created programmatically: build one per item with [`Signal::new`], and announce each to the browser by rendering a [`SignalDeclaration`] node — the value-level form of what the `signal` statement does:
+
+```rust
+# use topcoat::{Result, view::*, runtime::{Signal, SignalDeclaration}};
+# #[component]
+# async fn example() -> Result {
+let rows: Vec<f64> = vec![2.0, 4.0, 1.0];
+let quantities: Vec<Signal<f64>> = rows.iter().map(|&q| Signal::new(q)).collect();
+
+view! {
+    for signal in &quantities {
+        (SignalDeclaration::new(signal))
+    }
+}
+# }
+```
+
+A runtime expression captures signals by name, so give it one: a view-level `let` binds an element of the collection, and the expression uses it like any declared signal:
+
+```rust
+# use topcoat::{Result, view::*, runtime::{Signal, SignalDeclaration}};
+# #[component]
+# async fn example() -> Result {
+# let rows: Vec<f64> = vec![2.0, 4.0, 1.0];
+# let quantities: Vec<Signal<f64>> = rows.iter().map(|&q| Signal::new(q)).collect();
+view! {
+    for signal in &quantities {
+        (SignalDeclaration::new(signal))
+    }
+
+    for index in 0..rows.len() {
+        let quantity = &quantities[index];
+        <button @click=$(|_e| quantity.set(quantity.get() + 1.0))>"+"</button>
+        " " $(quantity.get())
+    }
+
+    let first = &quantities[0];
+    let second = &quantities[1];
+    <p>"Combined: " $(first.get() + second.get())</p>
+}
+# }
+```
+
+Each item's controls update its own signal, and expressions may combine signals from anywhere in the collection — all in the browser, exactly like statement-declared signals. The [dynamic-signals example](https://github.com/tokio-rs/topcoat/tree/main/examples/dynamic-signals) shows a complete order form built this way.
+
+A declaration must be rendered for every dynamic signal an expression captures; without it the browser has no state to bind. Rendering the declarations before the expressions that use them, as above, is the easiest way to keep that true.
+
 # Procedures
 
 Runtime expressions run in the browser, so they cannot query the database or use Rust beyond the shared vocabulary. When an event handler needs the server, it calls a **procedure**: an async server function invoked from a runtime expression like any other async function:
@@ -210,6 +261,9 @@ view! {
 A shard body is ordinary server code, like any component. The re-renders are served by an API endpoint exposed from your server, so a shard's arguments can be spoofed just like a procedure's and **must not be trusted**. See [`#[shard]`][shard] for the details: how re-renders behave, shard state, and registration.
 
 [`Event`]: struct.Event.html
+[`Signal`]: struct.Signal.html
+[`Signal::new`]: struct.Signal.html#method.new
+[`SignalDeclaration`]: struct.SignalDeclaration.html
 [`expr!`]: macro.expr.html
 [`view!`]: ../view/macro.view.html
 [procedure]: attr.procedure.html

--- a/examples/dynamic-signals/Cargo.toml
+++ b/examples/dynamic-signals/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dynamic-signals"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+topcoat.workspace = true
+
+[lints]
+workspace = true

--- a/examples/dynamic-signals/src/main.rs
+++ b/examples/dynamic-signals/src/main.rs
@@ -1,0 +1,74 @@
+use topcoat::{
+    Result,
+    asset::{AssetBundle, RouterBuilderAssetExt},
+    router::{Router, page},
+    runtime::{Signal, SignalDeclaration},
+    view::view,
+};
+
+#[tokio::main]
+async fn main() {
+    let router = Router::builder()
+        .page(order)
+        .assets(AssetBundle::load().unwrap())
+        .build();
+
+    topcoat::start(router).await.unwrap();
+}
+
+// An order form whose line items come from data, not source code: one signal
+// per item is created with `Signal::new`, announced to the browser with
+// `SignalDeclaration`, and captured by runtime expressions through view-level
+// `let` bindings. Every interaction below runs entirely in the browser.
+#[page("/")]
+async fn order() -> Result {
+    // In a real application these rows would come from a database.
+    let items: Vec<(String, f64)> = vec![
+        ("pencil".to_string(), 2.0),
+        ("notebook".to_string(), 4.0),
+        ("backpack".to_string(), 1.0),
+    ];
+
+    // One signal per row, created at run time.
+    let quantities: Vec<Signal<f64>> = items.iter().map(|(_, q)| Signal::new(*q)).collect();
+    let prices: Vec<f64> = vec![0.5, 3.0, 24.0];
+
+    view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>"Dynamic signals"</title>
+                topcoat::runtime::script()
+            </head>
+            <body>
+                <h1>"Order"</h1>
+
+                // Announce each runtime-created signal to the browser.
+                for signal in &quantities {
+                    (SignalDeclaration::new(signal))
+                }
+
+                for (index, (name, _)) in items.iter().enumerate() {
+                    // A view-level `let` gives the expression a name to capture.
+                    let quantity = &quantities[index];
+                    let price = prices[index];
+                    <div>
+                        <button @click=$(|_e| quantity.set(quantity.get() - 1.0))>"-"</button>
+                        " " $(quantity.get()) " "
+                        <button @click=$(|_e| quantity.set(quantity.get() + 1.0))>"+"</button>
+                        " " (name) " at $" (price)
+                    </div>
+                }
+
+                // An expression may combine any of the runtime-created signals.
+                let pencils = &quantities[0];
+                let notebooks = &quantities[1];
+                let backpacks = &quantities[2];
+                <p>
+                    <b>"Total: $"</b>
+                    $(pencils.get() * 0.5 + notebooks.get() * 3.0 + backpacks.get() * 24.0)
+                </p>
+            </body>
+        </html>
+    }
+}


### PR DESCRIPTION
﻿Documents the value-level path for creating signals dynamically — one per element of a runtime collection — raised in #198.

`Signal::new` and `SignalDeclaration` already compose into this; what was missing is documentation, an example, and tests so the pattern is stable API rather than accidental surface.

- **Guide**: a "Dynamic signals" section in the runtime guide, after bind attributes: creating signals programmatically, announcing them with `SignalDeclaration`, and bridging collection elements into expression captures with view-level `let`. Snippets run as doctests.
- **Example**: `examples/dynamic-signals`, an order form whose line items come from data — per-item steppers and a cross-item total, all client-side.
- **Tests**: `crates/topcoat-view/macro/tests/dynamic_signals.rs` pins the two behaviors the pattern relies on: each runtime-created signal renders a declaration with a distinct id, and capturing expressions hydrate those same ids (including one expression capturing two collection signals).

No behavior changes; `topcoat-view-macro` dev-dependencies gain the `runtime` feature for the new tests.
