### PR TITLE
docs(router): add design for page URL generation

### DIFF
--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -255,14 +255,6 @@ Reading would special-case `String` the way it special-cases `str` today, so ser
 
 One trait impl on the marker. The risk is two ways to write a link, with the shorter one breaking the moment the page gains a parameter.
 
-**Read a parameter list in attribute position.** `view!` could treat a parenthesized list in `href` or `action` position as a page plus its parameters.
-
-```rust
-<a href=(post, PostId(42))>"Post"</a>
-```
-
-Shortest form, no import. It also gives `(a, b)` a meaning in two attributes that it has nowhere else in `view!`, where parenthesized values are plain Rust.
-
 **Choose the attribute from the element.** A `page` attribute could expand to `href` on an anchor and `action` on a form.
 
 ```rust
@@ -270,7 +262,7 @@ Shortest form, no import. It also gives `(a, b)` a meaning in two attributes tha
 <form page=(create) method="post">
 ```
 
-Removes the last duplication, but invents a non-HTML attribute and hides which one it emits.
+Overloading `href` instead is not available. `AttributeValueViewParts` is implemented for tuples, so a parenthesized list in attribute position already means "render these in order", and `href=(post, PostId(42))` has a meaning today. A new attribute name sidesteps that, at the cost of inventing one that is not HTML and hiding which attribute it produces.
 
 **Check parameters at compile time.** Giving `module_router!` the route tree changes what the macro knows. It can pull in each module body itself, thread a module's parameters down to its children, and generate a typed `href` per page.
 

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -21,18 +21,19 @@ href!(post, PostId(42))                       // "/posts/42"
 href!(user, OrganizationId(9), UserId(41))    // "/organizations/9/users/41"
 ```
 
-Path parameters are the [`#[path_param]`](../crates/topcoat-router/macro/docs/path_param.md) newtypes the page already reads from the request, so one type serves both directions.
+Path parameters are the [`path_param!`](../crates/topcoat-router/macro/docs/path_param.md) newtypes the page already reads from the request, so one type serves both directions.
 
 ```rust
 // src/app/posts/post_id.rs
-#[path_param(error = not_found)]
-pub struct PostId(pub u64);
+path_param!(post_id: u64, error = not_found);
 
 #[page]
 async fn post(cx: &Cx) -> Result {
     view! { <h1>"Post " (path_param::<PostId>(cx)?)</h1> }
 }
 ```
+
+`path_param!` declares the parameter by its URL name and generates the type, `PostId` here. It replaces today's `#[path_param]` attribute, which cannot declare the generic that a string parameter needs to be constructible. This document assumes that change; its design lands next.
 
 ```rust
 // src/app/posts.rs
@@ -110,20 +111,20 @@ href!(document, DocPath("guides/getting-started"))    // "/docs/guides/getting-s
 
 An empty value leaves nothing between the slashes, and the `/posts/` it produces no longer matches the route it was built from, so it is rejected when the URL is built.
 
-A parameter the page reads as a string has to be constructible from a string. `#[path_param]` declares those over `str` today, which is unsized and so cannot be constructed at all, so an unparsed parameter takes its inner type as a type parameter instead.
+A parameter declared without a type is unparsed: the page reads its segment as a string. Reading alone could hold that string as an unsized `str`, but a link has to construct the value, so the generated type is generic over anything that borrows as one.
 
 ```rust
-pub struct Slug<T: AsRef<str>>(pub T);
+path_param!(slug);      // pub struct Slug<T: AsRef<str>>(pub T);
 
 href!(show, Slug("my-first-post"))    // &str
 href!(show, Slug(post.slug))          // String
 ```
 
-Reading is unchanged: `path_param::<Slug>(cx)` still borrows the decoded segment out of the request and allocates nothing. Declaring a generic tuple struct through an attribute macro reads poorly, so the declaration form belongs with [`path_param`](../crates/topcoat-router/macro/docs/path_param.md) rather than here.
+Reading is unaffected: `path_param::<Slug>(cx)` borrows the decoded segment out of the request, allocating nothing. The allocation, if there is one, moves to the link, where the value usually came out of a `String` already.
 
 Group segments never appear in a served URL and take no value, so a page under `app::_marketing::pricing` is reached with `href!(pricing)`.
 
-Linking to a page from outside its own module needs its parameter type, so declare the type and its field `pub`.
+Linking to a page from outside its own module needs its parameter type, so `path_param!` generates a public type with a public field.
 
 # When mistakes are caught
 

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -50,64 +50,76 @@ async fn index() -> Result {
 }
 ```
 
-`href!` rewrites to a method on the page, passing the parameters as a tuple.
+`href!` expands to `Href::new`, passing the page marker that `#[page]` already generates and the parameters as a tuple.
 
 ```rust
 href!(user, OrganizationId(9), UserId(41))
-user.href((OrganizationId(9), UserId(41)))
+Href::new(user, (OrganizationId(9), UserId(41)))
 ```
 
