### PR TITLE
feat(router): add a too-many-requests error with a Retry-After hint

### DIFF
--- a/crates/topcoat-router/docs/error.md
+++ b/crates/topcoat-router/docs/error.md
@@ -4,7 +4,7 @@ Every page, layout, layer, and route handler returns a `Result`. An `Err` become
 
 # Constructors
 
-Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description, and [`service_unavailable(secs)`](service_unavailable) responds 503 with [`ServiceUnavailableError`] and a `Retry-After` header.
+Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], and [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description. [`too_many_requests(secs)`](too_many_requests) and [`service_unavailable(secs)`](service_unavailable) respond 429 and 503, each carrying a `Retry-After` header.
 
 A constructor returns a concrete error type that converts into the handler's error, so bubble it up with `?` or return it directly:
 

--- a/crates/topcoat-router/src/error.rs
+++ b/crates/topcoat-router/src/error.rs
@@ -8,6 +8,7 @@ mod method_not_allowed;
 mod not_found;
 mod redirect;
 mod service_unavailable;
+mod too_many_requests;
 mod unauthorized;
 
 pub use bad_request::*;
@@ -19,6 +20,7 @@ pub use method_not_allowed::*;
 pub use not_found::*;
 pub use redirect::*;
 pub use service_unavailable::*;
+pub use too_many_requests::*;
 use topcoat_core::{
     context::Cx,
     error::{Error, Result},
@@ -66,6 +68,7 @@ fn error_into_response(cx: &Cx, error: Error) -> Response {
     let error = try_downcast!(error as RedirectError);
     let error = try_downcast!(error as UnauthorizedError);
     let error = try_downcast!(error as ServiceUnavailableError);
+    let error = try_downcast!(error as TooManyRequestsError);
 
     into_response_or_500(cx, internal_server_error(error))
 }
@@ -296,6 +299,24 @@ mod tests {
                 .get(RETRY_AFTER)
                 .map(http::HeaderValue::as_bytes),
             Some(&b"2"[..])
+        );
+    }
+
+    /// The 429 mirror: a rate limit answered as "the server is broken" is the
+    /// failure this guards.
+    #[test]
+    fn a_too_many_requests_error_maps_to_429_not_500() {
+        let error: Error = too_many_requests(60).into();
+
+        let response = error_into_response(&Cx::default(), error);
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .map(http::HeaderValue::as_bytes),
+            Some(&b"60"[..])
         );
     }
 

