### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpine-ajax"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -424,7 +424,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coffee-shop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "toasty",
@@ -477,7 +477,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tokio",
@@ -640,7 +640,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datastar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -842,7 +842,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1082,7 +1082,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1547,7 +1547,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mail"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tokio",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "manual-router"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2080,7 +2080,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "tokio",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "sse"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2421,7 +2421,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "toasty",
@@ -2787,7 +2787,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-alpine-ajax"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http",
  "tokio",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http",
  "memchr",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "console",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cookie 0.18.1",
  "getrandom 0.2.17",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "quote",
  "serde",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-datastar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "http",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "heck",
  "inventory",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http",
  "serde",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lettre",
  "thiserror",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http",
  "quote",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "futures-core",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "quote",
  "syn",
@@ -3363,7 +3363,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "websocket"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -113,36 +113,36 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-alpine-ajax = { version = "0.5.0", path = "crates/topcoat-alpine-ajax" }
-topcoat-asset = { version = "0.5.0", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.5.0", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.5.0", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.5.0", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.5.0", path = "crates/topcoat-core/macro" }
-topcoat-datastar = { version = "0.5.0", path = "crates/topcoat-datastar" }
-topcoat-font = { version = "0.5.0", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.5.0", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.5.0", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.5.0", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.5.0", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.5.0", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.5.0", path = "crates/topcoat-icon/macro" }
-topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
-topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
-topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
-topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.5.0", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.5.0", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.5.0", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.5.0", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.5.0", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.5.0", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.5.0", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.5.0", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.5.0", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.5.0", path = "crates/topcoat-view/macro" }
+topcoat-alpine-ajax = { version = "0.6.0", path = "crates/topcoat-alpine-ajax" }
+topcoat-asset = { version = "0.6.0", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.6.0", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.6.0", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.6.0", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.6.0", path = "crates/topcoat-core/macro" }
+topcoat-datastar = { version = "0.6.0", path = "crates/topcoat-datastar" }
+topcoat-font = { version = "0.6.0", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.6.0", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.6.0", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.6.0", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.6.0", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.6.0", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.6.0", path = "crates/topcoat-icon/macro" }
+topcoat-mail = { version = "0.6.0", path = "crates/topcoat-mail" }
+topcoat-mail-grammar = { version = "0.6.0", path = "crates/topcoat-mail/grammar" }
+topcoat-mail-macro = { version = "0.6.0", path = "crates/topcoat-mail/macro" }
+topcoat-router = { version = "0.6.0", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.6.0", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.6.0", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.6.0", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.6.0", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.6.0", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.6.0", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.6.0", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.6.0", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.6.0", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.6.0", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.6.0", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.6.0", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-alpine-ajax/CHANGELOG.md
+++ b/crates/topcoat-alpine-ajax/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-alpine-ajax-v0.5.0...topcoat-alpine-ajax-v0.6.0) - 2026-08-17
+
+### Added
+
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