-The method takes exactly one argument because Rust has no variadic functions, and one argument holding any number of parameters means a tuple. Zero and one read worst.
+The constructor takes a single argument for the parameters because Rust has no variadic functions, so any number of them means a tuple. Zero and one read worst, and zero is what most pages take.
 
 ```rust
-about.href(())
-post.href((PostId(42),))
+Href::new(about, ())
+Href::new(post, (PostId(42),))
 ```
 
-Most pages have no path parameters, so `about.href(())` is the shape a reader meets most often. `href!` spreads the parameters into that tuple, keeping it out of every link.
+`href!` spreads its arguments into that tuple, keeping it out of every link.
 
-The tuple stays the real API. It gives every page one calling convention, and leaves a method for helpers that build URLs generically. Everything below applies to both forms.
+`Href::new` stays the real API. It keeps URL building on `Href` instead of a method generated onto every page, and it lets a helper build a URL for a page it takes as an argument. Everything below applies to both forms.
 
 # What href! returns
 
 An `Href`, not a `String`. Resolving one needs the route table and the base URL, both of which live on the request context, so an `Href` describes a URL and builds it later. That is also why it cannot implement `Display`.
 
-A view resolves it for you.
+A view resolves it for you. `Href` implements `AttributeValueViewParts` and `NodeViewParts`, emitting each part of the URL as its own `ViewPart` the way `Class<T>` does, so rendering writes the segments into the response without building a string first.
 
 ```rust
 <a href=(href!(post, PostId(42)))>"Post"</a>
 ```
 
-Elsewhere it takes a context.
+A page marker renders as its own URL, which covers the parameterless links that make up most of a site.
+
+```rust
+<a href=(about)>"About"</a>
+```
+
+That goes through `Href::new(about, ())`, so a page that later gains a path parameter fails the way any link missing a parameter does.
+
+Elsewhere an `Href` takes a context.
 
 ```rust
 href!(post, PostId(42)).resolve(cx)      // "/posts/42"
 ```
 
-`query` and `fragment` extend an `Href` before it resolves, and the redirect constructors take one as is. Comments below show what a URL resolves to.
+`query`, `fragment`, and `absolute` each return an `Href`, so they chain onto one before it resolves. Comments below show what a URL resolves to.
 
 # Parameter values
 
 Each value is percent-encoded into its segment, so a title or an address containing `/`, `?`, or `#` stays inside the segment it belongs to.
 
 ```rust
-href!(show, Slug::new("hello/world"))     // "/posts/hello%2Fworld"
+href!(show, Slug("hello/world"))     // "/posts/hello%2Fworld"
 ```
 
 A catch-all segment (`{*path}`) stands for several segments, so it is the one case where `/` is preserved.
 
 ```rust
-href!(document, DocPath::new("guides/getting-started"))    // "/docs/guides/getting-started"
+href!(document, DocPath("guides/getting-started"))    // "/docs/guides/getting-started"
 ```
 
-A parameter declared over `str` is unsized and cannot be built with the tuple-struct constructor, so `#[path_param]` gives those types a `new` constructor that borrows the string.
+An empty value leaves nothing between the slashes, and the `/posts/` it produces no longer matches the route it was built from, so it is rejected when the URL is built.
+
+A parameter the page reads as a string has to be constructible from a string. `#[path_param]` declares those over `str` today, which is unsized and so cannot be constructed at all, so an unparsed parameter takes its inner type as a type parameter instead.
 
 ```rust
-#[path_param]
-pub struct Slug(str);
+pub struct Slug<T: AsRef<str>>(pub T);
 
-href!(show, Slug::new("my-first-post"))
+href!(show, Slug("my-first-post"))    // &str
+href!(show, Slug(post.slug))          // String
 ```
+
+Reading is unchanged: `path_param::<Slug>(cx)` still borrows the decoded segment out of the request and allocates nothing. Declaring a generic tuple struct through an attribute macro reads poorly, so the declaration form belongs with [`path_param`](../crates/topcoat-router/macro/docs/path_param.md) rather than here.
 
 Group segments never appear in a served URL and take no value, so a page under `app::_marketing::pricing` is reached with `href!(pricing)`.
 
@@ -165,29 +177,37 @@ href!(post, PostId(42)).fragment("comments")      // "/posts/42#comments"
 
 # Absolute URLs
 
-`href!` produces a root-relative URL, which is what a link inside the site needs. Content that leaves the site, such as mail, feeds, and sitemaps, needs the absolute form. `url!` takes the same arguments and resolves against the [base URL](../crates/topcoat/docs/context.md) registered on the router.
+An `Href` renders root-relative, which is what a link inside the site needs. Content that leaves the site needs the absolute form, so a [mail](../crates/topcoat/docs/mail.md) body renders every `Href` absolute. `absolute` and `relative` override that default for one link, which a feed or a sitemap served as a page needs.
+
+```rust
+href!(post, PostId(42)).absolute()      // "https://example.com/posts/42"
+```
+
+The scheme and host come from the [base URL](../crates/topcoat/docs/context.md) registered on the router.
 
 ```rust
 let router = Router::builder().base_url("https://example.com").build();
-
-url!(post, PostId(42))        // "https://example.com/posts/42"
 ```
 
