### PR TITLE
feat(router): add a service-unavailable error with a Retry-After hint

### DIFF
--- a/crates/topcoat-router/docs/error.md
+++ b/crates/topcoat-router/docs/error.md
@@ -4,7 +4,7 @@ Every page, layout, layer, and route handler returns a `Result`. An `Err` become
 
 # Constructors
 
-Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], and [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description.
+Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description, and [`service_unavailable(secs)`](service_unavailable) responds 503 with [`ServiceUnavailableError`] and a `Retry-After` header.
 
 A constructor returns a concrete error type that converts into the handler's error, so bubble it up with `?` or return it directly:
 

--- a/crates/topcoat-router/src/error.rs
+++ b/crates/topcoat-router/src/error.rs
@@ -7,6 +7,7 @@ mod internal_server;
 mod method_not_allowed;
 mod not_found;
 mod redirect;
+mod service_unavailable;
 mod unauthorized;
 
 pub use bad_request::*;
@@ -17,6 +18,7 @@ pub use internal_server::*;
 pub use method_not_allowed::*;
 pub use not_found::*;
 pub use redirect::*;
+pub use service_unavailable::*;
 use topcoat_core::{
     context::Cx,
     error::{Error, Result},
@@ -63,6 +65,7 @@ fn error_into_response(cx: &Cx, error: Error) -> Response {
     let error = try_downcast!(error as MethodNotAllowedError);
     let error = try_downcast!(error as RedirectError);
     let error = try_downcast!(error as UnauthorizedError);
+    let error = try_downcast!(error as ServiceUnavailableError);
 
     into_response_or_500(cx, internal_server_error(error))
 }
@@ -268,5 +271,40 @@ impl<T, E> RouterErrorExt for Result<T, E> {
             Ok(value) => Ok(value),
             Err(_) => Err(bad_request(description)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::header::RETRY_AFTER;
+
+    use super::*;
+
+    /// The mapping is a closed list of downcasts, so an error type that is not
+    /// on it degrades to a 500 no matter what its own `IntoResponse` says. A
+    /// shed answered as "broken" rather than "busy" is the failure this guards.
+    #[test]
+    fn a_service_unavailable_error_maps_to_503_not_500() {
+        let error: Error = service_unavailable(2).into();
+
+        let response = error_into_response(&Cx::default(), error);
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .map(http::HeaderValue::as_bytes),
+            Some(&b"2"[..])
+        );
+    }
+
+    #[test]
+    fn an_error_that_is_not_on_the_list_still_maps_to_500() {
+        let error: Error = std::io::Error::other("boom").into();
+
+        let response = error_into_response(&Cx::default(), error);
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/topcoat-router/src/error/service_unavailable.rs
+++ b/crates/topcoat-router/src/error/service_unavailable.rs
@@ -1,0 +1,120 @@
+use http::{HeaderValue, StatusCode, header::RETRY_AFTER};
+use topcoat_core::{context::Cx, error::Result};
+
+use crate::response::{IntoResponse, Response};
+
+/// Builds a service-unavailable (HTTP 503) response carrying a `Retry-After`
+/// hint, in seconds.
+///
+/// Return this when the server is temporarily at capacity: load shedding,
+/// admission control, or a saturated dependency. It is deliberately distinct
+/// from [`internal_server_error`](crate::error::internal_server_error), which
+/// tells a client, a load balancer, and an on-call engineer that something is
+/// broken. Answering "broken" when the truth is "busy" reads as an outage to
+/// everything automated downstream.
+///
+/// `Retry-After` is why the constructor takes an argument. A bare 503 tells a
+/// caller to go away without saying when to come back, so every well-behaved
+/// client invents its own backoff and they all synchronize.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::{Result, router::error::service_unavailable};
+/// # struct Permit;
+/// # fn try_admit() -> Option<Permit> { Some(Permit) }
+///
+/// async fn handle() -> Result<&'static str> {
+///     let Some(_permit) = try_admit() else {
+///         return Err(service_unavailable(2).into());
+///     };
+///
+///     Ok("served")
+/// }
+/// ```
+#[must_use]
+pub fn service_unavailable(retry_after_secs: u64) -> ServiceUnavailableError {
+    ServiceUnavailableError::new(retry_after_secs)
+}
+
+/// A service-unavailable response carried as the `Err` variant of a handler
+/// `Result`.
+///
+/// Construct one with [`service_unavailable`].
+#[derive(Debug)]
+pub struct ServiceUnavailableError {
+    retry_after_secs: u64,
+}
+
+impl ServiceUnavailableError {
+    fn new(retry_after_secs: u64) -> Self {
+        Self { retry_after_secs }
+    }
+
+    /// The `Retry-After` value this response carries, in seconds.
+    #[must_use]
+    pub fn retry_after_secs(&self) -> u64 {
+        self.retry_after_secs
+    }
+}
+
+impl std::fmt::Display for ServiceUnavailableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "service unavailable (retry after {}s)",
+            self.retry_after_secs
+        )
+    }
+}
+
+impl std::error::Error for ServiceUnavailableError {}
+
+impl IntoResponse for ServiceUnavailableError {
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        let mut response =
+            (StatusCode::SERVICE_UNAVAILABLE, "service unavailable").into_response(cx)?;
+        // A `u64`'s decimal form is always a valid header value, so the header
+        // is only skipped if that ever stops being true.
+        if let Ok(value) = HeaderValue::from_str(&self.retry_after_secs.to_string()) {
+            response.headers_mut().insert(RETRY_AFTER, value);
+        }
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topcoat_core::context::Cx;
+
+    use super::*;
+
+    #[test]
+    fn responds_503_with_a_retry_after_header() {
+        let response = service_unavailable(2)
+            .into_response(&Cx::default())
+            .expect("the response builds");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .map(HeaderValue::as_bytes),
+            Some(&b"2"[..])
+        );
+    }
+
+    #[test]
+    fn keeps_the_retry_after_it_was_built_with() {
+        assert_eq!(service_unavailable(30).retry_after_secs(), 30);
+    }
+
+    #[test]
+    fn reads_as_busy_rather_than_broken() {
+        assert_eq!(
+            service_unavailable(5).to_string(),
+            "service unavailable (retry after 5s)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`error_into_response` maps the router's own error types onto status codes through a closed list of downcasts and turns everything else into a 500. There is no constructor for 503, so an application shedding load has nothing to return — a bespoke error type falls off the end of the list and answers 500.

That matters because 500 and 503 mean different things to everything downstream. A 500 tells a client, a load balancer, and an on-call engineer that the server is broken. "Busy" answered as "broken" reads as an outage: health checks pull the instance, retry policies treat it as a fault, and the alert fires.

I hit this in an application with admission control, where a shed request rendered as HTTP 500.

## The change

`service_unavailable(secs)` responds 503 and sets `Retry-After`. The argument is the point of the type rather than a convenience: a bare 503 tells a caller to go away without saying when to come back, so every well-behaved client invents its own backoff and they all synchronize on the same retry.

It follows the shape of the existing constructors — `content_too_large()` for the module layout, `redirect(uri)` and `bad_request(description)` for taking an argument — and is added to the downcast list and the docs' constructor list.

## Testing

Three tests cover the type: the status and header it produces, the accessor, and the `Display` string.

The test that matters covers the mapping instead. `a_service_unavailable_error_maps_to_503_not_500` converts into `Error` and goes through `error_into_response`, which is where the original problem lives. Removing the new arm from the downcast list leaves the constructor and its own `IntoResponse` passing, while that test fails exactly the way the bug presented:

```
assertion `left == right` failed
  left: 500
 right: 503
```

`an_error_that_is_not_on_the_list_still_maps_to_500` pins the fallthrough so the guard cannot be satisfied by making everything 503.

## Checks

`cargo fmt --all --check`, `cargo clippy -p topcoat-router --all-targets --all-features` (0 warnings), `cargo test -p topcoat-router` (303 + 71 passed), doctest, `cargo doc` clean.

## Note

429 is the sibling gap — the module has no `too_many_requests` either, and rate limiting wants the same `Retry-After`. I left it out to keep this reviewable; happy to add it here or separately if you'd like it.
