### PR TITLE
fix: formatter exiting with code 0 on failed stdin formatting

### DIFF
--- a/crates/topcoat-cli/src/fmt.rs
+++ b/crates/topcoat-cli/src/fmt.rs
@@ -172,6 +172,7 @@ impl FmtCommand {
             Ok(()) => {}
             Err(error) => {
                 eprintln!("{}", style(error).red());
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
fixes #205 