### PR TITLE
fix(asset)!: write the bundle next to the executable it was scanned from

### DIFF
--- a/crates/topcoat-asset/src/bundle.rs
+++ b/crates/topcoat-asset/src/bundle.rs
@@ -1,5 +1,4 @@
 use std::{
-    ffi::OsStr,
     io,
     path::{Path, PathBuf},
 };
@@ -18,34 +17,24 @@ pub struct AssetBundle {
 }
 
 impl AssetBundle {
-    /// Auto-detect and load the bundle from a conventional location.
+    /// Load the bundle sitting next to the current executable.
     ///
-    /// Walks up from the current executable, checking each ancestor for an
-    /// `assets/manifest.toml`. This covers, without configuration:
+    /// The bundler writes to an `assets` directory beside the executable it
+    /// scanned, so `<exe_dir>/assets` is where a bundle belongs: `cargo run`
+    /// finds `target/<profile>/assets`, and a deployment ships the directory
+    /// alongside the binary.
     ///
-    /// - `<exe_dir>/assets/`: deployment, bundle shipped next to the binary.
-    /// - `target/<profile>/<bin>` -> `target/assets/` (typical `cargo run`).
-    /// - `target/<profile>/examples/<bin>` -> `target/assets/`.
-    /// - `target/<triple>/<profile>/<bin>` -> `target/assets/` (cross-compile).
-    /// - `target/<triple>/<profile>/examples/<bin>` -> `target/assets/`.
-    ///
-    /// The first directory that contains a readable `manifest.toml` is
-    /// loaded. The walk stops once it reaches a directory named `target`
-    /// (since `<target>/assets` is checked at that step) or after a bounded
-    /// number of ancestors. Returns [`io::ErrorKind::NotFound`] if no
-    /// candidate has a manifest.
-    ///
-    /// Use [`AssetBundle::load_dir`] when you already know the exact bundle
-    /// directory, such as a custom path passed to the asset bundler.
+    /// Use [`AssetBundle::load_dir`] when the bundle lives anywhere else, such
+    /// as a custom path passed to the asset bundler with `--out`.
     ///
     /// # Errors
     ///
-    /// Returns [`io::ErrorKind::NotFound`] if no candidate `assets` directory
-    /// contains a readable manifest, or propagates any I/O or parse error from
-    /// reading the located manifest via [`AssetBundle::load_dir`].
+    /// Returns [`io::ErrorKind::NotFound`] if there is no readable manifest
+    /// next to the executable, or propagates any I/O or parse error from
+    /// reading it via [`AssetBundle::load_dir`].
     pub fn load() -> io::Result<Self> {
         let exe = std::env::current_exe()?;
-        let exe_dir = exe
+        let dir = exe
             .parent()
             .ok_or_else(|| {
                 io::Error::new(
@@ -53,35 +42,16 @@ impl AssetBundle {
                     "current executable has no parent directory",
                 )
             })?
-            .to_path_buf();
+            .join("assets");
 
-        let mut tried = Vec::new();
-        let mut current = Some(exe_dir.as_path());
-        for _ in 0..6 {
-            let Some(d) = current else { break };
-            let candidate = d.join("assets");
-            if candidate.join(MANIFEST_NAME).is_file() {
-                return Self::load_dir(candidate);
-            }
-            tried.push(candidate);
-            if d.file_name() == Some(OsStr::new("target")) {
-                break;
-            }
-            current = d.parent();
+        if !dir.join(MANIFEST_NAME).is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("no asset bundle at {}", dir.display()),
+            ));
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            format!(
-                "no asset bundle found near {}: tried {}",
-                exe_dir.display(),
-                tried
-                    .iter()
-                    .map(|p| p.display().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-        ))
+        Self::load_dir(dir)
     }
 
     /// Load a bundle from a specific directory.

--- a/crates/topcoat-cli/src/asset/bundle.rs
+++ b/crates/topcoat-cli/src/asset/bundle.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use console::style;
@@ -12,18 +12,19 @@ use super::{CACHE_SCOPE, OUT_SUBDIR};
 pub(super) struct BundleArgs {
     #[command(flatten)]
     build: BuildFlags,
-    /// Output directory for the bundle (defaults to <cargo-target>/assets)
+    /// Output directory for the bundle (defaults to an `assets` directory
+    /// next to the built executable)
     #[arg(short, long)]
     out: Option<PathBuf>,
 }
 
 pub(super) async fn run(args: BundleArgs) {
-    let (_, bytes) = BuildOpts::from(args.build)
+    let (exe, bytes) = BuildOpts::from(args.build)
         .build_and_read(|_, _| {})
         .await
         .unwrap_or_else(|e| e.print_and_exit());
 
-    let out_dir = match run_bundle(&bytes, args.out).await {
+    let out_dir = match run_bundle(&exe, &bytes, args.out).await {
         Ok(path) => path,
         Err(error) => {
             eprintln!(
@@ -37,7 +38,19 @@ pub(super) async fn run(args: BundleArgs) {
     println!("bundled assets into {}", out_dir.display());
 }
 
+/// Bundle the assets embedded in `exe` (already read into `bytes`), writing
+/// them to `out_override` or to an `assets` directory next to `exe`.
+///
+/// The default is tied to the executable rather than to the target directory
+/// because an [`AssetId`](topcoat_asset::AssetId) can depend on the cargo
+/// profile: a build script writing into `OUT_DIR` puts
+/// `target/<profile>/build/...` in the asset path the ID hashes. A single
+/// shared bundle directory would let a `dev` bundle shadow a `release` one,
+/// leaving the other binary unable to resolve its own assets.
+/// [`AssetBundle::load`](topcoat_asset::AssetBundle::load) looks next to the
+/// executable first, so each profile finds the bundle built from it.
 pub(crate) async fn run_bundle(
+    exe: &Path,
     bytes: &[u8],
     out_override: Option<PathBuf>,
 ) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
@@ -45,7 +58,13 @@ pub(crate) async fn run_bundle(
         .await
         .and_then(|metadata| metadata.target_dir())
         .ok_or("could not derive cargo target directory")?;
-    let out_dir = out_override.unwrap_or_else(|| target_dir.join(OUT_SUBDIR));
+    let out_dir = match out_override {
+        Some(dir) => dir,
+        None => exe
+            .parent()
+            .ok_or("built executable has no parent directory")?
+            .join(OUT_SUBDIR),
+    };
     let cache_dir = topcoat_core::cache::cache_dir_in(&target_dir, CACHE_SCOPE);
 
     // `bundle` blocks on filesystem and network I/O, so run it off the runtime.

--- a/crates/topcoat-cli/src/asset/clean.rs
+++ b/crates/topcoat-cli/src/asset/clean.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use console::style;
@@ -7,7 +7,8 @@ use super::{CACHE_SCOPE, OUT_SUBDIR};
 
 #[derive(Args)]
 pub(super) struct CleanArgs {
-    /// Asset bundle directory to remove (defaults to <cargo-target>/assets)
+    /// Asset bundle directory to remove (defaults to every bundle in the
+    /// cargo target directory)
     #[arg(short, long)]
     out: Option<PathBuf>,
 }
@@ -24,10 +25,14 @@ pub(super) async fn run(args: CleanArgs) {
         std::process::exit(1);
     };
 
-    let out_dir = args.out.unwrap_or_else(|| target_dir.join(OUT_SUBDIR));
     let cache_dir = topcoat_core::cache::cache_dir_in(&target_dir, CACHE_SCOPE);
+    let mut dirs = match args.out {
+        Some(dir) => vec![dir],
+        None => bundle_dirs(&target_dir),
+    };
+    dirs.push(cache_dir);
 
-    for dir in [&out_dir, &cache_dir] {
+    for dir in &dirs {
         match std::fs::remove_dir_all(dir) {
             Ok(()) => println!("removed {}", dir.display()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -40,4 +45,34 @@ pub(super) async fn run(args: CleanArgs) {
             }
         }
     }
+}
+
+/// Every asset bundle in the target directory. Bundles are written next to
+/// the executable they were scanned from, so they sit at
+/// `<target>/<profile>/assets` and, for cross builds,
+/// `<target>/<triple>/<profile>/assets`. Only directories holding a manifest
+/// are returned, so an unrelated `assets` directory in the target tree is
+/// left alone.
+fn bundle_dirs(target_dir: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for dir in subdirs(target_dir) {
+        candidates.extend(subdirs(&dir));
+        candidates.push(dir);
+    }
+    candidates
+        .into_iter()
+        .map(|dir| dir.join(OUT_SUBDIR))
+        .filter(|dir| dir.join(topcoat_asset::MANIFEST_NAME).is_file())
+        .collect()
+}
+
+fn subdirs(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect()
 }

--- a/crates/topcoat-cli/src/dev/build.rs
+++ b/crates/topcoat-cli/src/dev/build.rs
@@ -94,7 +94,7 @@ async fn build(kind: BuildKind, opts: BuildOpts) -> Option<PathBuf> {
     };
 
     let spinner = Spinner::new("bundling assets");
-    let bundled = crate::asset::run_bundle(&bytes, None).await;
+    let bundled = crate::asset::run_bundle(&exe, &bytes, None).await;
     drop(spinner);
 
     if let Err(error) = bundled {

--- a/crates/topcoat/docs/asset.md
+++ b/crates/topcoat/docs/asset.md
@@ -81,10 +81,10 @@ topcoat dev
 cargo topcoat dev
 ```
 
-By default, the bundle is written to:
+By default, the bundle is written to an `assets` directory next to the executable it was scanned from:
 
 ```text
-<cargo-target>/assets
+<cargo-target>/<profile>/assets
 ```
 
 The download/cache directory for remote assets is:
@@ -108,6 +108,15 @@ topcoat asset bundle --bin my-app
 topcoat asset bundle --package my-package
 ```
 
+The subcommands build the application to scan it, and they accept the same profile flags as `cargo build`. Bundle with the profile you are going to run, since each profile keeps its own bundle:
+
+```sh
+topcoat asset bundle --release
+topcoat asset bundle --profile my-profile
+```
+
+The profile matters beyond the output path. An asset's ID is derived from the path it was declared with, and a build script writes into `OUT_DIR`, whose path covers the target directory, the profile, and a per-build hash. `tailwind::stylesheet!()` is one such asset. So a `dev` bundle does not describe a `--release` binary even though the file on disk is identical, and a bundle built in one checkout does not describe a binary built in another. Bundle and binary have to come from the same build.
+
 To write the bundle somewhere else, pass `--out` and load the same directory at runtime:
 
 ```sh
@@ -122,7 +131,7 @@ let router = Router::builder()
     .build();
 ```
 
-When `--out` is not in one of the auto-detected locations, use [`AssetBundle::load_dir`] to point at it explicitly.
+[`AssetBundle::load`] only looks next to the executable, so any `--out` outside that location has to be loaded with [`AssetBundle::load_dir`].
 
 # Path resolution
 


### PR DESCRIPTION
Fixes #212.

## What is still broken after #217

#217 did fix the MSVC linker problem. Byte-scanning both `tailwind.exe` builds for the `TOPCOAT_ASSET` marker on `x86_64-pc-windows-msvc` shows the declaration surviving in the release binary:

```
target\debug\tailwind.exe    id=5404681112881914444    path=...\target\debug\build\tailwind-7f722d3359c5bb6b\out/tailwind.css
target\release\tailwind.exe  id=12480077591628209191   path=...\target\release\build\tailwind-b97e50b9b147424f\out/tailwind.css
```

Nothing is stripped. But the two IDs differ, and that is the remaining bug. It is not Windows-specific.

`tailwind::stylesheet!()` expands to `asset!(concat!(env!("OUT_DIR"), "/tailwind.css"))`, and `AssetId::new` hashes the path string. `OUT_DIR` contains the profile, so the ID is profile-scoped.

`topcoat asset bundle` defaults to the `dev` profile, and every profile wrote its bundle to the same `<target>/assets`. So the reporter's `topcoat asset bundle` + `cargo build --release` leaves a dev-keyed manifest that the release binary cannot resolve:

```
thread 'tokio-rt-worker' panicked at crates\topcoat-asset\src\config.rs:139:13:
failed to resolve asset Asset { id: AssetId(12480077591628209191) } in the asset catalog
```

The two profiles also clobber each other's bundle, so they cannot coexist in one workspace.

## The change

Bundle into an `assets` directory next to the executable that was scanned, rather than one shared `<target>/assets`. `AssetBundle::load` already probes `<exe_dir>/assets` first, so no runtime change is needed: each profile finds the bundle built from it.

- `topcoat-cli/src/asset/bundle.rs`: `run_bundle` takes the scanned executable's path and defaults the output to `<exe_dir>/assets`. `--out` is unchanged.
- `topcoat-cli/src/dev/build.rs`: pass the executable through.
- `topcoat-cli/src/asset/clean.rs`: with no single fixed location left, remove every bundle under the target directory (`<target>/assets`, `<target>/*/assets`, `<target>/*/*/assets`), keyed on the directory actually holding a manifest so an unrelated `assets` directory is left alone. The `<target>/assets` entry also cleans up bundles left by earlier versions.
- `topcoat-asset/src/bundle.rs`: `AssetBundle::load` doc updated. No code change.
- `topcoat/docs/asset.md`: new default path, plus the `--release`/`--profile` flags (previously undocumented) and why the profile matters.

A mismatched bundle now fails at startup naming the directory it looked in, instead of panicking on the first request that renders an asset:

```
no asset bundle found near D:\Dev\topcoat\target\release:
tried D:\Dev\topcoat\target\release\assets, D:\Dev\topcoat\target\assets
```

## Verified

On `x86_64-pc-windows-msvc`, rustc 1.96.0, with `examples/tailwind`:

| Flow | Before | After |
|---|---|---|
| `asset bundle` + run release binary | request panics on an opaque asset ID | startup error naming the missing directory |
| `asset bundle --release` + run release binary | 200, only if nothing had clobbered `target/assets` | 200, `href="/_topcoat/assets/tailwind-a261247bbd892b1f.css"` |
| dev and release bundles at once | mutually clobbering | coexist, both 200 |
| `asset clean` | removed `<target>/assets` only | removes all bundles, including the legacy one |
| `topcoat dev` | — | 200, bundles into `target/debug/assets` |

`cargo fmt --check`, `cargo clippy` on both crates, and `cargo test -p topcoat-asset -p topcoat-cli` are clean.

## Not done here

Making the Tailwind ID profile-independent. The ID is defined as a hash of the declaring crate, source file, and path; special-casing generated paths cannot distinguish two different generated files, and it would hide the same mismatch for other assets.

`Debug for Asset` prints only the ID, which is why the original panic was hard to read. Decoding the embedded declaration so it also names the crate and path would help every stale-bundle case, but it is a separate change.

## Breaking change

The default bundle directory moves from `<cargo-target>/assets` to `<cargo-target>/<profile>/assets`. Anything copying or loading `target/assets` by hand needs updating. `AssetBundle::load` users are unaffected.
