### PR TITLE
fix(asset): register one route per bundled file

### DIFF
--- a/crates/topcoat-asset/src/asset.rs
+++ b/crates/topcoat-asset/src/asset.rs
@@ -309,7 +309,12 @@ fn normalize(path: &Path) -> PathBuf {
 ///
 /// Output filenames always include a short content hash so bundles stay
 /// cache-friendly: e.g. `logo-1a2b3c4d5e6f7a8b.png`, or
-/// `1a2b3c4d5e6f7a8b.png` if the stem is empty.
+/// `1a2b3c4d5e6f7a8b.png` if the stem is empty. Declarations of one file
+/// share its output filename, and with it the single route the file is
+/// served from, so they cannot disagree about the `Content-Type`: serving
+/// one file as two content types needs a different `rename` on one of the
+/// declarations, and the [`Bundler`](crate::Bundler) rejects the bundle
+/// otherwise.
 ///
 /// # Returns
 ///

--- a/crates/topcoat-asset/src/bundler.rs
+++ b/crates/topcoat-asset/src/bundler.rs
@@ -4,7 +4,7 @@ mod error;
 mod event;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::Write as _,
     fs, io,
     path::Path,
@@ -69,6 +69,11 @@ impl Bundler {
     /// reading/writing a bundled file; and for a checksum mismatch between a
     /// declared asset and its configured `checksum`. When several assets
     /// fail, the one declared earliest is reported.
+    ///
+    /// Assets that resolve to the same output filename share one bundled
+    /// file and one route, so they must agree on how that file is served:
+    /// two of them declaring different content types is rejected with
+    /// [`BundleError::ConflictingContentTypes`].
     pub fn bundle(&self, binary: &[u8], out_dir: impl AsRef<Path>) -> BundleResult {
         let out_dir = out_dir.as_ref();
         fs::create_dir_all(out_dir).map_err(|source| AssetError::ManifestIo {
@@ -99,7 +104,7 @@ impl Bundler {
         });
 
         let mut entries = Vec::with_capacity(assets.len());
-        let mut kept_files = HashSet::with_capacity(assets.len());
+        let mut kept_files = HashMap::with_capacity(assets.len());
         let mut bundled = 0;
         let mut unchanged = 0;
         for prepared in self.prepare_all(&assets, &existing, out_dir) {
@@ -109,13 +114,22 @@ impl Bundler {
             } else {
                 unchanged += 1;
             }
-            kept_files.insert(prepared.entry.file.clone());
+            let content_type = prepared.entry.content_type.clone();
+            if let Some(first) = kept_files.insert(prepared.entry.file.clone(), content_type)
+                && first != prepared.entry.content_type
+            {
+                return Err(BundleError::ConflictingContentTypes {
+                    file: prepared.entry.file,
+                    first,
+                    second: prepared.entry.content_type,
+                });
+            }
             entries.push(prepared.entry);
         }
 
         let mut removed = 0;
         for entry in existing.values() {
-            if !kept_files.contains(&entry.file) {
+            if !kept_files.contains_key(&entry.file) {
                 let path = out_dir.join(&entry.file);
                 match fs::remove_file(&path) {
                     Ok(()) => {
@@ -697,6 +711,69 @@ mod tests {
         let manifest = Fixture::manifest(&out);
         assert_eq!(manifest.assets[0].content_type, "text/css");
         assert_eq!(manifest.assets[1].content_type, "application/x-custom");
+    }
+
+    #[test]
+    fn one_output_file_declared_with_two_content_types_is_rejected() {
+        let mut fixture = Fixture::new("content-type-conflict");
+        let contents = "<svg></svg>";
+        fixture.declare_with(
+            "mark.svg",
+            contents,
+            &AssetOptions {
+                content_type: Some("image/svg+xml".into()),
+                ..AssetOptions::NONE
+            },
+        );
+        fixture.declare_with(
+            "mark.svg",
+            contents,
+            &AssetOptions {
+                content_type: Some("text/plain".into()),
+                ..AssetOptions::NONE
+            },
+        );
+
+        let out = fixture.out();
+        let error = fixture.bundle(&out, 1).0.unwrap_err();
+        match error {
+            BundleError::ConflictingContentTypes {
+                file,
+                first,
+                second,
+            } => {
+                assert_eq!(file, format!("mark-{}.svg", &sha256(contents)[..16]));
+                assert_eq!(first, "image/svg+xml");
+                assert_eq!(second, "text/plain");
+            }
+            other => panic!("expected conflicting content types, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn one_output_file_declared_with_one_content_type_is_accepted() {
+        let mut fixture = Fixture::new("content-type-agreement");
+        let contents = "<svg></svg>";
+        let options = AssetOptions {
+            content_type: Some("image/svg+xml".into()),
+            ..AssetOptions::NONE
+        };
+        fixture.declare_with("mark.svg", contents, &options);
+        fixture.declare_with(
+            "mark.svg",
+            contents,
+            &AssetOptions {
+                rename: Some("mark".into()),
+                ..options
+            },
+        );
+
+        let out = fixture.out();
+        fixture.bundle(&out, 1).0.unwrap();
+
+        let manifest = Fixture::manifest(&out);
+        assert_eq!(manifest.assets.len(), 2);
+        assert_eq!(manifest.assets[0].file, manifest.assets[1].file);
     }
 
     #[test]

--- a/crates/topcoat-asset/src/bundler/error.rs
+++ b/crates/topcoat-asset/src/bundler/error.rs
@@ -23,4 +23,14 @@ pub enum BundleError {
         #[source]
         source: Box<ureq::Error>,
     },
+    #[error(
+        "conflicting content types {first:?} and {second:?} for bundled file {file}: \
+         serving one file as two content types needs a different `rename` on one of \
+         the declarations"
+    )]
+    ConflictingContentTypes {
+        file: String,
+        first: String,
+        second: String,
+    },
 }

--- a/crates/topcoat-asset/src/router.rs
+++ b/crates/topcoat-asset/src/router.rs
@@ -80,7 +80,7 @@ impl RouterBuilderAssetExt for RouterBuilder {
                 let mut builder = self;
                 let mut registered = HashSet::new();
                 for asset in config.catalog.assets() {
-                    if registered.insert((asset.name(), asset.content_type())) {
+                    if registered.insert(asset.name()) {
                         builder = builder.route(AssetRoute::new(dir, asset));
                     }
                 }
@@ -157,11 +157,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "duplicate route registered")]
-    fn one_file_declared_with_two_content_types_conflicts() {
+    fn one_file_declared_with_two_content_types_serves_one_route() {
         let dir = temp_dir("conflicting-content-types");
+        fs::write(dir.join(FILE), "<svg></svg>").unwrap();
         let bundle = bundle(dir, &[(MAIN, "image/svg+xml"), (OTHER, "text/plain")]);
 
-        let _ = Router::builder().assets(bundle).build();
+        let router = Router::builder().assets(bundle).build();
+
+        let parts = get(&router, &format!("{ASSET_ROUTE_PREFIX}/{FILE}"));
+        assert_eq!(parts.status, StatusCode::OK);
+        let content_type = parts.headers.get(CONTENT_TYPE).unwrap();
+        assert!(content_type == "image/svg+xml" || content_type == "text/plain");
     }
 }

--- a/crates/topcoat-asset/src/router.rs
+++ b/crates/topcoat-asset/src/router.rs
@@ -157,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn one_file_declared_with_two_content_types_serves_one_route() {
+    fn a_catalog_that_disagrees_on_content_type_still_serves_one_route() {
         let dir = temp_dir("conflicting-content-types");
         fs::write(dir.join(FILE), "<svg></svg>").unwrap();
         let bundle = bundle(dir, &[(MAIN, "image/svg+xml"), (OTHER, "text/plain")]);

--- a/crates/topcoat-asset/src/router.rs
+++ b/crates/topcoat-asset/src/router.rs
@@ -2,6 +2,9 @@
 // cannot resolve; they degrade to plain text instead of failing the build.
 #![cfg_attr(not(feature = "serve"), allow(rustdoc::broken_intra_doc_links))]
 
+#[cfg(feature = "serve")]
+use std::collections::HashSet;
+
 use topcoat_router::RouterBuilder;
 
 #[cfg(feature = "serve")]
@@ -22,11 +25,12 @@ pub trait RouterBuilderAssetExt {
     /// macro get rendered as the URL the asset is hosted at.
     ///
     /// A serving configuration ([`AssetConfig::serve`](crate::AssetConfig::serve))
-    /// also adds an HTTP route for each bundled asset, served by the
-    /// application itself. A configuration hosted externally
-    /// ([`AssetConfig::hosted_at`](crate::AssetConfig::hosted_at)) adds no
-    /// routes; the bundled files must be hosted at the configured base URL by
-    /// other means.
+    /// also adds an HTTP route for each bundled file, served by the
+    /// application itself. Several assets can resolve to the same bundled
+    /// file, in which case they share one route. A configuration hosted
+    /// externally ([`AssetConfig::hosted_at`](crate::AssetConfig::hosted_at))
+    /// adds no routes; the bundled files must be hosted at the configured
+    /// base URL by other means.
     ///
     /// Anything convertible into an [`AssetConfig`] is accepted: an
     /// [`AssetBundle`](crate::AssetBundle) registers as the configuration
@@ -74,8 +78,11 @@ impl RouterBuilderAssetExt for RouterBuilder {
             #[cfg(feature = "serve")]
             Host::Serve { dir } => {
                 let mut builder = self;
+                let mut registered = HashSet::new();
                 for asset in config.catalog.assets() {
-                    builder = builder.route(AssetRoute::new(dir, asset));
+                    if registered.insert((asset.name(), asset.content_type())) {
+                        builder = builder.route(AssetRoute::new(dir, asset));
+                    }
                 }
                 builder
             }
@@ -83,5 +90,78 @@ impl RouterBuilderAssetExt for RouterBuilder {
         };
 
         builder.app_context(config)
+    }
+}
+
+#[cfg(all(test, feature = "serve"))]
+mod tests {
+    use std::{env, fmt::Write, fs, path::PathBuf};
+
+    use http::{Method, StatusCode, header::CONTENT_TYPE};
+    use topcoat_router::{Body, Router};
+
+    use super::*;
+    use crate::{AssetBundle, AssetId, AssetOptions, Manifest, serve::ASSET_ROUTE_PREFIX};
+
+    const OPTIONS: AssetOptions = AssetOptions::NONE;
+    const MAIN: AssetId = AssetId::new("app", "src/main.rs", "assets/mark.svg", &OPTIONS);
+    const OTHER: AssetId = AssetId::new("app", "src/other.rs", "assets/mark.svg", &OPTIONS);
+    const FILE: &str = "mark-16313d41ffdefca4.svg";
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = env::temp_dir().join(format!("topcoat-asset-router-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn bundle(dir: PathBuf, entries: &[(AssetId, &str)]) -> AssetBundle {
+        let mut toml = String::from("version = 1\n");
+        for (id, content_type) in entries {
+            let id = id.as_u64();
+            let _ = write!(
+                toml,
+                "\n[[assets]]\nid = {id}\nfile = \"{FILE}\"\nhash = \"0\"\ncontent_type = \"{content_type}\"\n"
+            );
+        }
+        AssetBundle {
+            dir,
+            catalog: Manifest::parse(&toml).unwrap().into(),
+        }
+    }
+
+    fn get(router: &Router, path: &str) -> http::response::Parts {
+        let request = http::Request::builder()
+            .method(Method::GET)
+            .uri(path)
+            .body(Body::empty())
+            .unwrap();
+        let response = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(router.handle(request));
+        response.into_parts().0
+    }
+
+    #[test]
+    fn one_file_declared_at_two_call_sites_serves_one_route() {
+        let dir = temp_dir("shared-file");
+        fs::write(dir.join(FILE), "<svg></svg>").unwrap();
+        let bundle = bundle(dir, &[(MAIN, "image/svg+xml"), (OTHER, "image/svg+xml")]);
+
+        let router = Router::builder().assets(bundle).build();
+
+        let parts = get(&router, &format!("{ASSET_ROUTE_PREFIX}/{FILE}"));
+        assert_eq!(parts.status, StatusCode::OK);
+        assert_eq!(parts.headers.get(CONTENT_TYPE).unwrap(), "image/svg+xml");
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate route registered")]
+    fn one_file_declared_with_two_content_types_conflicts() {
+        let dir = temp_dir("conflicting-content-types");
+        let bundle = bundle(dir, &[(MAIN, "image/svg+xml"), (OTHER, "text/plain")]);
+
+        let _ = Router::builder().assets(bundle).build();
     }
 }


### PR DESCRIPTION
## Summary

`asset!` mints an `AssetId` per call site and the bundled filename derives from the file's content hash, so declaring one file from two modules yields two catalog entries pointing at the same bundled file. `RouterBuilderAssetExt::assets` registered one `AssetRoute` per catalog entry, so `RouterBuilder::build` saw two routes for one URL and panicked before the application bound its port:

```
thread 'main' panicked at crates/topcoat-router/src/router.rs:541:25:
duplicate route registered for `GET /_topcoat/assets/mark-16313d41ffdefca4.svg`
```

The panic names the URL and no source location. I hit it in an application I built on Topcoat, where a logo was declared in two modules.

The fix has two halves.

**Router.** The `Host::Serve` arm registers a route the first time it sees a bundled filename. The `Content-Type` is not part of the key. A bundled filename carries a content hash, so entries that share a filename share their bytes: same file, same URL, same content, and collapsing them does not change what is served.

**Bundler.** `Bundler::bundle` now records the `Content-Type` of every output filename it prepares and fails with `BundleError::ConflictingContentTypes` when a later asset resolves to a filename already prepared under a different type. The message names the output filename, both types, and the `rename` that separates them:

```
conflicting content types "image/svg+xml" and "text/plain" for bundled file mark-16313d41ffdefca4.svg: serving one file as two content types needs a different `rename` on one of the declarations
```

That is the contradiction the filename-only key would otherwise resolve in silence: two entries claim different types for one route, `AssetCatalog::assets` iterates a `HashMap`, and the surviving type is arbitrary. The bundle now fails before a manifest is written, so the catalog the router loads can no longer contain it.

Of the four `AssetOptions` fields, `content_type` is the only one that can differ between two entries that share an output filename and change how the file is served. `rename` and `extension` shape the filename itself, so entries that share a filename agree on their effect; `checksum` is asserted against the source bytes during bundling and reaches neither the manifest nor the route.

The alternative fix is to intern `AssetId`s by resolved path in the bundler, so one file has one id. I did not take it because it changes asset identity semantics, while this one is local to route registration and manifest assembly.

Two open PRs sit next to this: #196 edits the same `Host::Serve` loop to collect static file URLs, and #243 changes where the bundler writes the bundle, while the new check sits in the `Bundler::bundle` loop that collects prepared entries.

## Testing

`one_file_declared_at_two_call_sites_serves_one_route` covers the defect: it panics with `duplicate route registered for GET /_topcoat/assets/mark-16313d41ffdefca4.svg` at 01cdbd9 and passes with the fix, serving `200` and `image/svg+xml` from the single surviving route.

`a_catalog_that_disagrees_on_content_type_still_serves_one_route` pins the filename-only key: two entries share the bundled filename and declare different content types, and it panics with the same `duplicate route registered` message under the previous key at 919a533. This is the test that was `one_file_declared_with_two_content_types_serves_one_route`. The bundler no longer produces such a catalog, but `Manifest::parse` accepts one built elsewhere or embedded ahead of time, as on WebAssembly, so the router still has to tolerate it. The test asserts the served type is one of the two declared and does not pin which.

`one_output_file_declared_with_two_content_types_is_rejected` covers the new check: two declarations of one file with different `content_type` options, expecting `BundleError::ConflictingContentTypes` carrying the output filename and both types. `bundle` returns `Ok` at 40b8c23, so the test fails there and passes now.

`one_output_file_declared_with_one_content_type_is_accepted` pins the other side: two declarations that resolve to one output filename and agree on the type still bundle, into two manifest entries pointing at one file.

- `cargo +nightly fmt --all`, then `--check`: exit 0
- `cargo topcoat fmt`: 541 files, 0 modified (the 5 failures are the Leptos benchmark files)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: exit 0
- `cargo test --workspace --all-features`: 115 `test result: ok` lines, 0 failed; `topcoat-asset` reports `32 passed; 0 failed`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`: exit 0

## Disclaimer

Written with Claude Opus 5 in Claude Code. The agent located the defect, wrote the fix, and ran the checks; I reviewed the diff and the test output before opening this PR.