--- a/crates/topcoat-router/src/error/too_many_requests.rs
+++ b/crates/topcoat-router/src/error/too_many_requests.rs
@@ -1,0 +1,119 @@
+use http::{HeaderValue, StatusCode, header::RETRY_AFTER};
+use topcoat_core::{context::Cx, error::Result};
+
+use crate::response::{IntoResponse, Response};
+
+/// Builds a too-many-requests (HTTP 429) response carrying a `Retry-After`
+/// hint, in seconds.
+///
+/// Return this when a caller has exceeded a limit you set for them: a rate
+/// limit, a quota, a per-account cap. It says the request was refused because
+/// of who sent it and how often, which is what separates it from
+/// [`service_unavailable`](crate::error::service_unavailable) — that one says
+/// the server as a whole is at capacity, and applies to every caller at once.
+/// A client that can tell the two apart can back off its own traffic in the
+/// first case and fail over in the second.
+///
+/// `Retry-After` is what makes the refusal actionable. Without it a rate
+/// limiter teaches callers nothing except to retry immediately.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::{Result, router::error::too_many_requests};
+/// # fn tokens_left() -> u32 { 0 }
+///
+/// async fn handle() -> Result<&'static str> {
+///     if tokens_left() == 0 {
+///         return Err(too_many_requests(60).into());
+///     }
+///
+///     Ok("served")
+/// }
+/// ```
+#[must_use]
+pub fn too_many_requests(retry_after_secs: u64) -> TooManyRequestsError {
+    TooManyRequestsError::new(retry_after_secs)
+}
+
+/// A too-many-requests response carried as the `Err` variant of a handler
+/// `Result`.
+///
+/// Construct one with [`too_many_requests`].
+#[derive(Debug)]
+pub struct TooManyRequestsError {
+    retry_after_secs: u64,
+}
+
+impl TooManyRequestsError {
+    fn new(retry_after_secs: u64) -> Self {
+        Self { retry_after_secs }
+    }
+
+    /// The `Retry-After` value this response carries, in seconds.
+    #[must_use]
+    pub fn retry_after_secs(&self) -> u64 {
+        self.retry_after_secs
+    }
+}
+
+impl std::fmt::Display for TooManyRequestsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "too many requests (retry after {}s)",
+            self.retry_after_secs
+        )
+    }
+}
+
+impl std::error::Error for TooManyRequestsError {}
+
+impl IntoResponse for TooManyRequestsError {
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        let mut response =
+            (StatusCode::TOO_MANY_REQUESTS, "too many requests").into_response(cx)?;
+        // A `u64`'s decimal form is always a valid header value, so the header
+        // is only skipped if that ever stops being true.
+        if let Ok(value) = HeaderValue::from_str(&self.retry_after_secs.to_string()) {
+            response.headers_mut().insert(RETRY_AFTER, value);
+        }
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topcoat_core::context::Cx;
+
+    use super::*;
+
+    #[test]
+    fn responds_429_with_a_retry_after_header() {
+        let response = too_many_requests(60)
+            .into_response(&Cx::default())
+            .expect("the response builds");
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(RETRY_AFTER)
+                .map(HeaderValue::as_bytes),
+            Some(&b"60"[..])
+        );
+    }
+
+    #[test]
+    fn keeps_the_retry_after_it_was_built_with() {
+        assert_eq!(too_many_requests(30).retry_after_secs(), 30);
+    }
+
+    #[test]
+    fn names_the_caller_not_the_server() {
+        assert_eq!(
+            too_many_requests(5).to_string(),
+            "too many requests (retry after 5s)"
+        );
+    }
+}


### PR DESCRIPTION
Sibling to #266, kept separate so each stays small.

## Summary

`error_into_response` maps the router's own error types onto status codes through a closed list of downcasts and turns everything else into a 500. The module has no constructor for 429, so a rate limiter has nothing to return and a refused request answers as though the server were broken.

429 and 503 are deliberately different answers. 429 refuses a *caller* for how much they asked; 503 says the *server* is at capacity for everyone. A client that can tell them apart throttles its own traffic in the first case and fails over in the second — answering 500 for either tells it to do neither, and tells a load balancer to pull a healthy instance.

## The change

`too_many_requests(secs)` responds 429 and sets `Retry-After`, so the refusal says both what the caller did and when to come back. Without the header a rate limiter teaches callers nothing except to retry immediately, which is the behaviour a limiter exists to prevent.

Same shape as the existing constructors, added to the downcast list and the docs' constructor list.

## Testing

Three tests cover the type: the status and header, the accessor, and the `Display` string.

The one that matters covers the mapping. Removing the new arm from the downcast list leaves the constructor and its own `IntoResponse` passing while the handler reports:

```
assertion `left == right` failed
  left: 500
 right: 429
```

`an_error_that_is_not_on_the_list_still_maps_to_500` pins the fallthrough so the guard cannot be satisfied by making everything 429.

## Checks

`cargo fmt --all --check`, `cargo clippy -p topcoat-router --all-targets --all-features` (0 warnings), `cargo test -p topcoat-router` (303 + 71 passed), doctest.

## Note on merge order

This and #266 both add a `mod`, a `pub use`, a downcast arm, and a docs sentence in the same places, so whichever lands second needs a small rebase — the conflict is textual adjacency, not disagreement. Happy to rebase this one onto #266, or to fold them together if you would rather review one PR than two.
