### PR TITLE
docs(router): cover unmatched URLs in the branded 404 pattern

### DIFF
--- a/crates/topcoat-router/docs/error.md
+++ b/crates/topcoat-router/docs/error.md
@@ -71,6 +71,19 @@ async fn root_layout(slot: Result) -> Result {
 
 The [`StatusCode`](crate::StatusCode) in the view keeps the response a 404; without it the replacement page would be served as a 200.
 
+A layout sees only the errors raised by the handlers it wraps. A URL that matches no route never enters the layout chain, so the router answers it with its own `text/plain` 404. Register a catch-all page to route unmatched URLs through the layout as well:
+
+```rust
+use topcoat::{Result, router::{error::not_found, page}};
+
+#[page("/{*path}")]
+async fn not_found_page() -> Result {
+    Err(not_found().into())
+}
+```
+
+A more specific route wins over the catch-all. A catch-all needs at least one remaining URL segment, so `/` keeps its own page.
+
 # Unexpected errors
 
 Any other error responds 500 without leaking its message to the client. To record a source error while keeping that behavior, wrap it in [`internal_server_error(error)`](internal_server_error) yourself.


### PR DESCRIPTION
## Summary

The "Catching an error" section presents an outer layout matching `error.downcast_ref::<NotFoundError>()` as the way to replace a page's `NotFoundError` with a branded not-found page, and the same guide states that a request matching no route gets a `NotFoundError`. Read together, the two sentences promise that one layout covers every 404. `Router::handle` picks `Terminal::NotFound` for an unmatched path. Layers wrap that terminal, layouts do not, so an unmatched URL gets the router's `text/plain` default while a handler-raised `NotFoundError` gets the branded page. An application I built on Topcoat followed the guide and shipped two different 404s.

This scopes the pattern to the errors a layout wraps, adds the catch-all page that routes unmatched URLs through the layout, and names the two limits of that page.

Sequencing: #242 touches `crates/topcoat-router/docs/error.md`, one line in the section on `Option` and `Result`, a different hunk from this change; the snippet added here takes an explicit path and stays clear of the path parameter surface #242 replaces.

## Testing

Reproduced on `main` at 01cdbd9 with an app carrying the guide's layout and a page that returns `Err(not_found().into())`:

```
$ curl -si localhost:3000/posts/1 | head -2
HTTP/1.1 404 Not Found
content-type: text/html; charset=utf-8

$ curl -si localhost:3000/nope | head -2
HTTP/1.1 404 Not Found
content-type: text/plain; charset=utf-8
```

49 bytes of branded HTML against the 9-byte `not found`. Adding the catch-all page from the new snippet turns `/nope` and `/a/b/c` into the branded `text/html` 404, leaves `/posts/1` on its own page, and leaves `/` on the home page.

Checks:

- `cargo +nightly fmt --all`: no changes.
- `cargo topcoat fmt`: 531 files, 0 modified (the 5 failures are the Leptos benchmark files, which fail to parse on `main` and on this branch).
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo test --workspace --all-features`: every suite passes, 0 failures. The new snippet runs as a doctest, `docs/error.md - error (line 76)`; the `topcoat-router` doctests are 74 passed, 0 failed, 2 ignored.
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`: exit 0.

## Disclaimer

Written with Claude Opus 5 in Claude Code. The agent located the defect, wrote the fix, and ran the checks; I reviewed the diff and the test output before opening this PR.
