### PR TITLE
docs(runtime): note that page guards do not cover shard endpoints

### DIFF
--- a/crates/topcoat-runtime/macro/docs/shard.md
+++ b/crates/topcoat-runtime/macro/docs/shard.md
@@ -43,6 +43,31 @@ When the `query` signal changes, the current argument values are sent to the ser
 
 A shard's content is a full view: it can declare signals, attach event handlers, and contain nested shards. A re-render replaces that content wholesale, though, so state declared inside the shard -- like a `signal` in its `view!` -- resets each time. State that must survive re-renders lives outside the shard and flows in through its arguments.
 
+# Guards
+
+A shard has its own endpoint, and a request to it runs the shard function alone. Guards applied by the page or its layouts never run, so a shard that renders private content resolves authorization itself. The caller picks the argument values, so that check covers them too: confirm the current user may see the data the arguments select.
+
+```rust
+use topcoat::{Result, context::Cx, runtime::shard, view::view};
+
+#[shard]
+async fn ledger_rows(cx: &Cx, account: String) -> Result {
+    let user = require_auth(cx).await?;
+    let rows = fetch_rows(cx, &user, &account).await?;
+
+    view! {
+        for row in rows {
+            <div>(row)</div>
+        }
+    }
+}
+# struct User;
+# async fn require_auth(_cx: &Cx) -> Result<User> { Ok(User) }
+# async fn fetch_rows(_cx: &Cx, _user: &User, _account: &str) -> Result<Vec<String>> { Ok(vec![]) }
+```
+
+The [`context`] module covers writing guards as functions on [`Cx`].
+
 # Arguments And Return Type
 
 Argument types must belong to the shared vocabulary of [`expr!`], since their values cross between Rust and JavaScript. The return type is [`Result`], whose `Ok` value is the rendered view.
@@ -60,6 +85,7 @@ Each shard is served by a route on the [`Router`]. `.discover()` registers every
 let router = Router::builder().shard(search_results).build();
 ```
 
+[`context`]: ../context/index.html
 [`Cx`]: ../context/struct.Cx.html
 [`Result`]: ../type.Result.html
 [`Router`]: ../router/struct.Router.html


### PR DESCRIPTION
## Summary

A shard is served by its own POST endpoint, so a request to `/_topcoat/shards/{uuid}` runs the shard function and nothing else. The page that contains the shard does not run, its layouts do not run, and a guard either of them applies does not cover the shard. The behavior is correct and the docs state that shard arguments must not be trusted; the missing piece is the statement at the call site that a page guard is not a shard guard.

In an application I built on Topcoat the page was guarded with `ok_or_unauthorized()` and the live widget inside it was not. One POST to the shard endpoint with no session returned 200 and 7889 bytes of another account's data. The page renders, no request fails, and no lint fires.

This adds a `Guards` section to `shard.md` after `Shard State`: the rule, the reason the arguments fall under it, and a snippet that resolves the session inside the shard.

## Testing

Reproduced against `main` at 01cdbd9 with a page guarded by `ok_or_unauthorized()` and a shard rendering private rows:

```
page, session present:        200
page, no session:             401, 12 bytes
shard endpoint, no session:   200, 125 bytes, the private rows in the body
```

Moving the same guard into the shard turns the third line into `401, 12 bytes` and leaves the authenticated call at 200.

Checks from `.agents/skills/check/SKILL.md`:

```
cargo +nightly fmt --all                                                        no diff
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings   0 warnings
cargo test --workspace --all-features                                           1644 passed, 0 failed
RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked   0 warnings
```

The new snippet runs as doctest `shard.md - shard (line 50)` in `topcoat-runtime-macro`.

No open pull request touches `crates/topcoat-runtime/macro/docs/shard.md`; #242, #243, #245 and #248 were checked file by file.

## Disclaimer

Written with Claude Opus 5 in Claude Code. The agent located the defect, wrote the fix, and ran the checks; I reviewed the diff and the test output before opening this PR.
