### PR TITLE
fix(datastar): reject multiline selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,7 @@ version = "0.5.0"
 dependencies = [
  "futures-util",
  "http",
+ "memchr",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/topcoat-datastar/Cargo.toml
+++ b/crates/topcoat-datastar/Cargo.toml
@@ -16,6 +16,7 @@ topcoat-router = { workspace = true, features = ["sse"] }
 
 futures-util.workspace = true
 http.workspace = true
+memchr.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/topcoat-datastar/src/common.rs
+++ b/crates/topcoat-datastar/src/common.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use futures_util::stream;
+use memchr::memchr2;
 use topcoat_core::{context::Cx, error::Result};
 use topcoat_router::{
     IntoResponse, Response,
@@ -14,7 +15,7 @@ pub(crate) const PATCH_SIGNALS_EVENT: &str = "datastar-patch-signals";
 #[track_caller]
 pub(crate) fn assert_valid_selector(selector: &str) {
     assert!(
-        !selector.contains(['\r', '\n']),
+        memchr2(b'\r', b'\n', selector.as_bytes()).is_none(),
         "Datastar selectors cannot contain line breaks"
     );
 }

--- a/crates/topcoat-datastar/src/common.rs
+++ b/crates/topcoat-datastar/src/common.rs
@@ -10,6 +10,15 @@ use topcoat_router::{
 pub(crate) const PATCH_ELEMENTS_EVENT: &str = "datastar-patch-elements";
 pub(crate) const PATCH_SIGNALS_EVENT: &str = "datastar-patch-signals";
 
+/// Panics if `selector` cannot be represented on one Datastar command line.
+#[track_caller]
+pub(crate) fn assert_valid_selector(selector: &str) {
+    assert!(
+        !selector.contains(['\r', '\n']),
+        "Datastar selectors cannot contain line breaks"
+    );
+}
+
 /// Assembles a Datastar event of the given `kind`, joining the already
 /// prefixed data `lines`.
 pub(crate) fn event(

--- a/crates/topcoat-datastar/src/patch_elements.rs
+++ b/crates/topcoat-datastar/src/patch_elements.rs
@@ -50,10 +50,18 @@ impl PatchElements {
 
     /// Creates a patch that removes the elements matching `selector` from the
     /// DOM.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `selector` contains a line break.
+    #[track_caller]
     pub fn remove(selector: impl Into<String>) -> Self {
+        let selector = selector.into();
+        common::assert_valid_selector(&selector);
+
         Self {
             elements: None,
-            selector: Some(selector.into()),
+            selector: Some(selector),
             mode: ElementPatchMode::Remove,
             use_view_transition: false,
             id: None,
@@ -63,8 +71,15 @@ impl PatchElements {
 
     /// Targets the elements matching this CSS selector instead of matching by
     /// `id`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `selector` contains a line break.
+    #[track_caller]
     pub fn selector(mut self, selector: impl Into<String>) -> Self {
-        self.selector = Some(selector.into());
+        let selector = selector.into();
+        common::assert_valid_selector(&selector);
+        self.selector = Some(selector);
         self
     }
 
@@ -192,6 +207,30 @@ mod tests {
              data: selector #stale\n\
              data: mode remove\n\n"
         );
+    }
+
+    #[test]
+    fn selector_line_breaks_panic() {
+        for selector in [
+            "#feed\nelements <img src=x onerror=alert(1)>",
+            "#feed\relements <img src=x onerror=alert(1)>",
+            "#feed\r\nelements <img src=x onerror=alert(1)>",
+        ] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    let _ = PatchElements::new("<p>safe</p>").selector(selector);
+                })
+                .is_err(),
+                "selector should panic for {selector:?}"
+            );
+            assert!(
+                std::panic::catch_unwind(|| {
+                    let _ = PatchElements::remove(selector);
+                })
+                .is_err(),
+                "remove should panic for {selector:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/topcoat-datastar/src/response.rs
+++ b/crates/topcoat-datastar/src/response.rs
@@ -5,25 +5,34 @@ use serde_json::Value;
 use topcoat_core::{context::Cx, error::Result};
 use topcoat_router::IntoResponseParts;
 
-use crate::ElementPatchMode;
-use crate::header;
+use crate::{ElementPatchMode, common, header};
 
 /// Targets the elements a `text/html` response patches via the
 /// `datastar-selector` header. The value is a CSS selector.
 ///
 /// Without it, Datastar matches the response's elements to the DOM by their
 /// `id` attribute.
+///
+/// # Panics
+///
+/// Converting from a selector containing a line break panics. Applying a
+/// directly constructed value containing a line break also panics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatastarSelector(pub String);
 
 impl<T: Into<String>> From<T> for DatastarSelector {
+    #[track_caller]
     fn from(selector: T) -> Self {
-        Self(selector.into())
+        let selector = selector.into();
+        common::assert_valid_selector(&selector);
+        Self(selector)
     }
 }
 
 impl IntoResponseParts for DatastarSelector {
+    #[track_caller]
     fn into_response_parts(self, _cx: &Cx, parts: &mut Parts) -> Result<()> {
+        common::assert_valid_selector(&self.0);
         parts
             .headers
             .insert(header::DATASTAR_SELECTOR, HeaderValue::from_str(&self.0)?);
@@ -154,6 +163,31 @@ mod tests {
             .into_response_parts(&Cx::default(), &mut parts)
             .unwrap();
         assert_eq!(header_value(&parts, &header::DATASTAR_SELECTOR), "#feed");
+    }
+
+    #[test]
+    fn selector_line_breaks_panic() {
+        for selector in [
+            "#feed\nelements <img src=x onerror=alert(1)>",
+            "#feed\relements <img src=x onerror=alert(1)>",
+            "#feed\r\nelements <img src=x onerror=alert(1)>",
+        ] {
+            assert!(
+                std::panic::catch_unwind(|| DatastarSelector::from(selector)).is_err(),
+                "conversion should panic for {selector:?}"
+            );
+
+            let mut parts = parts();
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    DatastarSelector(selector.to_owned())
+                        .into_response_parts(&Cx::default(), &mut parts)
+                        .unwrap();
+                }))
+                .is_err(),
+                "direct construction should panic for {selector:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject carriage returns and newlines in Datastar selector APIs
- validate both `PatchElements` selectors and `DatastarSelector` response headers
- report invalid-selector panics at the caller with `#[track_caller]`
- keep multiline HTML, scripts, and signal payloads supported

Datastar selectors are single-line command arguments. Accepting line breaks let one selector value be interpreted as multiple commands, so invalid selectors now fail at the public API edge.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt` (543 files checked, 0 modified; only the known Leptos benchmark parse errors)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI disclaimer

OpenAI Codex (GPT-5) was used to inspect the affected code, implement the validation and tests, and run the verification commands. The maintainer directed the API behavior and reviewed the design decisions.