### PR TITLE
fix(router): isolate request panics

### DIFF
--- a/crates/topcoat-router/src/error.rs
+++ b/crates/topcoat-router/src/error.rs
@@ -33,6 +33,13 @@ pub(crate) fn respond(cx: &Cx, value: impl IntoResponse) -> Response {
         .unwrap_or_else(|error| error_into_response(cx, error))
 }
 
+/// Builds a bare 500 response without consulting request or application code.
+pub(crate) fn internal_server_response() -> Response {
+    let mut response = Response::new(Body::from("internal server error"));
+    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+    response
+}
+
 /// Maps the framework's error types onto their HTTP status codes, falling back
 /// to a 500 for anything else.
 fn error_into_response(cx: &Cx, error: Error) -> Response {
@@ -59,11 +66,9 @@ fn error_into_response(cx: &Cx, error: Error) -> Response {
 /// Renders an error response, falling back to a bare 500 (none of the error
 /// types' responses can actually fail to build).
 fn into_response_or_500(cx: &Cx, value: impl IntoResponse) -> Response {
-    value.into_response(cx).unwrap_or_else(|_| {
-        let mut response = Response::new(Body::from("internal server error"));
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
-    })
+    value
+        .into_response(cx)
+        .unwrap_or_else(|_| internal_server_response())
 }
 
 /// Renders the contained value, or the framework error response on `Err`.

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -2,14 +2,19 @@ use std::any::{Any, type_name};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
+use std::future::{Future, poll_fn};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::pin::pin;
 use std::sync::Arc;
+use std::task::Poll;
 
 use topcoat_core::base_url::BaseUrl;
 use topcoat_core::context::{ContextMap, CxBuilder};
 
 use crate::{
     Endpoint, Layer, LayerId, Layers, LayoutFn, Methods, Next, PageFn, PageWithLayouts,
-    PathSegment, RawPathParams, Request, Response, Route, Terminal, error::respond,
+    PathSegment, RawPathParams, Request, Response, Route, Terminal,
+    error::{internal_server_response, respond},
 };
 
 /// A finalized Topcoat routing table.
@@ -61,8 +66,26 @@ impl Router {
     /// A route registered for the request's specific method wins over an
     /// any-method route at the same path. Returns `404 Not Found` when no
     /// route matches the path, or `405 Method Not Allowed` (with an `Allow`
-    /// header) when the path matches but no route accepts the method.
+    /// header) when the path matches but no route accepts the method. A panic
+    /// while processing the request becomes a `500 Internal Server Error`
+    /// response.
     pub async fn handle(&self, request: Request) -> Response {
+        let mut future = pin!(self.handle_inner(request));
+
+        poll_fn(|cx| {
+            // The whole request and its context are discarded after a panic,
+            // so no potentially inconsistent request-local state is reused.
+            match catch_unwind(AssertUnwindSafe(|| future.as_mut().poll(cx))) {
+                Ok(Poll::Ready(response)) => Poll::Ready(response),
+                Ok(Poll::Pending) => Poll::Pending,
+                Err(_) => Poll::Ready(internal_server_response()),
+            }
+        })
+        .await
+    }
+
+    /// Handles one request inside the panic isolation boundary.
+    async fn handle_inner(&self, request: Request) -> Response {
         let (parts, body) = request.into_parts();
 
         // Resolve the layer stack and the chain's terminal. A matched path
@@ -585,7 +608,7 @@ mod tests {
     use http::{HeaderMap, StatusCode};
     use topcoat_core::context::{Cx, app_context, request_context};
     use topcoat_core::error::Result;
-    use topcoat_view::{HtmlContext, PartsWriter, View, ViewParts};
+    use topcoat_view::{DynViewPart, HtmlContext, HtmlWriter, PartsWriter, View, ViewParts};
 
     use super::*;
     use crate::{
@@ -632,6 +655,14 @@ mod tests {
 
     fn say_posted(cx: &Cx, _body: Body) -> RouteFuture<'_> {
         Box::pin(async move { "posted".into_response(cx) })
+    }
+
+    fn panic_route(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        Box::pin(async move { panic!("request handler panicked") })
+    }
+
+    fn panic_before_future_route(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        panic!("request handler panicked before returning its future");
     }
 
     /// Echoes the captured path params as `key=value` pairs joined by `&`.
@@ -700,6 +731,27 @@ mod tests {
 
     fn render_page(_cx: &Cx, _body: Body) -> ViewFuture<'_> {
         Box::pin(async move { Ok(view("page")) })
+    }
+
+    #[derive(Debug, Clone)]
+    struct PanickingViewPart;
+
+    impl DynViewPart for PanickingViewPart {
+        fn render(&self, _cx: &Cx, _w: &mut HtmlWriter<'_, '_>) {
+            panic!("view rendering panicked");
+        }
+
+        fn clone_box(&self) -> Box<dyn DynViewPart> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn render_panicking_page(_cx: &Cx, _body: Body) -> ViewFuture<'_> {
+        Box::pin(async move {
+            let mut parts = ViewParts::new();
+            PartsWriter::new(&mut parts, HtmlContext::Text).push_dyn(Box::new(PanickingViewPart));
+            Ok(View::new(parts))
+        })
     }
 
     /// Wraps the child content in `R[ ... ]` so layout nesting is observable.
@@ -838,6 +890,31 @@ mod tests {
         // The catch-all captures the remainder of the URL, slashes included.
         let (_, _, body) = send(&router, Method::GET, "/files/a/b/c");
         assert_eq!(&body[..], b"rest=a/b/c");
+    }
+
+    #[test]
+    fn handler_panics_become_internal_server_errors() {
+        let router = RouterBuilder::new()
+            .route(RouteFn::new(Method::GET, path("/panic"), panic_route))
+            .route(RouteFn::new(
+                Method::GET,
+                path("/early-panic"),
+                panic_before_future_route,
+            ))
+            .route(RouteFn::new(Method::GET, path("/x"), say_route))
+            .build();
+
+        let (status, _, body) = send(&router, Method::GET, "/panic");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(&body[..], b"internal server error");
+
+        let (status, _, body) = send(&router, Method::GET, "/early-panic");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(&body[..], b"internal server error");
+
+        let (status, _, body) = send(&router, Method::GET, "/x");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"route");
     }
 
     // -- Router::handle: method sets --
@@ -1171,6 +1248,26 @@ mod tests {
             "text/html; charset=utf-8"
         );
         assert_eq!(&body[..], b"page");
+    }
+
+    #[test]
+    fn rendering_panic_becomes_internal_server_error() {
+        let router = RouterBuilder::new()
+            .page(PageFn::new(
+                Method::GET,
+                path("/panic"),
+                render_panicking_page,
+            ))
+            .route(RouteFn::new(Method::GET, path("/x"), say_route))
+            .build();
+
+        let (status, _, body) = send(&router, Method::GET, "/panic");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(&body[..], b"internal server error");
+
+        let (status, _, body) = send(&router, Method::GET, "/x");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"route");
     }
 
     #[test]

--- a/crates/topcoat-router/src/serve.rs
+++ b/crates/topcoat-router/src/serve.rs
@@ -112,9 +112,13 @@ pub async fn internal_serve(
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
+    use std::convert::Infallible;
     use std::net::SocketAddr;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
+    use http_body::Frame;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::oneshot;
@@ -122,7 +126,10 @@ mod tests {
     use topcoat_core::context::Cx;
 
     use super::*;
-    use crate::{Body, IntoResponse, Method, Path, RouteFn, RouteFuture, RouteHandlerFn, Router};
+    use crate::{
+        Body, Bytes, IntoResponse, Method, Path, Response, RouteFn, RouteFuture, RouteHandlerFn,
+        Router,
+    };
 
     /// Builds a router with `handler` registered under `GET /x`.
     fn router_with(handler: RouteHandlerFn) -> Router {
@@ -137,6 +144,28 @@ mod tests {
 
     fn say_route(cx: &Cx, _body: Body) -> RouteFuture<'_> {
         Box::pin(async move { "served".into_response(cx) })
+    }
+
+    fn panic_route(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        Box::pin(async move { panic!("request handler panicked") })
+    }
+
+    struct PanickingBody;
+
+    impl http_body::Body for PanickingBody {
+        type Data = Bytes;
+        type Error = Infallible;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            panic!("response body panicked");
+        }
+    }
+
+    fn panicking_body_route(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        Box::pin(async move { Ok(Response::new(Body::new(PanickingBody))) })
     }
 
     /// A route slow enough that a shutdown signal lands mid-request.
@@ -176,19 +205,27 @@ mod tests {
             .unwrap();
     }
 
+    async fn get(addr: SocketAddr, path: &str) -> String {
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(
+                format!("GET {path} HTTP/1.1\r\nhost: test\r\nconnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).await.unwrap();
+        response
+    }
+
     #[tokio::test]
     async fn returns_once_the_shutdown_signal_fires() {
         let service = RouterService::new(router_with(say_route));
         let (addr, shutdown_tx, server) = spawn_server(service).await;
 
         // A roundtrip proves the server is up before it is shut down.
-        let mut stream = TcpStream::connect(addr).await.unwrap();
-        stream
-            .write_all(b"GET /x HTTP/1.1\r\nhost: test\r\nconnection: close\r\n\r\n")
-            .await
-            .unwrap();
-        let mut response = String::new();
-        stream.read_to_string(&mut response).await.unwrap();
+        let response = get(addr, "/x").await;
         assert!(response.contains("200 OK"));
         assert!(response.ends_with("served"));
 
@@ -197,6 +234,68 @@ mod tests {
 
         // The listener is gone; new connections are refused.
         assert!(TcpStream::connect(addr).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_panic_returns_500_and_server_keeps_running() {
+        let router = Router::builder()
+            .route(RouteFn::new(
+                Method::GET,
+                Cow::Borrowed(Path::new("/panic")),
+                panic_route,
+            ))
+            .route(RouteFn::new(
+                Method::GET,
+                Cow::Borrowed(Path::new("/x")),
+                say_route,
+            ))
+            .build();
+        let (addr, shutdown_tx, server) = spawn_server(RouterService::new(router)).await;
+
+        let response = get(addr, "/panic").await;
+        assert!(response.contains("500 Internal Server Error"));
+        assert!(response.ends_with("internal server error"));
+
+        let response = get(addr, "/x").await;
+        assert!(response.contains("200 OK"));
+        assert!(response.ends_with("served"));
+
+        shutdown_tx.send(()).unwrap();
+        shut_down(server).await;
+    }
+
+    #[tokio::test]
+    async fn response_body_panic_does_not_stop_server() {
+        let router = Router::builder()
+            .route(RouteFn::new(
+                Method::GET,
+                Cow::Borrowed(Path::new("/body-panic")),
+                panicking_body_route,
+            ))
+            .route(RouteFn::new(
+                Method::GET,
+                Cow::Borrowed(Path::new("/x")),
+                say_route,
+            ))
+            .build();
+        let (addr, shutdown_tx, server) = spawn_server(RouterService::new(router)).await;
+
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"GET /body-panic HTTP/1.1\r\nhost: test\r\nconnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = String::new();
+        // The response has already left the router, so the body panic ends
+        // this connection instead of becoming a replacement 500 response.
+        let _ = stream.read_to_string(&mut response).await;
+
+        let response = get(addr, "/x").await;
+        assert!(response.contains("200 OK"));
+        assert!(response.ends_with("served"));
+
+        shutdown_tx.send(()).unwrap();
+        shut_down(server).await;
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- catch unwinding request futures at the router edge and return a bare 500 response for handler and buffered view-render panics
- keep late response-body panics isolated to their connection after the response has already started
- add router and live-server regressions covering early and asynchronous handler panics, deferred rendering, and continued process operation

Previously, request futures were polled directly by the connection task, so a panic closed the connection without producing an HTTP response.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt` (521 files checked, 0 modified; expected Leptos benchmark parse reports only)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI disclaimer

Created with OpenAI Codex (GPT-5). AI was used to inspect the request path, implement panic isolation, add regression tests, and run the verification checks.