### PR TITLE
fix(asset): improve asset linking system

### DIFF
--- a/crates/topcoat-asset/src/asset.rs
+++ b/crates/topcoat-asset/src/asset.rs
@@ -7,12 +7,13 @@ use topcoat_core::fnv1a;
 
 use crate::{AssetOptions, ConstReader, ConstWriter, Source};
 
+/// Handle to an asset declared via [`asset!`](crate::asset).
 ///
-///
-/// `Asset` values are cheap to copy and store, and stable across runs as
-/// long as the declaring crate name, source file path, and asset path
-/// don't change. Use [`AssetBundle::get`](crate::AssetBundle::get) to
-/// resolve one back to a file.
+/// `Asset` values are cheap to copy and reference the declaration the
+/// [`asset!`](crate::asset) macro embeds into the compiled binary. Rendered
+/// in a view, a handle resolves to the URL of its bundled file;
+/// [`id`](Self::id) recovers the compact [`AssetId`] the file is cataloged
+/// under.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Asset(&'static [u8]);
 
@@ -23,10 +24,17 @@ impl Asset {
         Self(inner)
     }
 
+    /// The compact [`AssetId`] identifying this asset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the handle does not reference a valid encoded declaration;
+    /// handles returned by [`asset!`](crate::asset) are always valid.
     #[must_use]
     pub fn id(&self) -> AssetId {
-        // Prevent the optimizer from removing the raw asset bytes from the
-        // executable if they are used.
+        // The bundler discovers assets by scanning the binary for these
+        // bytes; reading them through black_box stops the optimizer from
+        // folding the load and stripping them out.
         let bytes = core::hint::black_box(self.0);
         let mut reader = ConstReader::new(bytes);
         reader.skip(SCRAMBLED_PREFIX.len());
@@ -47,15 +55,23 @@ impl std::fmt::Debug for Asset {
 }
 
 /// Compact identifier for an asset declared via [`asset!`](crate::asset).
+///
+/// `AssetId` values are cheap to copy and store, and stable across runs as
+/// long as the declaring crate name, source file path, and asset path
+/// don't change. They key the catalogs and manifests a bundle is resolved
+/// through: [`Asset::id`] recovers one at runtime, and
+/// [`AssetBundle::get`](crate::AssetBundle::get) resolves it back to a
+/// file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct AssetId(u64);
 
 impl AssetId {
-    /// Build an `Asset` ID from the same inputs the [`asset!`](crate::asset)
+    /// Build an asset ID from the same inputs the [`asset!`](crate::asset)
     /// macro uses.
     ///
-    /// Prefer calling [`asset!`](crate::asset) directly; this is exposed
+    /// Prefer declaring assets with [`asset!`](crate::asset) and reading
+    /// the ID off the returned handle with [`Asset::id`]; this is exposed
     /// for tooling and tests that need to reconstruct an ID from its parts.
     #[must_use]
     pub const fn new(
@@ -86,7 +102,7 @@ impl AssetId {
 /// An asset declaration recovered from a compiled binary.
 ///
 /// This is what the [`Bundler`](crate::Bundler) sees while scanning: the
-/// [`Asset`] ID together with the path, options, and the crate/source
+/// [`AssetId`] together with the path, options, and the crate/source
 /// context needed to resolve relative paths back to real files.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawAsset {
@@ -98,6 +114,7 @@ pub struct RawAsset {
     options: AssetOptions,
 }
 
+/// Size in bytes of one encoded asset declaration embedded into the binary.
 pub const ENCODED_ASSET_SIZE: usize = 2048;
 
 impl RawAsset {
@@ -242,16 +259,25 @@ fn normalize(path: &Path) -> PathBuf {
     out
 }
 
-/// Declare an asset and get back its [`Asset`] ID.
+/// Declare an asset and get back its [`Asset`] handle.
 ///
 /// The first argument is the asset's source location, either a path or
 /// an `http(s)://` URL. Any remaining arguments configure
 /// [`AssetOptions`] using the same syntax as
 /// [`asset_options!`](crate::asset_options).
 ///
-/// Because the macro expands to a `const` and a `#[used] static`, both
-/// the path and any options must be string literals (or other const
-/// expressions): they cannot be computed at runtime.
+/// Because the macro expands to compile-time items, both the path and any
+/// options must be string literals (or other const expressions): they
+/// cannot be computed at runtime.
+///
+/// # Discovery
+///
+/// The macro embeds the declaration into the compiled binary, where the
+/// [`Bundler`](crate::Bundler) finds it by scanning. The embedded data is
+/// kept in the binary through the returned [`Asset`] handle: an asset is
+/// bundled only while some code path uses its handle. A declaration whose
+/// handle is never used can be optimized out of the binary, and the
+/// bundler then no longer sees it.
 ///
 /// # Path resolution
 ///
@@ -287,9 +313,10 @@ fn normalize(path: &Path) -> PathBuf {
 ///
 /// # Returns
 ///
-/// A `const` [`Asset`] ID. The ID is stable across builds as long as the
-/// declaring crate, source file, and path string don't change: renaming
-/// the file on disk or changing options does *not* change the ID.
+/// A `const`-compatible [`Asset`] handle. Its [`AssetId`], read with
+/// [`Asset::id`], is stable across builds as long as the declaring crate,
+/// source file, and path string don't change: renaming the file on disk
+/// or changing options does *not* change the ID.
 ///
 /// # Examples
 ///

--- a/crates/topcoat-asset/src/asset.rs
+++ b/crates/topcoat-asset/src/asset.rs
@@ -7,17 +7,51 @@ use topcoat_core::fnv1a;
 
 use crate::{AssetOptions, ConstReader, ConstWriter, Source};
 
-/// Compact identifier for an asset declared via [`asset!`](crate::asset).
+///
 ///
 /// `Asset` values are cheap to copy and store, and stable across runs as
 /// long as the declaring crate name, source file path, and asset path
 /// don't change. Use [`AssetBundle::get`](crate::AssetBundle::get) to
 /// resolve one back to a file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Asset(u64);
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Asset(&'static [u8]);
 
 impl Asset {
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn new(inner: &'static [u8]) -> Self {
+        Self(inner)
+    }
+
+    #[must_use]
+    pub fn id(&self) -> AssetId {
+        // Prevent the optimizer from removing the raw asset bytes from the
+        // executable if they are used.
+        let bytes = core::hint::black_box(self.0);
+        let mut reader = ConstReader::new(bytes);
+        reader.skip(SCRAMBLED_PREFIX.len());
+        AssetId(
+            reader
+                .read_u64_le()
+                .expect("raw asset does not have a valid ID"),
+        )
+    }
+}
+
+impl std::fmt::Debug for Asset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(Asset))
+            .field("id", &self.id())
+            .finish()
+    }
+}
+
+/// Compact identifier for an asset declared via [`asset!`](crate::asset).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AssetId(u64);
+
+impl AssetId {
     /// Build an `Asset` ID from the same inputs the [`asset!`](crate::asset)
     /// macro uses.
     ///
@@ -56,7 +90,7 @@ impl Asset {
 /// context needed to resolve relative paths back to real files.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawAsset {
-    id: Asset,
+    id: AssetId,
     path: String,
     crate_name: String,
     manifest_dir: String,
@@ -69,7 +103,7 @@ pub const ENCODED_ASSET_SIZE: usize = 2048;
 impl RawAsset {
     #[must_use]
     pub const fn encode(
-        id: Asset,
+        id: AssetId,
         path: &str,
         crate_name: &str,
         manifest_dir: &str,
@@ -93,7 +127,7 @@ impl RawAsset {
         let mut r = ConstReader::new(buffer);
         r.skip(asset_prefix().len())?;
         Some(Self {
-            id: Asset(r.read_u64_le()?),
+            id: AssetId(r.read_u64_le()?),
             path: r.read_str()?.to_owned(),
             crate_name: r.read_str()?.to_owned(),
             manifest_dir: r.read_str()?.to_owned(),
@@ -119,7 +153,7 @@ impl RawAsset {
     }
 
     #[must_use]
-    pub fn id(&self) -> Asset {
+    pub fn id(&self) -> AssetId {
         self.id
     }
 
@@ -283,9 +317,8 @@ macro_rules! asset {
         const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
         const SOURCE_FILE: &str = file!();
         const OPTIONS: $crate::AssetOptions = $crate::asset_options!($($($ao)*)?);
-        const ID: $crate::Asset = $crate::Asset::new(CRATE_NAME, SOURCE_FILE, PATH, &OPTIONS);
+        const ID: $crate::AssetId = $crate::AssetId::new(CRATE_NAME, SOURCE_FILE, PATH, &OPTIONS);
 
-        #[used]
         pub static ENCODED_ASSET: [u8; $crate::ENCODED_ASSET_SIZE] = $crate::RawAsset::encode(
             ID,
             PATH,
@@ -295,7 +328,7 @@ macro_rules! asset {
             &OPTIONS,
         );
 
-        ID
+        $crate::Asset::new(ENCODED_ASSET.as_slice())
     }};
 }
 

--- a/crates/topcoat-asset/src/bundle.rs
+++ b/crates/topcoat-asset/src/bundle.rs
@@ -4,10 +4,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{Asset, AssetCatalog, AssetId, BundledAsset, MANIFEST_NAME, Manifest};
+use crate::{AssetCatalog, AssetId, BundledAsset, MANIFEST_NAME, Manifest};
 
 /// An asset bundle on disk: a directory of bundled files plus the
-/// [`AssetCatalog`] mapping [`Asset`] IDs to them.
+/// [`AssetCatalog`] mapping [`AssetId`]s to them.
 ///
 /// Built by the [`Bundler`](crate::Bundler) and loaded at runtime via
 /// [`AssetBundle::load`] or [`AssetBundle::load_dir`].
@@ -115,13 +115,13 @@ impl AssetBundle {
         &self.dir
     }
 
-    /// The catalog mapping [`Asset`] IDs to the files in the bundle directory.
+    /// The catalog mapping [`AssetId`]s to the files in the bundle directory.
     #[must_use]
     pub fn catalog(&self) -> &AssetCatalog {
         &self.catalog
     }
 
-    /// Look up the bundled file for an [`Asset`] ID.
+    /// Look up the bundled file for an [`AssetId`].
     ///
     /// The returned entry names the file; its on-disk location is that name
     /// under [`dir`](AssetBundle::dir).

--- a/crates/topcoat-asset/src/bundle.rs
+++ b/crates/topcoat-asset/src/bundle.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{Asset, AssetCatalog, BundledAsset, MANIFEST_NAME, Manifest};
+use crate::{Asset, AssetCatalog, AssetId, BundledAsset, MANIFEST_NAME, Manifest};
 
 /// An asset bundle on disk: a directory of bundled files plus the
 /// [`AssetCatalog`] mapping [`Asset`] IDs to them.
@@ -126,7 +126,7 @@ impl AssetBundle {
     /// The returned entry names the file; its on-disk location is that name
     /// under [`dir`](AssetBundle::dir).
     #[must_use]
-    pub fn get(&self, id: Asset) -> Option<&BundledAsset> {
+    pub fn get(&self, id: AssetId) -> Option<&BundledAsset> {
         self.catalog.get(id)
     }
 }

--- a/crates/topcoat-asset/src/bundler.rs
+++ b/crates/topcoat-asset/src/bundler.rs
@@ -15,8 +15,7 @@ use std::{
 use sha2::{Digest, Sha256};
 
 use crate::{
-    Asset, AssetError, AssetId, MANIFEST_NAME, MANIFEST_VERSION, Manifest, ManifestEntry, RawAsset,
-    Source,
+    AssetError, AssetId, MANIFEST_NAME, MANIFEST_VERSION, Manifest, ManifestEntry, RawAsset, Source,
 };
 
 use cache::Cache;
@@ -354,11 +353,11 @@ mod tests {
         }
 
         /// Write `contents` to `name` and declare it as an asset.
-        fn declare(&mut self, name: &str, contents: &str) -> Asset {
+        fn declare(&mut self, name: &str, contents: &str) -> AssetId {
             self.declare_with(name, contents, &AssetOptions::NONE)
         }
 
-        fn declare_with(&mut self, name: &str, contents: &str, options: &AssetOptions) -> Asset {
+        fn declare_with(&mut self, name: &str, contents: &str, options: &AssetOptions) -> AssetId {
             let src = self.root.join("src");
             fs::create_dir_all(&src).unwrap();
             let path = src.join(name);
@@ -367,14 +366,14 @@ mod tests {
         }
 
         /// Declare an asset without creating the file it points at.
-        fn declare_missing(&mut self, name: &str) -> Asset {
+        fn declare_missing(&mut self, name: &str) -> AssetId {
             let path = self.root.join("src").join(name);
             let path = path.to_str().unwrap().to_owned();
             self.declare_path(&path, &AssetOptions::NONE)
         }
 
-        fn declare_path(&mut self, path: &str, options: &AssetOptions) -> Asset {
-            let id = Asset::new("test", "src/lib.rs", path, options);
+        fn declare_path(&mut self, path: &str, options: &AssetOptions) -> AssetId {
+            let id = AssetId::new("test", "src/lib.rs", path, options);
             self.binary.extend_from_slice(&RawAsset::encode(
                 id,
                 path,

--- a/crates/topcoat-asset/src/bundler.rs
+++ b/crates/topcoat-asset/src/bundler.rs
@@ -15,7 +15,8 @@ use std::{
 use sha2::{Digest, Sha256};
 
 use crate::{
-    Asset, AssetError, MANIFEST_NAME, MANIFEST_VERSION, Manifest, ManifestEntry, RawAsset, Source,
+    Asset, AssetError, AssetId, MANIFEST_NAME, MANIFEST_VERSION, Manifest, ManifestEntry, RawAsset,
+    Source,
 };
 
 use cache::Cache;
@@ -160,7 +161,7 @@ impl Bundler {
     fn prepare_all(
         &self,
         assets: &[RawAsset],
-        existing: &HashMap<Asset, ManifestEntry>,
+        existing: &HashMap<AssetId, ManifestEntry>,
         out_dir: &Path,
     ) -> Vec<Result<Prepared, BundleError>> {
         let workers = self.parallelism.min(assets.len());
@@ -203,7 +204,7 @@ impl Bundler {
     fn prepare(
         &self,
         asset: &RawAsset,
-        existing: &HashMap<Asset, ManifestEntry>,
+        existing: &HashMap<AssetId, ManifestEntry>,
         out_dir: &Path,
     ) -> Result<Prepared, BundleError> {
         let source = asset.source();

--- a/crates/topcoat-asset/src/bundler/event.rs
+++ b/crates/topcoat-asset/src/bundler/event.rs
@@ -186,7 +186,7 @@ mod tests {
         );
         assert_eq!(
             BundleEvent::Bundled {
-                id: Asset::new("test", "src/lib.rs", "app.css", &crate::AssetOptions::NONE),
+                id: AssetId::new("test", "src/lib.rs", "app.css", &crate::AssetOptions::NONE),
                 file: "app-0123456789abcdef.css".to_owned(),
                 bytes: 12,
             }

--- a/crates/topcoat-asset/src/bundler/event.rs
+++ b/crates/topcoat-asset/src/bundler/event.rs
@@ -2,7 +2,7 @@ use std::{fmt, path::PathBuf, sync::Arc};
 
 use http::Uri;
 
-use crate::Asset;
+use crate::AssetId;
 
 /// A step the [`Bundler`](super::Bundler) took while syncing assets.
 ///
@@ -23,13 +23,13 @@ pub enum BundleEvent {
     Downloaded { uri: Uri, path: PathBuf, bytes: u64 },
     /// An asset was written into the bundle directory.
     Bundled {
-        id: Asset,
+        id: AssetId,
         file: String,
         bytes: usize,
     },
     /// An asset was already in the bundle directory with the same
     /// contents, so it was left alone.
-    Unchanged { id: Asset, file: String },
+    Unchanged { id: AssetId, file: String },
     /// A file that is no longer referenced was deleted from the bundle
     /// directory.
     Removed { file: String },

--- a/crates/topcoat-asset/src/catalog.rs
+++ b/crates/topcoat-asset/src/catalog.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{Asset, AssetBundle, Manifest};
+use crate::{AssetBundle, AssetId, Manifest};
 
 /// A single entry inside an [`AssetCatalog`].
 #[derive(Debug, Clone)]
@@ -37,13 +37,13 @@ impl BundledAsset {
 /// into the binary on targets without filesystem access, like WebAssembly).
 #[derive(Debug, Default, Clone)]
 pub struct AssetCatalog {
-    bundled_assets: HashMap<Asset, BundledAsset>,
+    bundled_assets: HashMap<AssetId, BundledAsset>,
 }
 
 impl AssetCatalog {
     /// Look up the bundled asset for an [`Asset`] ID.
     #[must_use]
-    pub fn get(&self, id: Asset) -> Option<&BundledAsset> {
+    pub fn get(&self, id: AssetId) -> Option<&BundledAsset> {
         self.bundled_assets.get(&id)
     }
 

--- a/crates/topcoat-asset/src/catalog.rs
+++ b/crates/topcoat-asset/src/catalog.rs
@@ -24,7 +24,7 @@ impl BundledAsset {
     }
 }
 
-/// The mapping from [`Asset`] IDs to their bundled filenames and content
+/// The mapping from [`AssetId`]s to their bundled filenames and content
 /// types.
 ///
 /// This is the part of an asset bundle needed to resolve asset URLs, without
@@ -41,7 +41,7 @@ pub struct AssetCatalog {
 }
 
 impl AssetCatalog {
-    /// Look up the bundled asset for an [`Asset`] ID.
+    /// Look up the bundled asset for an [`AssetId`].
     #[must_use]
     pub fn get(&self, id: AssetId) -> Option<&BundledAsset> {
         self.bundled_assets.get(&id)

--- a/crates/topcoat-asset/src/config.rs
+++ b/crates/topcoat-asset/src/config.rs
@@ -12,7 +12,7 @@ use topcoat_core::context::{Cx, app_context};
 use crate::AssetBundle;
 #[cfg(feature = "serve")]
 use crate::serve::ASSET_ROUTE_PREFIX;
-use crate::{Asset, AssetCatalog, AssetId, BundledAsset};
+use crate::{Asset, AssetCatalog, BundledAsset};
 
 /// Where the bundled assets are hosted.
 #[derive(Debug, Clone)]
@@ -96,13 +96,14 @@ impl AssetConfig {
         }
     }
 
-    /// The catalog mapping [`Asset`] IDs to their bundled files.
+    /// The catalog mapping [`AssetId`](crate::AssetId)s to their bundled
+    /// files.
     #[must_use]
     pub fn catalog(&self) -> &AssetCatalog {
         &self.catalog
     }
 
-    /// Look up the bundled file for an [`Asset`] ID in the catalog.
+    /// Look up the bundled file for an [`Asset`] in the catalog.
     #[must_use]
     pub fn get(&self, asset: Asset) -> Option<&BundledAsset> {
         self.catalog.get(asset.id())
@@ -173,7 +174,7 @@ pub fn asset_config(cx: &Cx) -> &AssetConfig {
     app_context(cx)
 }
 
-/// Resolves an [`Asset`] ID to its [`BundledAsset`] in the context's
+/// Resolves an [`Asset`] to its [`BundledAsset`] in the context's
 /// registered [`AssetConfig`].
 ///
 /// # Panics
@@ -191,7 +192,7 @@ pub fn bundled_asset(cx: &Cx, asset: Asset) -> &BundledAsset {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Manifest;
+    use crate::{AssetId, AssetOptions, ENCODED_ASSET_SIZE, Manifest, RawAsset};
 
     #[test]
     fn hosted_at_trims_trailing_slashes() {
@@ -203,19 +204,25 @@ mod tests {
 
     #[test]
     fn resolves_urls_against_the_base_url() {
-        let manifest = Manifest::parse(
+        const OPTIONS: AssetOptions = AssetOptions::NONE;
+        const ID: AssetId = AssetId::new("app", "src/lib.rs", "logo.png", &OPTIONS);
+        static ENCODED: [u8; ENCODED_ASSET_SIZE] =
+            RawAsset::encode(ID, "logo.png", "app", "/app", "src/lib.rs", &OPTIONS);
+        let asset = Asset::new(&ENCODED);
+
+        let manifest = Manifest::parse(&format!(
             r#"
 version = 1
 
 [[assets]]
-id = 42
+id = {}
 file = "logo-1a2b3c4d5e6f7a8b.png"
 hash = "0"
 content_type = "image/png"
 "#,
-        )
+            ID.as_u64()
+        ))
         .unwrap();
-        let asset = manifest.assets[0].id;
 
         let config = AssetConfig::hosted_at("https://cdn.example.com/assets", manifest);
 

--- a/crates/topcoat-asset/src/config.rs
+++ b/crates/topcoat-asset/src/config.rs
@@ -12,7 +12,7 @@ use topcoat_core::context::{Cx, app_context};
 use crate::AssetBundle;
 #[cfg(feature = "serve")]
 use crate::serve::ASSET_ROUTE_PREFIX;
-use crate::{Asset, AssetCatalog, BundledAsset};
+use crate::{Asset, AssetCatalog, AssetId, BundledAsset};
 
 /// Where the bundled assets are hosted.
 #[derive(Debug, Clone)]
@@ -104,8 +104,8 @@ impl AssetConfig {
 
     /// Look up the bundled file for an [`Asset`] ID in the catalog.
     #[must_use]
-    pub fn get(&self, id: Asset) -> Option<&BundledAsset> {
-        self.catalog.get(id)
+    pub fn get(&self, asset: Asset) -> Option<&BundledAsset> {
+        self.catalog.get(asset.id())
     }
 
     /// The base URL asset URLs are formed against: the internal asset route

--- a/crates/topcoat-asset/src/manifest.rs
+++ b/crates/topcoat-asset/src/manifest.rs
@@ -2,7 +2,7 @@ use std::{fs, io, path::Path};
 
 use serde::{Deserialize, Serialize};
 
-use crate::Asset;
+use crate::AssetId;
 
 /// Filename of the manifest within a bundle directory.
 pub const MANIFEST_NAME: &str = "manifest.toml";
@@ -67,7 +67,7 @@ impl Manifest {
 /// hex digest of the file's contents, and the `Content-Type` it is served with.
 #[derive(Serialize, Deserialize)]
 pub struct ManifestEntry {
-    pub id: Asset,
+    pub id: AssetId,
     pub file: String,
     pub hash: String,
     pub content_type: String,

--- a/crates/topcoat-asset/src/manifest.rs
+++ b/crates/topcoat-asset/src/manifest.rs
@@ -9,7 +9,7 @@ pub const MANIFEST_NAME: &str = "manifest.toml";
 /// Current on-disk manifest format version.
 pub const MANIFEST_VERSION: u32 = 1;
 
-/// On-disk index of a bundle directory, mapping [`Asset`] IDs to files.
+/// On-disk index of a bundle directory, mapping [`AssetId`]s to files.
 #[derive(Serialize, Deserialize)]
 pub struct Manifest {
     pub version: u32,

--- a/crates/topcoat-cli/src/common/cargo/build.rs
+++ b/crates/topcoat-cli/src/common/cargo/build.rs
@@ -119,15 +119,6 @@ impl BuildOpts {
                 cmd.env_remove(&k);
             }
         }
-        // MSVC's linker strips the `#[used]` statics that carry the embedded
-        // asset declarations (see `topcoat-asset`), so on Windows the bundler
-        // finds no assets and every page panics resolving them. /OPT:NOREF
-        // keeps unreferenced data alive. RUSTFLAGS was stripped above, so
-        // this sets a deterministic value rather than appending to user
-        // state.
-        if cfg!(all(windows, target_env = "msvc")) {
-            cmd.env("RUSTFLAGS", "-C link-arg=/OPT:NOREF");
-        }
         cmd.args(["build", "--message-format=json-diagnostic-rendered-ansi"]);
         cmd.env("CARGO_TERM_PROGRESS_WHEN", "always");
         cmd.env("CARGO_TERM_PROGRESS_WIDTH", "80");

--- a/crates/topcoat-font/src/source.rs
+++ b/crates/topcoat-font/src/source.rs
@@ -86,9 +86,10 @@ impl FontSourceUrl {
                 fnv1a::hash_continue(fnv1a::hash_continue(h, b"s"), inner.as_bytes())
             }
             #[cfg(feature = "asset")]
-            Self::Asset(inner) => {
-                fnv1a::hash_continue(fnv1a::hash_continue(h, b"a"), &inner.as_u64().to_le_bytes())
-            }
+            Self::Asset(inner) => fnv1a::hash_continue(
+                fnv1a::hash_continue(h, b"a"),
+                &inner.id().as_u64().to_le_bytes(),
+            ),
         }
     }
 }

--- a/crates/topcoat/docs/asset.md
+++ b/crates/topcoat/docs/asset.md
@@ -1,4 +1,4 @@
-Topcoat assets are declared from Rust code with [`asset!`](asset). The macro returns a small [`Asset`] ID and embeds the declaration into the compiled binary. After building your application, Topcoat can scan the binary, copy or download every declared file into an asset bundle directory, and serve those bundled files from the router.
+Topcoat assets are declared from Rust code with [`asset!`](asset). The macro returns a small [`Asset`] handle and embeds the declaration into the compiled binary. After building your application, Topcoat can scan the binary, copy or download every declared file into an asset bundle directory, and serve those bundled files from the router.
 
 # Declaring assets
 
@@ -44,6 +44,8 @@ When an [`Asset`] appears inside [`view!`](crate::view::view), Topcoat renders i
 ```
 
 The hash in the filename is based on the file contents, so URLs are safe to cache aggressively.
+
+The bundler finds declarations by scanning the compiled binary. The embedded declaration is kept in the binary through the returned [`Asset`] handle, so an asset only ends up in the bundle while some code path uses its handle: a declaration whose handle is never used can be optimized out of the binary, and the bundler then skips it.
 
 # Loading the bundle
 


### PR DESCRIPTION
Assets now get a chance to be removed from the bundle entirely if they are unused, while at the same time being more robust if they _are_ used (e.g. on Windows with MSVC)