-An application mounted under a path prefix registers it as part of that base URL, as in `https://example.com/app`. The proxy strips the prefix before the router matches, so the router only ever sees `/posts/42` while the browser needs `/app/posts/42`. Relative URLs carry the prefix for that reason, so `href!` reads the base URL too.
+A router without one falls back to the address it is serving on, so links resolve during development without configuring anything.
+
+An application mounted under a path prefix registers it as part of that base URL, as in `https://example.com/app`. The proxy strips the prefix before the router matches, so the router only ever sees `/posts/42` while the browser needs `/app/posts/42`. Relative URLs carry the prefix for that reason, so every `Href` reads the base URL.
 
 # Redirecting
 
 A Post/Redirect/Get handler names its destination the way a link does.
 
 ```rust
-use topcoat::router::error::see_other;
+use topcoat::router::error::{SeeOther, see_other};
 
-#[page(POST)]
-async fn create(Form(input): Form<NewPost>) -> Result {
+#[route(POST "/posts")]
+async fn create(Form(input): Form<NewPost>) -> Result<SeeOther> {
     let id = insert(input).await?;
-    Err(see_other(href!(post, PostId(id))).into())
+    Ok(see_other(href!(post, PostId(id))))
 }
 ```
+
+`see_other` takes an `Href` and resolves it while building the response, which is where the context is available.
 
 # Resolving outside a view
 
@@ -196,7 +216,7 @@ A handler already holds the context `resolve` needs.
 ```rust
 #[route(GET "/feed.xml")]
 async fn feed(cx: &Cx) -> Result<String> {
-    Ok(url!(post, PostId(42)).resolve(cx))
+    Ok(href!(post, PostId(42)).absolute().resolve(cx))
 }
 ```
 
@@ -204,7 +224,7 @@ Work that runs outside a request, such as a background job or a sitemap task, ta
 
 ```rust
 let cx = router.cx();
-let url = url!(post, PostId(42)).resolve(&cx);
+let url = href!(post, PostId(42)).absolute().resolve(&cx);
 ```
 
 Tests use the same method. A module-derived URL resolves through the route table, so a context built by hand covers only pages with an explicit path.
@@ -227,44 +247,25 @@ async fn publish(cx: &Cx) -> Result<&'static str> {
 href!(publish, PostId(42))        // "/api/posts/42/publish"
 ```
 
-A `#[layout]` has no URL of its own, so it gets neither.
+A `#[layout]` has no URL of its own, so it cannot be linked to.
 
 # Other ideas
 
 These are worth considering but not settled.
 
-**Give string parameters a sized type.** A `str` parameter is unsized, so it can be named but never held: not constructed, returned, stored, or collected. `Slug::new` above exists only to work around that.
+**Take the query string and fragment as macro arguments.** A named argument would keep a whole URL in one call rather than splitting it between a macro and a method.
 
 ```rust
-#[path_param]
-pub struct Slug(pub String);
-
-path_param::<Slug>(cx)                  // still &str, still no allocation
-href!(show, Slug(post.slug.clone()))
+href!(index, query: PostsQuery { page: 2, q: "rust" })
+href!(index, query: { "page": 2 })
+href!(post, PostId(42), fragment: "comments")
 ```
 
-Reading would special-case `String` the way it special-cases `str` today, so serving a request still allocates nothing. The allocation moves to URL building, where the value usually came out of a `String` anyway. `Cow<'static, str>` avoids it for literals at the cost of a noisier type.
+`query: PostsQuery { .. }` names the type but is not a struct literal, since a link sets the fields it cares about and leaves the rest out. It would expand the way Toasty's `create!` does, against a builder generated by `#[query_params]`. The methods stay either way, so this is sugar over them.
 
-`String` then reads identically to `str` and does more, so the question is whether `str` stays at all.
+**Assertions for links in tests.** An assertion that takes an `Href` could resolve it against the router itself, and compare part by part rather than as one string, so a failure names the segment or query parameter that differs.
 
-**Render a page marker directly.** A page with no parameters could render as its own URL.
-
-```rust
-<a href=(about)>"About"</a>
-```
-
-One trait impl on the marker. The risk is two ways to write a link, with the shorter one breaking the moment the page gains a parameter.
-
-**Choose the attribute from the element.** A `page` attribute could expand to `href` on an anchor and `action` on a form.
-
-```rust
-<a page=(post, PostId(42))>"Post"</a>
-<form page=(create) method="post">
-```
-
-Overloading `href` instead is not available. `AttributeValueViewParts` is implemented for tuples, so a parenthesized list in attribute position already means "render these in order", and `href=(post, PostId(42))` has a meaning today. A new attribute name sidesteps that, at the cost of inventing one that is not HTML and hiding which attribute it produces.
-
-**Check parameters at compile time.** Giving `module_router!` the route tree changes what the macro knows. It can pull in each module body itself, thread a module's parameters down to its children, and generate a typed `href` per page.
+**Check parameters at compile time.** Giving `module_router!` the route tree changes what the macro knows. It can pull in each module body itself, thread a module's parameters down to its children, and generate a typed constructor per page.
 
 ```rust
 module_router! {
@@ -276,8 +277,8 @@ module_router! {
 Every page then takes its parameters directly.
 
 ```rust
