### PR TITLE
fix(runtime): derive shard and procedure ids from the declaration site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,6 @@ dependencies = [
  "syn",
  "topcoat-core-grammar",
  "topcoat-runtime",
- "uuid",
 ]
 
 [[package]]

--- a/crates/topcoat-runtime/grammar/Cargo.toml
+++ b/crates/topcoat-runtime/grammar/Cargo.toml
@@ -23,7 +23,6 @@ syn = { workspace = true, features = ["full", "visit"] }
 
 serde.workspace = true
 serde_json.workspace = true
-uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/topcoat-runtime/grammar/src/procedure.rs
+++ b/crates/topcoat-runtime/grammar/src/procedure.rs
@@ -120,13 +120,29 @@ impl ToTokens for Procedure {
         };
         let return_ty = quote! { <#return_ty as #topcoat_internal::ResultExt>::T };
 
-        let id = uuid::Uuid::new_v4().to_string();
+        let id_ident = format_ident!("__TOPCOAT_PROCEDURE_ID_{}", ident);
 
         quote! {
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            const #id_ident: &'static ::core::primitive::str = {
+                const HASH: u64 = #topcoat_runtime::endpoint_id_hash(
+                    ::core::env!("CARGO_CRATE_NAME"),
+                    ::core::module_path!(),
+                    ::core::stringify!(#ident),
+                );
+                const BYTES: [u8; #topcoat_runtime::ENDPOINT_ID_LEN] =
+                    #topcoat_runtime::endpoint_id_hex(HASH);
+                match ::core::str::from_utf8(&BYTES) {
+                    ::core::result::Result::Ok(id) => id,
+                    ::core::result::Result::Err(_) => ::core::panic!("hex is ascii"),
+                }
+            };
+
             #(#docs)*
             #[allow(non_upper_case_globals)]
             #vis const #ident: &#topcoat_runtime::Procedure::<(#(#arg_tys,)*), #return_ty> = &#topcoat_runtime::Procedure::new(
-                #topcoat_runtime::ProcedureId::new(#id),
+                #topcoat_runtime::ProcedureId::new(#id_ident),
                 |cx, body| {
                     #[allow(clippy::unused_async)]
                     #item
@@ -157,6 +173,29 @@ mod tests {
             Ok(_) => panic!("expected parse error for `{source}`"),
             Err(err) => err.to_string(),
         }
+    }
+
+    fn expand(source: &str) -> String {
+        Procedure::parse(TokenStream::new(), source.parse().unwrap())
+            .unwrap()
+            .to_token_stream()
+            .to_string()
+    }
+
+    const SOURCE: &str = "async fn double(value: f64) -> Result<f64> { Ok(value * 2.0) }";
+
+    #[test]
+    fn expands_to_the_same_id_every_time() {
+        assert_eq!(expand(SOURCE), expand(SOURCE));
+    }
+
+    #[test]
+    fn derives_the_id_from_the_crate_module_and_name() {
+        let expanded = expand(SOURCE);
+        assert!(expanded.contains("endpoint_id_hash"));
+        assert!(expanded.contains("CARGO_CRATE_NAME"));
+        assert!(expanded.contains("module_path ! ()"));
+        assert!(expanded.contains("stringify ! (double)"));
     }
 
     #[test]

--- a/crates/topcoat-runtime/grammar/src/shard.rs
+++ b/crates/topcoat-runtime/grammar/src/shard.rs
@@ -10,7 +10,6 @@ use topcoat_core_grammar::paths::{
     topcoat_context, topcoat_error, topcoat_inventory, topcoat_router, topcoat_runtime,
     topcoat_view, topcoat_view_macro,
 };
-use uuid::Uuid;
 
 use crate::shard::{ShardAttr, ShardItem};
 
@@ -96,9 +95,25 @@ impl ToTokens for Shard {
 
         let impl_ident = format_ident!("__topcoat_shard_impl_{}", ident);
         let erased_ident = format_ident!("__TOPCOAT_SHARD_ERASED_{}", ident);
-        let id = Uuid::new_v4().to_string();
+        let id_ident = format_ident!("__TOPCOAT_SHARD_ID_{}", ident);
 
         quote! {
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            const #id_ident: &'static ::core::primitive::str = {
+                const HASH: u64 = #topcoat_runtime::endpoint_id_hash(
+                    ::core::env!("CARGO_CRATE_NAME"),
+                    ::core::module_path!(),
+                    ::core::stringify!(#ident),
+                );
+                const BYTES: [u8; #topcoat_runtime::ENDPOINT_ID_LEN] =
+                    #topcoat_runtime::endpoint_id_hex(HASH);
+                match ::core::str::from_utf8(&BYTES) {
+                    ::core::result::Result::Ok(id) => id,
+                    ::core::result::Result::Err(_) => ::core::panic!("hex is ascii"),
+                }
+            };
+
             // The user's real body. Shared by the component's initial render and
             // the server endpoint that re-renders the shard. The leading `__cx`
             // parameter makes the request context implicitly available to macros
@@ -116,7 +131,7 @@ impl ToTokens for Shard {
                 )*
                 let __placeholder = #impl_ident(__cx, #(#call_args),*).await?;
                 let __scope = #topcoat_runtime::ReactiveScope::new(
-                    #topcoat_runtime::ShardId::new(#id),
+                    #topcoat_runtime::ShardId::new(#id_ident),
                     ::std::vec![#(#js_idents),*],
                     __placeholder,
                 );
@@ -135,7 +150,7 @@ impl ToTokens for Shard {
             #[allow(non_upper_case_globals)]
             const #erased_ident: #topcoat_runtime::ErasedShard =
                 #topcoat_runtime::ErasedShard::new(
-                    #topcoat_runtime::ShardId::new(#id),
+                    #topcoat_runtime::ShardId::new(#id_ident),
                     |cx, body| ::std::boxed::Box::pin(async move {
                         type __Surrogate =
                             <(#(#value_tys,)*) as #topcoat_runtime::Surrogated>::Surrogate;
@@ -163,5 +178,33 @@ impl ToTokens for Shard {
             }
             .to_tokens(tokens);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand(source: &str) -> String {
+        Shard::parse(TokenStream::new(), source.parse().unwrap())
+            .unwrap()
+            .to_token_stream()
+            .to_string()
+    }
+
+    const SOURCE: &str = "async fn rows(query: String) -> Result { view! { (query) } }";
+
+    #[test]
+    fn expands_to_the_same_id_every_time() {
+        assert_eq!(expand(SOURCE), expand(SOURCE));
+    }
+
+    #[test]
+    fn derives_the_id_from_the_crate_module_and_name() {
+        let expanded = expand(SOURCE);
+        assert!(expanded.contains("endpoint_id_hash"));
+        assert!(expanded.contains("CARGO_CRATE_NAME"));
+        assert!(expanded.contains("module_path ! ()"));
+        assert!(expanded.contains("stringify ! (rows)"));
     }
 }

--- a/crates/topcoat-runtime/macro/docs/procedure.md
+++ b/crates/topcoat-runtime/macro/docs/procedure.md
@@ -61,6 +61,10 @@ async fn search(cx: &Cx, query: String) -> Result<String> {
 
 Awaiting a call yields the procedure's `Ok` value directly. An `Err` becomes an error response, and the expression awaiting the call fails in the browser without a value; the error itself is not observable from the expression. If the client needs to react to failures, return the outcome as data instead, for example with an `Ok` type of `Result<String, String>`.
 
+# Endpoint URLs
+
+A procedure is served from `/_topcoat/procedures/<id>`, where `<id>` is a hash of the declaring crate, the module path, and the function name. The same source produces the same id on every build, so a page loaded before a deploy keeps calling the procedure after it. Renaming the function, moving it to another module, or renaming the crate changes the id and retires the old URL.
+
 # Registration
 
 Each procedure is served by a route on the [`Router`]. `.discover()` registers every procedure linked into the binary; alternatively, mount procedures individually:

--- a/crates/topcoat-runtime/macro/docs/shard.md
+++ b/crates/topcoat-runtime/macro/docs/shard.md
@@ -74,6 +74,12 @@ Argument types must belong to the shared vocabulary of [`expr!`], since their va
 
 A parameter named `cx` borrowing [`Cx`] is special: just like in a component, it is filled from the request context on the server and does not take an argument at the call site.
 
+# Endpoint URLs
+
+A shard is served from `/_topcoat/shards/<id>`, where `<id>` is a hash of the declaring crate, the module path, and the function name. The same source produces the same id on every build, so a browser tab opened before a deploy keeps reaching the shard after it. Renaming the function, moving it to another module, or renaming the crate changes the id and retires the old URL.
+
+A URL that outlives a deploy is a URL an attacker can keep, which is another reason for the shard to resolve authorization itself, as covered under [Guards](#guards).
+
 # Registration
 
 Each shard is served by a route on the [`Router`]. `.discover()` registers every shard linked into the binary; alternatively, mount shards individually:

--- a/crates/topcoat-runtime/src/id.rs
+++ b/crates/topcoat-runtime/src/id.rs
@@ -1,0 +1,94 @@
+//! Derivation of the ids that name shard and procedure endpoints.
+//!
+//! The `#[shard]` and `#[procedure]` macros cannot see the module a
+//! declaration lives in, because expansion happens before name resolution.
+//! They instead emit `module_path!()` into the generated code and fold it
+//! here, in the declaring crate, the same way
+//! [`AssetId::new`](topcoat_asset::AssetId::new) folds an asset declaration.
+//!
+//! The key is the declaring crate, the module path, and the item name. Two
+//! items cannot share a name inside one module, so the key is collision-free
+//! for declarations at module scope, and it stays the same across rebuilds of
+//! unchanged source.
+
+use topcoat_core::fnv1a;
+
+/// Length of the ASCII hex string an endpoint id renders as.
+pub const ENDPOINT_ID_LEN: usize = 16;
+
+/// Folds the declaration site of a shard or procedure into one `u64`.
+///
+/// `crate_name` comes from `CARGO_CRATE_NAME`, `module_path` from
+/// `module_path!()`, and `ident` from the name of the annotated function.
+#[must_use]
+pub const fn endpoint_id_hash(crate_name: &str, module_path: &str, ident: &str) -> u64 {
+    let mut h = fnv1a::hash(crate_name.as_bytes());
+    h = fnv1a::hash_continue(h, b"\0");
+    h = fnv1a::hash_continue(h, module_path.as_bytes());
+    h = fnv1a::hash_continue(h, b"\0");
+    h = fnv1a::hash_continue(h, ident.as_bytes());
+    h
+}
+
+/// Renders `hash` as lowercase, big-endian ASCII hex.
+///
+/// The result is valid UTF-8 and safe in a URL path segment, so generated
+/// code turns it into the `&'static str` a shard or procedure id wraps.
+#[must_use]
+pub const fn endpoint_id_hex(hash: u64) -> [u8; ENDPOINT_ID_LEN] {
+    const DIGITS: [u8; 16] = *b"0123456789abcdef";
+
+    let bytes = hash.to_be_bytes();
+    let mut out = [b'0'; ENDPOINT_ID_LEN];
+    let mut i = 0;
+    while i < bytes.len() {
+        out[i * 2] = DIGITS[(bytes[i] >> 4) as usize];
+        out[i * 2 + 1] = DIGITS[(bytes[i] & 0x0f) as usize];
+        i += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(crate_name: &str, module_path: &str, ident: &str) -> String {
+        let bytes = endpoint_id_hex(endpoint_id_hash(crate_name, module_path, ident));
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn pins_the_id_of_a_known_declaration() {
+        assert_eq!(id("my_app", "my_app::widgets", "rows"), "7fc28631a7c30011");
+    }
+
+    #[test]
+    fn separates_the_same_name_in_two_modules() {
+        assert_ne!(
+            id("my_app", "my_app::a", "rows"),
+            id("my_app", "my_app::b", "rows")
+        );
+    }
+
+    #[test]
+    fn separates_the_same_declaration_in_two_crates() {
+        assert_ne!(
+            id("my_app", "shared::widgets", "rows"),
+            id("other_app", "shared::widgets", "rows")
+        );
+    }
+
+    #[test]
+    fn renders_hex_of_a_fixed_width() {
+        assert_eq!(id("a", "b", "c").len(), ENDPOINT_ID_LEN);
+        assert_eq!(
+            String::from_utf8(endpoint_id_hex(0).to_vec()).unwrap(),
+            "0000000000000000"
+        );
+        assert_eq!(
+            String::from_utf8(endpoint_id_hex(u64::MAX).to_vec()).unwrap(),
+            "ffffffffffffffff"
+        );
+    }
+}

--- a/crates/topcoat-runtime/src/lib.rs
+++ b/crates/topcoat-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod bind_attribute;
 mod event_handler;
 mod expr;
+mod id;
 #[cfg(feature = "router")]
 mod procedure;
 #[cfg(feature = "router")]
@@ -15,6 +16,7 @@ mod surrogate;
 pub use bind_attribute::*;
 pub use event_handler::*;
 pub use expr::*;
+pub use id::*;
 #[cfg(feature = "router")]
 pub use procedure::*;
 #[cfg(feature = "router")]


### PR DESCRIPTION
## Summary

Fixes #252. `#[shard]` and `#[procedure]` minted their endpoint id with `Uuid::new_v4()` at macro expansion time, so every compilation produced new URLs under `/_topcoat/shards/<id>` and `/_topcoat/procedures/<id>`. A browser tab left open across a deploy keeps polling the previous binary's id, the new binary does not serve it, and the failure is silent: the runtime swaps the empty body in and the widget content disappears with nothing in the console. `topcoat asset bundle` compiles the crate, so the bundling step can mint fresh ids partway through a deploy sequence.

The macros now emit `module_path!()` into the generated code and hash it in the declaring crate, the same shape as `AssetId::new` doing its work at the declaration site. The key is `CARGO_CRATE_NAME`, the module path, and the function name, folded with the in-tree `fnv1a` const hash and rendered as 16 ASCII hex characters. Two items cannot share a name inside one module, so that key is collision-free for declarations at module scope, where hashing the source file would not be: two modules in one file can each hold a `#[shard] fn rows`. The derivation, the argument for it, and the check that it compiles and survives a rebuild are AmeinEskinder's, from his comment on #252.

`ShardId` and `ProcedureId` keep their `&'static str` newtype and `const fn new`, and the route path still comes from `as_str`. Nothing in the tree parses or validates the id shape: the two route builders interpolate it with `format!`, `ReactiveScope` writes it into the scope comment, and the browser runtime passes it through `encodeURIComponent`. The id is 16 hex characters rather than a 36-character uuid, which no consumer notices.

The tradeoff, stated plainly because it is a maintainer decision: a derived id makes a shard or procedure URL permanent across deploys, where today it changes on every build, so someone who records a URL keeps a working one instead of losing it at the next deploy. Shard endpoints need their own authorization either way, as the guards note from #251 says. If you want a different derivation, such as a per-deploy salt or an opt-in `#[shard(id = "...")]` escape hatch, redirect me and I will redo it.

## Testing

Before, on `main`, expanding `examples/shard` twice with only a comment changed between the two runs:

```
$ cargo +nightly rustc -p shard --profile=check -- -Zunpretty=expanded | grep -o 'ShardId::new("[^"]*")'
ShardId::new("4d223daa-a583-4c0a-9976-fb7ce4c1b9c7")

$ printf '\n// touch to force a rebuild\n' >> examples/shard/src/main.rs
$ cargo +nightly rustc -p shard --profile=check -- -Zunpretty=expanded | grep -o 'ShardId::new("[^"]*")'
ShardId::new("5404c1da-f715-45ef-927c-fa05f6a46b92")
```

After, the id is computed in the declaring crate, so it appears in the binary rather than in the expansion. `6aaf9450fdc57264` is `endpoint_id_hash("shard", "shard", "combobox_content")`, and the same comment edit leaves it in place:

```
$ cargo build -p shard && grep -ao 6aaf9450fdc57264 target/debug/shard
6aaf9450fdc57264
$ md5sum target/debug/shard
eadc9c7ad4d30bc55034f7fd3da6427e  target/debug/shard

$ printf '\n// touch to force a rebuild\n' >> examples/shard/src/main.rs
$ cargo build -p shard && grep -ao 6aaf9450fdc57264 target/debug/shard
6aaf9450fdc57264
$ md5sum target/debug/shard
eadc9c7ad4d30bc55034f7fd3da6427e  target/debug/shard
```

`examples/procedure` behaves the same way, serving `82edc9c5c31a7706` for `print_on_server`.

New tests: `crates/topcoat-runtime/src/id.rs` pins the id of a known crate, module, and name, so a change in the derivation fails loudly, and covers the module and crate separation plus the hex width. The shard and procedure grammars each gain a test that two expansions of one source are identical and that the id comes from crate, module, and name.

Check gauntlet from `.agents/skills/check/SKILL.md`:

```
$ cargo +nightly fmt --all
$ cargo +nightly fmt --all --check
(clean)

$ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 33s
(exit 0, no warnings)

$ cargo test --workspace --all-features
(exit 0, 1656 passed, 0 failed)

$ RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.29s
   Generated target/doc/alpine_ajax/index.html and 59 other files
(exit 0)
```

`crates/topcoat-runtime/browser` is untouched, so `dist/index.js` is unchanged and the yarn steps do not apply.

## Disclaimer

Written with Claude Opus 5 in Claude Code. The agent located the defect, wrote the fix, and ran the checks; I reviewed the diff and the test output before opening this PR.