--- a/crates/topcoat-asset/CHANGELOG.md
+++ b/crates/topcoat-asset/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.5.0...topcoat-asset-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(asset)* ignore false-positive asset scans with empty paths ([#280](https://github.com/tokio-rs/topcoat/pull/280))
+- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
+- *(asset)* register one route per bundled file ([#249](https://github.com/tokio-rs/topcoat/pull/249))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.4.0...topcoat-asset-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-cli/CHANGELOG.md
+++ b/crates/topcoat-cli/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.5.0...topcoat-cli-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(cli)* warn on version mismatch between topcoat and cli ([#305](https://github.com/tokio-rs/topcoat/pull/305))
+
+### Fixed
+
+- *(cli)* add '/ws' to exempt OriginPolicy on dev ([#348](https://github.com/tokio-rs/topcoat/pull/348))
+- *(cli)* exclude build script outputs from final output detection ([#301](https://github.com/tokio-rs/topcoat/pull/301))
+- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
+
+### Other
+
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.4.0...topcoat-cli-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-cookie/CHANGELOG.md
+++ b/crates/topcoat-cookie/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.5.0...topcoat-cookie-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.4.0...topcoat-cookie-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-core/CHANGELOG.md
+++ b/crates/topcoat-core/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.5.0...topcoat-core-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
+- *(core)* seal Cx on detach
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
+- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
+- sort imports
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.4.0...topcoat-core-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-core/grammar/CHANGELOG.md
+++ b/crates/topcoat-core/grammar/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.5.0...topcoat-core-grammar-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+
+### Fixed
+
+- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- sort imports
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.4.0...topcoat-core-grammar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-core/macro/CHANGELOG.md
+++ b/crates/topcoat-core/macro/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.5.0...topcoat-core-macro-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+
+### Fixed
+
+- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
+
+### Other
+
+- fix memoize docs stale example
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.4.0...topcoat-core-macro-v0.5.0) - 2026-07-27
 
 ### Other

--- a/crates/topcoat-datastar/CHANGELOG.md
+++ b/crates/topcoat-datastar/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.5.0...topcoat-datastar-v0.6.0) - 2026-08-17
+
+### Added
+
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))
+
+### Other
+
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.4.0...topcoat-datastar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-font/CHANGELOG.md
+++ b/crates/topcoat-font/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.5.0...topcoat-font-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.4.0...topcoat-font-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-font/grammar/CHANGELOG.md
+++ b/crates/topcoat-font/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.5.0...topcoat-font-grammar-v0.6.0) - 2026-08-17
+
+### Fixed
+
+- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))
+
+### Other
+
+- sort imports
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.1.3...topcoat-font-grammar-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-font/macro/CHANGELOG.md
+++ b/crates/topcoat-font/macro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.5.0...topcoat-font-macro-v0.6.0) - 2026-08-17
+
+### Fixed
+
+- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))
+
+### Other
+
+- sort imports
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.1.3...topcoat-font-macro-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-htmx/CHANGELOG.md
+++ b/crates/topcoat-htmx/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.5.0...topcoat-htmx-v0.6.0) - 2026-08-17
+
+### Added
+
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Other
+
+- sort imports
+- make request and response dedicated modules
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.1.3...topcoat-htmx-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-icon/grammar/CHANGELOG.md
+++ b/crates/topcoat-icon/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.5.0...topcoat-icon-grammar-v0.6.0) - 2026-08-17
+
+### Other
+
+- sort imports
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.1.3...topcoat-icon-grammar-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-mail/CHANGELOG.md
+++ b/crates/topcoat-mail/CHANGELOG.md
@@ -6,3 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.5.0...topcoat-mail-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
+- sort imports
+- make request and response dedicated modules