-post.href(PostId(42))       // one argument per path parameter
-post.href(UserId(42))       // does not compile
+Href::new(post, PostId(42))       // one argument per path parameter
+Href::new(post, UserId(42))       // does not compile
 ```
 
-That drops the tuple and most of the reason `href!` exists, and it is the only approach that catches a bad link without running the code that builds it. The cost is that route modules compile as one unit and editor tooling follows them less well.
+That drops the tuple and most of the reason `href!` exists, and it is the only approach that catches a bad link without running the code that builds it. The cost is that route modules compile as one unit and editor tooling follows them less well, so it is worth revisiting after the dynamic form ships rather than in the first iteration.

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -25,7 +25,7 @@ Path parameters are the [`path_param!`](../crates/topcoat-router/macro/docs/path
 
 ```rust
 // src/app/posts/post_id.rs
-path_param!(post_id: u64, error = not_found);
+path_param!(pub post_id: u64, error = not_found);
 
 #[page]
 async fn post(cx: &Cx) -> Result {
@@ -33,7 +33,7 @@ async fn post(cx: &Cx) -> Result {
 }
 ```
 
-`path_param!` declares the parameter by its URL name and generates the type, `PostId` here. It replaces today's `#[path_param]` attribute, which cannot declare the generic that a string parameter needs to be constructible. This document assumes that change; its design lands next.
+`path_param!` declares the parameter by its URL name and generates the type, `PostId` here, with the visibility the declaration gives it. It replaces today's `#[path_param]` attribute, which cannot declare the generic that a string parameter needs to be constructible. This document assumes that change; its design lands next.
 
 ```rust
 // src/app/posts.rs
@@ -114,7 +114,7 @@ An empty value leaves nothing between the slashes, and the `/posts/` it produces
 A parameter declared without a type is unparsed: the page reads its segment as a string. Reading alone could hold that string as an unsized `str`, but a link has to construct the value, so the generated type is generic over anything that borrows as one.
 
 ```rust
-path_param!(slug);      // pub struct Slug<T: AsRef<str>>(pub T);
+path_param!(pub slug);      // pub struct Slug<T: AsRef<str>>(pub T);
 
 href!(show, Slug("my-first-post"))    // &str
 href!(show, Slug(post.slug))          // String
@@ -124,7 +124,7 @@ Reading is unaffected: `path_param::<Slug>(cx)` borrows the decoded segment out 
 
 Group segments never appear in a served URL and take no value, so a page under `app::_marketing::pricing` is reached with `href!(pricing)`.
 
-Linking to a page from outside its own module needs its parameter type, so `path_param!` generates a public type with a public field.
+Linking to a page from outside its own module needs its parameter type there, so `path_param!` takes a visibility and the generated field carries it: `path_param!(pub slug)`. A parameter only ever linked from its own subtree can stay private.
 
 # When mistakes are caught
 

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -178,9 +178,9 @@ href!(index).query(&[("page", 2)])
 href!(post, PostId(42)).fragment("comments")      // "/posts/42#comments"
 ```
 
-# Absolute URLs
+# Relative and absolute URLs
 
-An `Href` renders root-relative, which is what a link inside the site needs. Content that leaves the site needs the absolute form, so a [mail](../crates/topcoat/docs/mail.md) body renders every `Href` absolute. `absolute` and `relative` override that default for one link: a feed or a sitemap is served as a page but its URLs are read elsewhere.
+Whether an `Href` renders relative or absolute is the rendering context's call. A page renders root-relative, which is what a link inside the site needs. A context that knows its output leaves the site renders absolute, so every `Href` in a [mail](../crates/topcoat/docs/mail.md) body comes out absolute without the link asking for it. `absolute` and `relative` force a mode where the context cannot know: a feed or a sitemap renders as a page, but its URLs are read elsewhere.
 
 ```rust
 href!(post, PostId(42)).absolute()      // "https://example.com/posts/42"

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -1,0 +1,291 @@
+Topcoat generates URLs from the pages that serve them. `href!` builds a page's URL from its path parameters, so a link names the handler it points at instead of a string that goes stale when the route moves.
+
+```rust
+use topcoat::{Result, router::{href, page}, view::view};
+
+#[page]
+async fn home() -> Result {
+    view! {
+        <a href=(href!(about))>"About"</a>
+    }
+}
+```
+
+# Building a URL
+
+`href!` takes the page's handler name, then one value per path parameter, in the order the parameters appear in the path.
+
+```rust
+href!(about)                                  // "/about"
+href!(post, PostId(42))                       // "/posts/42"
+href!(user, OrganizationId(9), UserId(41))    // "/organizations/9/users/41"
+```
+
+Path parameters are the [`#[path_param]`](../crates/topcoat-router/macro/docs/path_param.md) newtypes the page already reads from the request, so one type serves both directions.
+
+```rust
+// src/app/posts/post_id.rs
+#[path_param(error = not_found)]
+pub struct PostId(pub u64);
+
+#[page]
+async fn post(cx: &Cx) -> Result {
+    view! { <h1>"Post " (path_param::<PostId>(cx)?)</h1> }
+}
+```
+
+```rust
+// src/app/posts.rs
+use crate::app::posts::post_id::{PostId, post};
+
+#[page]
+async fn index() -> Result {
+    view! {
+        <ul>
+            for id in [1_u64, 2, 3] {
+                <li><a href=(href!(post, PostId(id)))>"Post " (id)</a></li>
+            }
+        </ul>
+    }
+}
+```
+
+`href!` rewrites to a method on the page, passing the parameters as a tuple.
+
+```rust
+href!(user, OrganizationId(9), UserId(41))
+user.href((OrganizationId(9), UserId(41)))
+```
+
+The method takes exactly one argument because Rust has no variadic functions, and one argument holding any number of parameters means a tuple. Zero and one read worst.
+
+```rust
+about.href(())
+post.href((PostId(42),))
+```
+
+Most pages have no path parameters, so `about.href(())` is the shape a reader meets most often. `href!` spreads the parameters into that tuple, keeping it out of every link.
+
+The tuple stays the real API. It gives every page one calling convention, and leaves a method for helpers that build URLs generically. Everything below applies to both forms.
+
+# What href! returns
+
+An `Href`, not a `String`. Resolving one needs the route table and the base URL, both of which live on the request context, so an `Href` describes a URL and builds it later. That is also why it cannot implement `Display`.
+
+A view resolves it for you.
+
+```rust
+<a href=(href!(post, PostId(42)))>"Post"</a>
+```
+
+Elsewhere it takes a context.
+
+```rust
+href!(post, PostId(42)).resolve(cx)      // "/posts/42"
+```
+
+`query` and `fragment` extend an `Href` before it resolves, and the redirect constructors take one as is. Comments below show what a URL resolves to.
+
+# Parameter values
+
+Each value is percent-encoded into its segment, so a title or an address containing `/`, `?`, or `#` stays inside the segment it belongs to.
+
+```rust
+href!(show, Slug::new("hello/world"))     // "/posts/hello%2Fworld"
+```
+
+A catch-all segment (`{*path}`) stands for several segments, so it is the one case where `/` is preserved.
+
+```rust
+href!(document, DocPath::new("guides/getting-started"))    // "/docs/guides/getting-started"
+```
+
+A parameter declared over `str` is unsized and cannot be built with the tuple-struct constructor, so `#[path_param]` gives those types a `new` constructor that borrows the string.
+
+```rust
+#[path_param]
+pub struct Slug(str);
+
+href!(show, Slug::new("my-first-post"))
+```
+
+Group segments never appear in a served URL and take no value, so a page under `app::_marketing::pricing` is reached with `href!(pricing)`.
+
+Linking to a page from outside its own module needs its parameter type, so declare the type and its field `pub`.
+
+# When mistakes are caught
+
+Parameters are checked when the URL is built, never at compile time. A macro sees only its own item, so a page cannot name parameters its ancestors declare. Explicit paths could be checked earlier, but one rule for every page beats a partial one.
+
+A URL carries the source location it was built at, so the failure names the link rather than the page rendering it.
+
+```text
+page `app::posts::post_id::post` serves "/posts/{post_id}" and needs `post_id`, but was given `user_id`
+  link built at src/app/posts.rs:31:22
+```
+
+An unregistered page reads the same way. It usually means a page with an explicit path in an application that never called `.discover()`, or a module not reachable through a `mod` declaration from the module router's root.
+
+```text
+no route registered for page `app::posts::post_id::post`
+  link built at src/app/posts.rs:31:22
+```
+
+These are programming errors with no recovery, so they panic rather than render a broken link, the same way a missing [asset](../crates/topcoat/docs/asset.md) does. A view renders to a complete string before its response is built, so the panic never truncates a partly written response.
+
+# Query strings and fragments
+
+`query` appends a query string from any `serde::Serialize` value. `#[query_params]` structs derive `Serialize`, so the struct a page reads is the struct a link writes.
+
+```rust
+#[query_params]
+pub struct PostsQuery {
+    page: Option<u32>,
+    q: Option<String>,
+}
+
+// "/posts?page=2&q=rust"
+href!(index).query(&PostsQuery {
+    page: Some(2),
+    q: Some("rust".into()),
+})
+```
+
+Fields holding `None` are left out. A slice of pairs covers one-off links that do not deserve a type.
+
+```rust
+href!(index).query(&[("page", 2)])
+```
+
+`fragment` appends a `#` fragment.
+
+```rust
+href!(post, PostId(42)).fragment("comments")      // "/posts/42#comments"
+```
+
+# Absolute URLs
+
+`href!` produces a root-relative URL, which is what a link inside the site needs. Content that leaves the site, such as mail, feeds, and sitemaps, needs the absolute form. `url!` takes the same arguments and resolves against the [base URL](../crates/topcoat/docs/context.md) registered on the router.
+
+```rust
+let router = Router::builder().base_url("https://example.com").build();
+
+url!(post, PostId(42))        // "https://example.com/posts/42"
+```
+
+An application mounted under a path prefix registers it as part of that base URL, as in `https://example.com/app`. The proxy strips the prefix before the router matches, so the router only ever sees `/posts/42` while the browser needs `/app/posts/42`. Relative URLs carry the prefix for that reason, so `href!` reads the base URL too.
+
+# Redirecting
+
+A Post/Redirect/Get handler names its destination the way a link does.
+
+```rust
+use topcoat::router::error::see_other;
+
+#[page(POST)]
+async fn create(Form(input): Form<NewPost>) -> Result {
+    let id = insert(input).await?;
+    Err(see_other(href!(post, PostId(id))).into())
+}
+```
+
+# Resolving outside a view
+
+A handler already holds the context `resolve` needs.
+
+```rust
+#[route(GET "/feed.xml")]
+async fn feed(cx: &Cx) -> Result<String> {
+    Ok(url!(post, PostId(42)).resolve(cx))
+}
+```
+
+Work that runs outside a request, such as a background job or a sitemap task, takes a context from the router itself.
+
+```rust
+let cx = router.cx();
+let url = url!(post, PostId(42)).resolve(&cx);
+```
+
+Tests use the same method. A module-derived URL resolves through the route table, so a context built by hand covers only pages with an explicit path.
+
+```rust
+let cx = app::router().cx();
+assert_eq!(href!(post, PostId(42)).resolve(&cx), "/posts/42");
+```
+
+# API routes
+
+`#[route]` handlers work the same way, which covers form actions and fetch targets.
+
+```rust
+#[route(POST "/api/posts/{post_id}/publish")]
+async fn publish(cx: &Cx) -> Result<&'static str> {
+    Ok("published")
+}
+
+href!(publish, PostId(42))        // "/api/posts/42/publish"
+```
+
+A `#[layout]` has no URL of its own, so it gets neither.
+
+# Other ideas
+
+These are worth considering but not settled.
+
+**Give string parameters a sized type.** A `str` parameter is unsized, so it can be named but never held: not constructed, returned, stored, or collected. `Slug::new` above exists only to work around that.
+
+```rust
+#[path_param]
+pub struct Slug(pub String);
+
+path_param::<Slug>(cx)                  // still &str, still no allocation
+href!(show, Slug(post.slug.clone()))
+```
+
+Reading would special-case `String` the way it special-cases `str` today, so serving a request still allocates nothing. The allocation moves to URL building, where the value usually came out of a `String` anyway. `Cow<'static, str>` avoids it for literals at the cost of a noisier type.
+
+`String` then reads identically to `str` and does more, so the question is whether `str` stays at all.
+
+**Render a page marker directly.** A page with no parameters could render as its own URL.
+
+```rust
+<a href=(about)>"About"</a>
+```
+
+One trait impl on the marker. The risk is two ways to write a link, with the shorter one breaking the moment the page gains a parameter.
+
+**Read a parameter list in attribute position.** `view!` could treat a parenthesized list in `href` or `action` position as a page plus its parameters.
+
+```rust
+<a href=(post, PostId(42))>"Post"</a>
+```
+
+Shortest form, no import. It also gives `(a, b)` a meaning in two attributes that it has nowhere else in `view!`, where parenthesized values are plain Rust.
+
+**Choose the attribute from the element.** A `page` attribute could expand to `href` on an anchor and `action` on a form.
+
+```rust
+<a page=(post, PostId(42))>"Post"</a>
+<form page=(create) method="post">
+```
+
+Removes the last duplication, but invents a non-HTML attribute and hides which one it emits.
+
+**Check parameters at compile time.** Giving `module_router!` the route tree changes what the macro knows. It can pull in each module body itself, thread a module's parameters down to its children, and generate a typed `href` per page.
+
+```rust
+module_router! {
+    mod about;
+    mod posts { mod post_id; }
+}
+```
+
+Every page then takes its parameters directly.
+
+```rust
+post.href(PostId(42))       // one argument per path parameter
+post.href(UserId(42))       // does not compile
+```
+
+That drops the tuple and most of the reason `href!` exists, and it is the only approach that catches a bad link without running the code that builds it. The cost is that route modules compile as one unit and editor tooling follows them less well.

--- a/design/url_generation.md
+++ b/design/url_generation.md
@@ -35,6 +35,8 @@ async fn post(cx: &Cx) -> Result {
 
 `path_param!` declares the parameter by its URL name and generates the type, `PostId` here, with the visibility the declaration gives it. It replaces today's `#[path_param]` attribute, which cannot declare the generic that a string parameter needs to be constructible. This document assumes that change; its design lands next.
 
+A page that links to `post` imports it alongside the type.
+
 ```rust
 // src/app/posts.rs
 use crate::app::posts::post_id::{PostId, post};
@@ -50,24 +52,6 @@ async fn index() -> Result {
     }
 }
 ```
-
-`href!` expands to `Href::new`, passing the page marker that `#[page]` already generates and the parameters as a tuple.
-
-```rust
-href!(user, OrganizationId(9), UserId(41))
-Href::new(user, (OrganizationId(9), UserId(41)))
-```
-
-The constructor takes a single argument for the parameters because Rust has no variadic functions, so any number of them means a tuple. Zero and one read worst, and zero is what most pages take.
-
-```rust
-Href::new(about, ())
-Href::new(post, (PostId(42),))
-```
-
-`href!` spreads its arguments into that tuple, keeping it out of every link.
-
-`Href::new` stays the real API. It keeps URL building on `Href` instead of a method generated onto every page, and it lets a helper build a URL for a page it takes as an argument. Everything below applies to both forms.
 
 # What href! returns
 
@@ -85,17 +69,46 @@ A page marker renders as its own URL, which covers the parameterless links that 
 <a href=(about)>"About"</a>
 ```
 
-That goes through `Href::new(about, ())`, so a page that later gains a path parameter fails the way any link missing a parameter does.
-
 Elsewhere an `Href` takes a context.
 
 ```rust
 href!(post, PostId(42)).resolve(cx)      // "/posts/42"
 ```
 
-`query`, `fragment`, and `absolute` each return an `Href`, so they chain onto one before it resolves. Comments below show what a URL resolves to.
+`query`, `fragment`, and `absolute` each return an `Href`, so they chain onto one before it resolves.
+
+# Href::new
+
+`href!` expands to `Href::new`, passing the page marker that `#[page]` already generates and the parameters as a tuple.
+
+```rust
+href!(user, OrganizationId(9), UserId(41))
+Href::new(user, (OrganizationId(9), UserId(41)))
+```
+
+The constructor takes a single argument for the parameters because Rust has no variadic functions, so any number of them means a tuple. Zero and one read worst, and zero is what most pages take.
+
+```rust
+Href::new(about, ())
+Href::new(post, (PostId(42),))
+```
+
+`href!` spreads its arguments into that tuple, keeping it out of every link. A rendered page marker goes through `Href::new(about, ())` as well, so a page that later gains a path parameter fails there the way any link missing a parameter does.
+
+`Href::new` stays the real API. It keeps URL building on `Href` instead of a method generated onto every page, and it lets a helper build a URL for a page it takes as an argument. The rest of this document applies to both forms.
 
 # Parameter values
+
+A parameter declared without a type is unparsed: its segment is a string the page reads as is. Reading it needs no more than an unsized `str`, but a link has to construct one, so the generated type is generic over anything that borrows as a string.
+
+```rust
+path_param!(pub slug);      // pub struct Slug<T: AsRef<str>>(pub T);
+
+href!(show, Slug("my-first-post"))    // &str
+href!(show, Slug(post.slug))          // String
+```
+
+`path_param::<Slug>(cx)` still borrows the decoded segment out of the request, so serving a request allocates nothing. The allocation moves to the link, where the value usually came out of a `String` already.
 
 Each value is percent-encoded into its segment, so a title or an address containing `/`, `?`, or `#` stays inside the segment it belongs to.
 
@@ -111,20 +124,9 @@ href!(document, DocPath("guides/getting-started"))    // "/docs/guides/getting-s
 
 An empty value leaves nothing between the slashes, and the `/posts/` it produces no longer matches the route it was built from, so it is rejected when the URL is built.
 
-A parameter declared without a type is unparsed: the page reads its segment as a string. Reading alone could hold that string as an unsized `str`, but a link has to construct the value, so the generated type is generic over anything that borrows as one.
-
-```rust
-path_param!(pub slug);      // pub struct Slug<T: AsRef<str>>(pub T);
-
-href!(show, Slug("my-first-post"))    // &str
-href!(show, Slug(post.slug))          // String
-```
-
-Reading is unaffected: `path_param::<Slug>(cx)` borrows the decoded segment out of the request, allocating nothing. The allocation, if there is one, moves to the link, where the value usually came out of a `String` already.
-
 Group segments never appear in a served URL and take no value, so a page under `app::_marketing::pricing` is reached with `href!(pricing)`.
 
-Linking to a page from outside its own module needs its parameter type there, so `path_param!` takes a visibility and the generated field carries it: `path_param!(pub slug)`. A parameter only ever linked from its own subtree can stay private.
+Linking to a page from outside its own module needs its parameter type there, so `path_param!` takes a visibility, which the generated field carries. A parameter linked only from its own subtree can stay private.
 
 # When mistakes are caught
 
@@ -178,7 +180,7 @@ href!(post, PostId(42)).fragment("comments")      // "/posts/42#comments"
 
 # Absolute URLs
 
-An `Href` renders root-relative, which is what a link inside the site needs. Content that leaves the site needs the absolute form, so a [mail](../crates/topcoat/docs/mail.md) body renders every `Href` absolute. `absolute` and `relative` override that default for one link, which a feed or a sitemap served as a page needs.
+An `Href` renders root-relative, which is what a link inside the site needs. Content that leaves the site needs the absolute form, so a [mail](../crates/topcoat/docs/mail.md) body renders every `Href` absolute. `absolute` and `relative` override that default for one link: a feed or a sitemap is served as a page but its URLs are read elsewhere.
 
 ```rust
 href!(post, PostId(42)).absolute()      // "https://example.com/posts/42"
@@ -190,7 +192,7 @@ The scheme and host come from the [base URL](../crates/topcoat/docs/context.md) 
 let router = Router::builder().base_url("https://example.com").build();
 ```
 
-A router without one falls back to the address it is serving on, so links resolve during development without configuring anything.
+A router without one falls back to the address it serves on, so links resolve in development without configuration.
 
 An application mounted under a path prefix registers it as part of that base URL, as in `https://example.com/app`. The proxy strips the prefix before the router matches, so the router only ever sees `/posts/42` while the browser needs `/app/posts/42`. Relative URLs carry the prefix for that reason, so every `Href` reads the base URL.
 
@@ -208,11 +210,11 @@ async fn create(Form(input): Form<NewPost>) -> Result<SeeOther> {
 }
 ```
 
-`see_other` takes an `Href` and resolves it while building the response, which is where the context is available.
+`see_other` takes an `Href` and resolves it while building the response, where the context is available.
 
 # Resolving outside a view
 
-A handler already holds the context `resolve` needs.
+`resolve` needs a context, and a handler already holds one.
 
 ```rust
 #[route(GET "/feed.xml")]
@@ -228,7 +230,7 @@ let cx = router.cx();
 let url = href!(post, PostId(42)).absolute().resolve(&cx);
 ```
 
-Tests use the same method. A module-derived URL resolves through the route table, so a context built by hand covers only pages with an explicit path.
+A test takes one from the application's router. A module-derived URL resolves through the route table, so a context built by hand covers only pages with an explicit path.
 
 ```rust
 let cx = app::router().cx();
@@ -282,4 +284,4 @@ Href::new(post, PostId(42))       // one argument per path parameter
 Href::new(post, UserId(42))       // does not compile
 ```
 
-That drops the tuple and most of the reason `href!` exists, and it is the only approach that catches a bad link without running the code that builds it. The cost is that route modules compile as one unit and editor tooling follows them less well, so it is worth revisiting after the dynamic form ships rather than in the first iteration.
+That drops the tuple and most of the reason `href!` exists, and it is the only approach that catches a bad link without running the code that builds it. The cost is that route modules compile as one unit and editor tooling follows them less well, so it is worth revisiting once the dynamic form ships.


### PR DESCRIPTION
[Rendered](https://github.com/tokio-rs/topcoat/blob/url-generation-design/design/url_generation.md)

## Summary

Design for generating a page's URL from its path parameters, so links name the handler they point at instead of a hardcoded string.

`href!(post, PostId(42))` expands to `Href::new(post, (PostId(42),))`, passing the marker struct `#[page]` already generates and the parameters as a tuple. It returns a lazy `Href` that resolves against the route table and base URL when rendered, mirroring how `Asset` resolves through the app context. A page with no parameters renders as its own URL, so `href=(about)` is a link. `href!` is the only macro: an `Href` renders relative in a view and absolute in mail, and `.absolute()`/`.relative()` override that per link.

Parameters are checked when the URL is built rather than at compile time. A macro cannot see an ancestor module's `#[path_param]`, and a module-derived path is not assembled until `Router::build()`, so a compile-time check would hold in some modules and not others. Failures carry the source location of the `href!` that produced them, so the error names the link rather than the page rendering it.

**This is a design PR. The implementation follows once the direction is approved.**

The doc closes with an "Other ideas" section for the parts that are not settled: taking the query string and fragment as macro arguments, test assertions over links, and the `module_router!` change that would make every page compile-time checked.

## Testing

No code, so no test suite. The mechanisms the design leans on were verified against rustc with standalone programs:

- an explicit item shadows a glob import
- a `#[used]` linker-section static inside a block registers before `main`, including from functions that never run
- that static cannot live in a generic fn (E0401), and cannot infer its type from a sibling expression
- `#[track_caller]` reports the `href!` call site through `macro_rules!`
- an `include!`-based module tree accumulates the parameter chain and preserves `module_path!()`

The third result is the load-bearing one: it rules out collecting call-site parameter *types* at link time, which is why there is no `Router::build()` validation pass and why checking happens where the types exist.