--- a/crates/topcoat-mail/grammar/CHANGELOG.md
+++ b/crates/topcoat-mail/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.5.0...topcoat-mail-grammar-v0.6.0) - 2026-08-17
+
+### Other
+
+- sort imports
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.4.0...topcoat-mail-grammar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-mail/macro/CHANGELOG.md
+++ b/crates/topcoat-mail/macro/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.5.0...topcoat-mail-macro-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+
+### Other
+
+- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
+- sort imports
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.4.0...topcoat-mail-macro-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-router/CHANGELOG.md
+++ b/crates/topcoat-router/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.5.0...topcoat-router-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(router)* use `impl AsRef<str>` for route error urls ([#351](https://github.com/tokio-rs/topcoat/pull/351))
+- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
+- *(router)* request rewriting ([#347](https://github.com/tokio-rs/topcoat/pull/347))
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(router)* sitemaps ([#336](https://github.com/tokio-rs/topcoat/pull/336))
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(router)* add matched endpoint path to request context ([#318](https://github.com/tokio-rs/topcoat/pull/318))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
+- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
+- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
+- *(router)* add a too-many-requests error with a Retry-After hint ([#267](https://github.com/tokio-rs/topcoat/pull/267))
+- *(router)* add Js and Wasm response wrappers ([#268](https://github.com/tokio-rs/topcoat/pull/268))
+- *(router)* add a service-unavailable error with a Retry-After hint ([#266](https://github.com/tokio-rs/topcoat/pull/266))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
+- *(router)* [**breaking**] request body limits ([#233](https://github.com/tokio-rs/topcoat/pull/233))
+
+### Fixed
+
+- fix docs issues
+- *(router)* isolate request panics ([#257](https://github.com/tokio-rs/topcoat/pull/257))
+- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
+- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
+- sort imports
+- make request and response dedicated modules
+- merge router service and serve into single file
+- [**breaking**] return ContentTooLargeError instead of LengthLimitError from to_bytes ([#263](https://github.com/tokio-rs/topcoat/pull/263))
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.4.0...topcoat-router-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-router/grammar/CHANGELOG.md
+++ b/crates/topcoat-router/grammar/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.5.0...topcoat-router-grammar-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
+
+### Fixed
+
+- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
+- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.4.0...topcoat-router-grammar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-router/macro/CHANGELOG.md
+++ b/crates/topcoat-router/macro/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.5.0...topcoat-router-macro-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
+- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.4.0...topcoat-router-macro-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-runtime/CHANGELOG.md
+++ b/crates/topcoat-runtime/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.5.0...topcoat-runtime-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(runtime)* support signals outside the body ([#334](https://github.com/tokio-rs/topcoat/pull/334))
+- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
+- *(runtime)* reject non-2xx shard responses instead of rendering them ([#247](https://github.com/tokio-rs/topcoat/pull/247))
+- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
+- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
+- sort imports
+- make request and response dedicated modules
+- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.4.0...topcoat-runtime-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-runtime/grammar/CHANGELOG.md
+++ b/crates/topcoat-runtime/grammar/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.5.0...topcoat-runtime-grammar-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+
+### Fixed
+
+- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))
+- *(runtime)* reject invalid procedure signatures at parse time ([#230](https://github.com/tokio-rs/topcoat/pull/230))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.4.0...topcoat-runtime-grammar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-runtime/macro/CHANGELOG.md
+++ b/crates/topcoat-runtime/macro/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.5.0...topcoat-runtime-macro-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+
+### Fixed
+
+- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
+- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
+- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))
+
+### Other
+
+- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.4.0...topcoat-runtime-macro-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-session/CHANGELOG.md
+++ b/crates/topcoat-session/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.5.0...topcoat-session-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.4.0...topcoat-session-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-ui/CHANGELOG.md
+++ b/crates/topcoat-ui/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.5.0...topcoat-ui-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- sort imports
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.1.3...topcoat-ui-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-ui/registry/CHANGELOG.md
+++ b/crates/topcoat-ui/registry/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.5.0...topcoat-ui-registry-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.4.0...topcoat-ui-registry-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.5.0...topcoat-view-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- implement NodeViewParts and AttributeValueViewParts for Cow<'static, str> ([#306](https://github.com/tokio-rs/topcoat/pull/306))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+
+### Fixed
+
+- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
+- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
+- *(view)* add docs about concurrent rendering
+- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
+- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.4.0...topcoat-view-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-view/grammar/CHANGELOG.md
+++ b/crates/topcoat-view/grammar/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.5.0...topcoat-view-grammar-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+
+### Fixed
+
+- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
+- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
+- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
+- sort imports
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.4.0...topcoat-view-grammar-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat-view/macro/CHANGELOG.md
+++ b/crates/topcoat-view/macro/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.5.0...topcoat-view-macro-v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+
+### Fixed
+
+- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))
+
+### Other
+
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- *(view)* add docs about concurrent rendering
+- sort imports
+- make request and response dedicated modules
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.4.0...topcoat-view-macro-v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tokio-rs/topcoat/compare/v0.5.0...v0.6.0) - 2026-08-17
+
+### Added
+
+- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
+- *(router)* sitemaps ([#336](https://github.com/tokio-rs/topcoat/pull/336))
+- *(core)* seal Cx on detach
+- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
+- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
+- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
+- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
+- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
+- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
+- *(cli)* warn on version mismatch between topcoat and cli ([#305](https://github.com/tokio-rs/topcoat/pull/305))
+- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
+- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
+- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
+- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
+- *(router)* use `impl AsRef<str>` for route error urls ([#351](https://github.com/tokio-rs/topcoat/pull/351))
+- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
+- *(router)* request rewriting ([#347](https://github.com/tokio-rs/topcoat/pull/347))
+- *(router)* add matched endpoint path to request context ([#318](https://github.com/tokio-rs/topcoat/pull/318))
+- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
+- *(router)* add a too-many-requests error with a Retry-After hint ([#267](https://github.com/tokio-rs/topcoat/pull/267))
+- *(router)* add Js and Wasm response wrappers ([#268](https://github.com/tokio-rs/topcoat/pull/268))
+- *(router)* add a service-unavailable error with a Retry-After hint ([#266](https://github.com/tokio-rs/topcoat/pull/266))
+- *(router)* [**breaking**] request body limits ([#233](https://github.com/tokio-rs/topcoat/pull/233))
+- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
+- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
+- implement NodeViewParts and AttributeValueViewParts for Cow<'static, str> ([#306](https://github.com/tokio-rs/topcoat/pull/306))
+
+### Fixed
+
+- fix docs issues
+- fix doc tests with default features
+- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
+- *(asset)* ignore false-positive asset scans with empty paths ([#280](https://github.com/tokio-rs/topcoat/pull/280))
+- *(asset)* register one route per bundled file ([#249](https://github.com/tokio-rs/topcoat/pull/249))
+- *(cli)* add '/ws' to exempt OriginPolicy on dev ([#348](https://github.com/tokio-rs/topcoat/pull/348))
+- *(cli)* exclude build script outputs from final output detection ([#301](https://github.com/tokio-rs/topcoat/pull/301))
+- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
+- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
+- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))
+- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))
+- *(router)* isolate request panics ([#257](https://github.com/tokio-rs/topcoat/pull/257))
+- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
+- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))
+- *(runtime)* support signals outside the body ([#334](https://github.com/tokio-rs/topcoat/pull/334))
+- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
+- *(runtime)* reject non-2xx shard responses instead of rendering them ([#247](https://github.com/tokio-rs/topcoat/pull/247))
+- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
+- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))
+- *(runtime)* reject invalid procedure signatures at parse time ([#230](https://github.com/tokio-rs/topcoat/pull/230))
+- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))
+
+### Other
+
+- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
+- sort imports
+- make request and response dedicated modules
+- decrease logo size
+- add readme logo
+- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
+- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
+- fix memoize docs stale example
+- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
+- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
+- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
+- merge router service and serve into single file
+- [**breaking**] return ContentTooLargeError instead of LengthLimitError from to_bytes ([#263](https://github.com/tokio-rs/topcoat/pull/263))
+- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
+- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
+- *(view)* add docs about concurrent rendering
+- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
+
 ## [0.5.0](https://github.com/tokio-rs/topcoat/compare/v0.4.0...v0.5.0) - 2026-07-27
 
 ### Added

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["alpine-ajax"] }
+topcoat = { version = "0.6.0", features = ["alpine-ajax"] }
 ```
 
 # Loading the Alpine AJAX script

--- a/crates/topcoat/docs/datastar.md
+++ b/crates/topcoat/docs/datastar.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::datastar` and gated behind the `d
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["datastar"] }
+topcoat = { version = "0.6.0", features = ["datastar"] }
 ```
 
 # Loading the Datastar script

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.5.0", features = ["font-fontsource"] }
+topcoat = { version = "0.6.0", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["htmx"] }
+topcoat = { version = "0.6.0", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["icon-iconify"] }
+topcoat = { version = "0.6.0", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.5.0", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.6.0", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/mail.md
+++ b/crates/topcoat/docs/mail.md
@@ -5,7 +5,7 @@ Everything below is re-exported from `topcoat::mail` and gated behind the `mail`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["mail", "mail-smtp"] }
+topcoat = { version = "0.6.0", features = ["mail", "mail-smtp"] }
 ```
 
 # Setup

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["tailwind"] }
+topcoat = { version = "0.6.0", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.5.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.6.0", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.5.0", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.6.0", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.5.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.6.0", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-alpine-ajax`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-view`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-router`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-asset`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-cookie`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-core-grammar`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-core-macro`: 0.5.0 -> 0.6.0
* `topcoat-datastar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-view-grammar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-view-macro`: 0.5.0 -> 0.6.0
* `topcoat-font`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-font-grammar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-font-macro`: 0.5.0 -> 0.6.0
* `topcoat-htmx`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-icon`: 0.5.0 -> 0.6.0
* `topcoat-icon-grammar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-icon-macro`: 0.5.0 -> 0.6.0
* `topcoat-mail`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-mail-grammar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-mail-macro`: 0.5.0 -> 0.6.0
* `topcoat-router-grammar`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-router-macro`: 0.5.0 -> 0.6.0
* `topcoat-runtime`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-runtime-grammar`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-runtime-macro`: 0.5.0 -> 0.6.0
* `topcoat-session`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `topcoat-tailwind`: 0.5.0 -> 0.6.0
* `topcoat-ui-registry`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-ui`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `topcoat-cli`: 0.5.0 -> 0.6.0 (✓ API compatible changes)

### ⚠ `topcoat-core` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function topcoat_core::fnv1a::hash, previously in file /tmp/.tmpDGBvKo/topcoat-core/src/fnv1a.rs:17
  function topcoat_core::fnv1a::hash_continue, previously in file /tmp/.tmpDGBvKo/topcoat-core/src/fnv1a.rs:26

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  OFFSET in file /tmp/.tmpDGBvKo/topcoat-core/src/fnv1a.rs:11

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_core::context::CxBuilder, previously in file /tmp/.tmpDGBvKo/topcoat-core/src/context.rs:55
  struct topcoat_core::context::ContextMap, previously in file /tmp/.tmpDGBvKo/topcoat-core/src/context/context_map.rs:153
```

### ⚠ `topcoat-view` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum topcoat_view::ViewPart, previously in file /tmp/.tmpDGBvKo/topcoat-view/src/view.rs:129

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  PartsWriter::new, previously in file /tmp/.tmpDGBvKo/topcoat-view/src/view.rs:445

--- failure method_receiver_ref_became_owned: method receiver changed from immutable reference to owned value ---

Description:
A method's receiver changed from an immutable reference to an owned value. Ownership is transferred as part of the call, which is a breaking change.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_receiver_ref_became_owned.ron

Failed in:
  topcoat_view::View::render now takes Self, not &Self, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-view/src/view.rs:185
  topcoat_view::View::render_response now takes Self, not &Self, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-view/src/view.rs:230

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait topcoat_view::DynViewPart gained Sync in file /tmp/.tmp8ztsky/topcoat/crates/topcoat-view/src/part.rs:16

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method clone_box of trait DynViewPart, previously in file /tmp/.tmpDGBvKo/topcoat-view/src/view.rs:340
```

### ⚠ `topcoat-router` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type PageWithLayouts is no longer UnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/src/page.rs:192
  type PageWithLayouts is no longer RefUnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/src/page.rs:192

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function topcoat_router::headers, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:98
  function topcoat_router::content_type, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:116
  function topcoat_router::version, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:79
  function topcoat_router::parts, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:22
  function topcoat_router::uri, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:60
  function topcoat_router::extensions, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:140
  function topcoat_router::method, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/context.rs:41

--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_const_removed.ron

Failed in:
  LayoutFn::new in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/src/page.rs:173
  LayerFn::new in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/src/layer.rs:109

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  PageFn::const_new, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/page.rs:50
  Path::matches_start, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/path.rs:257
  RawPathParams::iter, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/path_param.rs:74
  RouteFn::const_new, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/route.rs:77

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  topcoat_router::tower::TowerLayer::new takes 2 parameters in /tmp/.tmpDGBvKo/topcoat-router/src/tower.rs:177, but now takes 1 parameters in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/src/tower.rs:190

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait topcoat_router::IntoResponse, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/response.rs:60
  trait topcoat_router::OptionalFromRequest, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/request.rs:121
  trait topcoat_router::IntoResponseParts, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/response.rs:78
  trait topcoat_router::FromRequest, previously in file /tmp/.tmpDGBvKo/topcoat-router/src/request.rs:70
```

### ⚠ `topcoat-asset` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant BundleError:ConflictingContentTypes in /tmp/.tmp8ztsky/topcoat/crates/topcoat-asset/src/bundler/error.rs:31
```

### ⚠ `topcoat-core-grammar` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type MemoizeAttr is no longer Send, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-core/grammar/src/memoize.rs:18
  type MemoizeAttr is no longer Sync, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-core/grammar/src/memoize.rs:18

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field MemoizeAttr.as_ref in /tmp/.tmp8ztsky/topcoat/crates/topcoat-core/grammar/src/memoize.rs:19
```

### ⚠ `topcoat-mail` breaking changes

```text
--- failure method_receiver_ref_became_owned: method receiver changed from immutable reference to owned value ---

Description:
A method's receiver changed from an immutable reference to an owned value. Ownership is transferred as part of the call, which is a breaking change.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_receiver_ref_became_owned.ron

Failed in:
  topcoat_mail::Mail::formatted now takes Self, not &Self, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-mail/src/mime.rs:36
```

### ⚠ `topcoat-router-grammar` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  PathParam::new, previously in file /tmp/.tmpDGBvKo/topcoat-router-grammar/src/path_param.rs:81

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  topcoat_router_grammar::path_param::PathParam::parse takes 2 parameters in /tmp/.tmpDGBvKo/topcoat-router-grammar/src/path_param.rs:102, but now takes 1 parameters in /tmp/.tmp8ztsky/topcoat/crates/topcoat-router/grammar/src/path_param.rs:300

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_router_grammar::path_param::PathParamAttr, previously in file /tmp/.tmpDGBvKo/topcoat-router-grammar/src/path_param.rs:14
  struct topcoat_router_grammar::path_param::PathParamItem, previously in file /tmp/.tmpDGBvKo/topcoat-router-grammar/src/path_param.rs:30
```

### ⚠ `topcoat-runtime` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type ShardRoute is no longer UnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/shard.rs:61
  type ShardRoute is no longer RefUnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/shard.rs:61
  type ProcedureRoute is no longer UnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:73
  type ProcedureRoute is no longer RefUnwindSafe, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:73

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type ProcedureSurrogate no longer derives Debug, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:145
  type ProcedureRoute no longer derives Debug, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:73
  type ProcedureRoute no longer derives Clone, in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:73

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_runtime::Procedure, previously in file /tmp/.tmpDGBvKo/topcoat-runtime/src/procedure.rs:37
  struct topcoat_runtime::ErasedShard, previously in file /tmp/.tmpDGBvKo/topcoat-runtime/src/shard.rs:37
  struct topcoat_runtime::ErasedProcedure, previously in file /tmp/.tmpDGBvKo/topcoat-runtime/src/procedure.rs:60

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct ProcedureSurrogate allows 2 -> 1 generic types in /tmp/.tmp8ztsky/topcoat/crates/topcoat-runtime/src/procedure.rs:145
```

### ⚠ `topcoat-session` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function topcoat_session::verify_origin, previously in file /tmp/.tmpDGBvKo/topcoat-session/src/origin.rs:30

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  SessionConfigBuilder::trust_origin, previously in file /tmp/.tmpDGBvKo/topcoat-session/src/config.rs:81
  SessionConfigBuilder::dangerous_disable_origin_verification, previously in file /tmp/.tmpDGBvKo/topcoat-session/src/config.rs:94

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_session::OriginLayer, previously in file /tmp/.tmpDGBvKo/topcoat-session/src/origin.rs:108
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.5.0...topcoat-core-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* seal Cx on detach
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
</blockquote>

## `topcoat-alpine-ajax`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-alpine-ajax-v0.5.0...topcoat-alpine-ajax-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
</blockquote>

## `topcoat-view`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.5.0...topcoat-view-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- implement NodeViewParts and AttributeValueViewParts for Cow<'static, str> ([#306](https://github.com/tokio-rs/topcoat/pull/306))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
- *(view)* add docs about concurrent rendering
- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-router`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.5.0...topcoat-router-v0.6.0) - 2026-08-17

### Added

- *(router)* use `impl AsRef<str>` for route error urls ([#351](https://github.com/tokio-rs/topcoat/pull/351))
- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(router)* request rewriting ([#347](https://github.com/tokio-rs/topcoat/pull/347))
- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(router)* sitemaps ([#336](https://github.com/tokio-rs/topcoat/pull/336))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(router)* add matched endpoint path to request context ([#318](https://github.com/tokio-rs/topcoat/pull/318))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
- *(router)* add a too-many-requests error with a Retry-After hint ([#267](https://github.com/tokio-rs/topcoat/pull/267))
- *(router)* add Js and Wasm response wrappers ([#268](https://github.com/tokio-rs/topcoat/pull/268))
- *(router)* add a service-unavailable error with a Retry-After hint ([#266](https://github.com/tokio-rs/topcoat/pull/266))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
- *(router)* [**breaking**] request body limits ([#233](https://github.com/tokio-rs/topcoat/pull/233))

### Fixed

- fix docs issues
- *(router)* isolate request panics ([#257](https://github.com/tokio-rs/topcoat/pull/257))
- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
- sort imports
- make request and response dedicated modules
- merge router service and serve into single file
- [**breaking**] return ContentTooLargeError instead of LengthLimitError from to_bytes ([#263](https://github.com/tokio-rs/topcoat/pull/263))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.5.0...topcoat-asset-v0.6.0) - 2026-08-17

### Added

- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(asset)* ignore false-positive asset scans with empty paths ([#280](https://github.com/tokio-rs/topcoat/pull/280))
- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
- *(asset)* register one route per bundled file ([#249](https://github.com/tokio-rs/topcoat/pull/249))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.5.0...topcoat-cookie-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.5.0...topcoat-core-grammar-v0.6.0) - 2026-08-17

### Added

- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- sort imports
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.5.0...topcoat-core-macro-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))

### Fixed

- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))

### Other

- fix memoize docs stale example
</blockquote>

## `topcoat-datastar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.5.0...topcoat-datastar-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.5.0...topcoat-view-grammar-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
- sort imports
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.5.0...topcoat-view-macro-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* add docs about concurrent rendering
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-font`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.5.0...topcoat-font-v0.6.0) - 2026-08-17

### Added

- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.5.0...topcoat-font-grammar-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.5.0...topcoat-font-macro-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.5.0...topcoat-htmx-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.5.0...topcoat-icon-grammar-v0.6.0) - 2026-08-17

### Other

- sort imports
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-mail`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.5.0...topcoat-mail-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-mail-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.5.0...topcoat-mail-grammar-v0.6.0) - 2026-08-17

### Other

- sort imports
</blockquote>

## `topcoat-mail-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.5.0...topcoat-mail-macro-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Other

- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.5.0...topcoat-router-grammar-v0.6.0) - 2026-08-17

### Added

- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))

### Fixed

- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.5.0...topcoat-router-macro-v0.6.0) - 2026-08-17

### Added

- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
- make request and response dedicated modules
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.5.0...topcoat-runtime-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(runtime)* support signals outside the body ([#334](https://github.com/tokio-rs/topcoat/pull/334))
- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
- *(runtime)* reject non-2xx shard responses instead of rendering them ([#247](https://github.com/tokio-rs/topcoat/pull/247))
- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- sort imports
- make request and response dedicated modules
- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.5.0...topcoat-runtime-grammar-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))
- *(runtime)* reject invalid procedure signatures at parse time ([#230](https://github.com/tokio-rs/topcoat/pull/230))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.5.0...topcoat-runtime-macro-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))

### Other

- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.5.0...topcoat-session-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.5.0...topcoat-ui-registry-v0.6.0) - 2026-08-17

### Added

- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
</blockquote>

## `topcoat`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/v0.5.0...v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(router)* sitemaps ([#336](https://github.com/tokio-rs/topcoat/pull/336))
- *(core)* seal Cx on detach
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- *(cli)* warn on version mismatch between topcoat and cli ([#305](https://github.com/tokio-rs/topcoat/pull/305))
- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
- *(router)* use `impl AsRef<str>` for route error urls ([#351](https://github.com/tokio-rs/topcoat/pull/351))
- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(router)* request rewriting ([#347](https://github.com/tokio-rs/topcoat/pull/347))
- *(router)* add matched endpoint path to request context ([#318](https://github.com/tokio-rs/topcoat/pull/318))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- *(router)* add a too-many-requests error with a Retry-After hint ([#267](https://github.com/tokio-rs/topcoat/pull/267))
- *(router)* add Js and Wasm response wrappers ([#268](https://github.com/tokio-rs/topcoat/pull/268))
- *(router)* add a service-unavailable error with a Retry-After hint ([#266](https://github.com/tokio-rs/topcoat/pull/266))
- *(router)* [**breaking**] request body limits ([#233](https://github.com/tokio-rs/topcoat/pull/233))
- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- implement NodeViewParts and AttributeValueViewParts for Cow<'static, str> ([#306](https://github.com/tokio-rs/topcoat/pull/306))

### Fixed

- fix docs issues
- fix doc tests with default features
- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
- *(asset)* ignore false-positive asset scans with empty paths ([#280](https://github.com/tokio-rs/topcoat/pull/280))
- *(asset)* register one route per bundled file ([#249](https://github.com/tokio-rs/topcoat/pull/249))
- *(cli)* add '/ws' to exempt OriginPolicy on dev ([#348](https://github.com/tokio-rs/topcoat/pull/348))
- *(cli)* exclude build script outputs from final output detection ([#301](https://github.com/tokio-rs/topcoat/pull/301))
- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))
- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))
- *(router)* isolate request panics ([#257](https://github.com/tokio-rs/topcoat/pull/257))
- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))
- *(runtime)* support signals outside the body ([#334](https://github.com/tokio-rs/topcoat/pull/334))
- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
- *(runtime)* reject non-2xx shard responses instead of rendering them ([#247](https://github.com/tokio-rs/topcoat/pull/247))
- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))
- *(runtime)* reject invalid procedure signatures at parse time ([#230](https://github.com/tokio-rs/topcoat/pull/230))
- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
- decrease logo size
- add readme logo
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- fix memoize docs stale example
- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
- merge router service and serve into single file
- [**breaking**] return ContentTooLargeError instead of LengthLimitError from to_bytes ([#263](https://github.com/tokio-rs/topcoat/pull/263))
- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
- *(view)* add docs about concurrent rendering
- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.5.0...topcoat-ui-v0.6.0) - 2026-08-17

### Added

- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- sort imports
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.5.0...topcoat-cli-v0.6.0) - 2026-08-17

### Added

- *(cli)* warn on version mismatch between topcoat and cli ([#305](https://github.com/tokio-rs/topcoat/pull/305))

### Fixed

- *(cli)* add '/ws' to exempt OriginPolicy on dev ([#348](https://github.com/tokio-rs/topcoat/pull/348))
- *(cli)* exclude build script outputs from final output detection ([#301](https://github.com/tokio-rs/topcoat/pull/301))
- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).