### PR TITLE
feat(router): add Js and Wasm response wrappers

### DIFF
--- a/crates/topcoat-router/docs/content.md
+++ b/crates/topcoat-router/docs/content.md
@@ -62,6 +62,8 @@ async fn create_user() -> Result<(StatusCode, Json<User>)> {
 }
 ```
 
+[`Js`] and [`Wasm`] are response-only wrappers for the two media types a browser checks rather than guesses: it refuses to execute a `<script type="module">` that does not arrive as JavaScript, and `WebAssembly.compileStreaming` rejects anything that is not exactly `application/wasm`. Reach for them when a route serves a script or a module by hand rather than through the asset bundle.
+
 Implement [`IntoResponse`](crate::response::IntoResponse) yourself for a type that should control its own status, headers, and body. A page sets its status and headers from inside the `view!` body instead; see the `view!` macro docs.
 
 # Multipart form data

--- a/crates/topcoat-router/src/content.rs
+++ b/crates/topcoat-router/src/content.rs
@@ -10,15 +10,19 @@
 mod css;
 mod form;
 mod html;
+mod js;
 mod json;
 #[cfg(feature = "multipart")]
 pub mod multipart;
 #[cfg(feature = "sse")]
 pub mod sse;
+mod wasm;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 
 pub use css::*;
 pub use form::*;
 pub use html::*;
+pub use js::*;
 pub use json::*;
+pub use wasm::*;

--- a/crates/topcoat-router/src/content/js.rs
+++ b/crates/topcoat-router/src/content/js.rs
@@ -1,0 +1,86 @@
+use http::header::{CONTENT_TYPE, HeaderValue};
+use topcoat_core::{context::Cx, error::Result};
+
+use crate::{
+    Body,
+    response::{IntoResponse, Response},
+};
+
+/// JavaScript response wrapper.
+///
+/// Wrap any value convertible into a [`Body`] (such as a `String`) to reply
+/// with `Content-Type: text/javascript`. Use it from a
+/// [`route`](../topcoat_router_macro/attr.route.html) that serves a script by
+/// hand, rather than as a bundled [`asset`](crate).
+///
+/// The media type is not cosmetic for module scripts: a browser refuses to
+/// execute `<script type="module">` whose response does not carry a JavaScript
+/// media type, and reports it as a MIME type mismatch rather than a script
+/// error.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::{
+///     Result,
+///     router::{content::Js, route},
+/// };
+///
+/// #[route(GET "/app.js")]
+/// async fn app_js() -> Result<Js<&'static str>> {
+///     Ok(Js("export const ready = true;"))
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct Js<T>(pub T);
+
+impl<T> From<T> for Js<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> IntoResponse for Js<T>
+where
+    T: Into<Body>,
+{
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        (
+            [(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/javascript; charset=utf-8"),
+            )],
+            self.0.into(),
+        )
+            .into_response(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topcoat_core::context::Cx;
+
+    use super::*;
+    use crate::to_bytes;
+
+    #[tokio::test]
+    async fn into_response_sets_javascript_content_type() {
+        let response = Js("export const a = 1;")
+            .into_response(&Cx::default())
+            .expect("response builds");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .map(http::HeaderValue::as_bytes),
+            Some(b"text/javascript; charset=utf-8".as_slice())
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("reading the response body");
+        assert_eq!(&body[..], b"export const a = 1;");
+    }
+}

--- a/crates/topcoat-router/src/content/wasm.rs
+++ b/crates/topcoat-router/src/content/wasm.rs
@@ -1,0 +1,102 @@
+use http::header::{CONTENT_TYPE, HeaderValue};
+use topcoat_core::{context::Cx, error::Result};
+
+use crate::{
+    Body,
+    response::{IntoResponse, Response},
+};
+
+/// WebAssembly response wrapper.
+///
+/// Wrap any value convertible into a [`Body`] (such as a `&'static [u8]` from
+/// `include_bytes!`) to reply with `Content-Type: application/wasm`. Use it
+/// from a [`route`](../topcoat_router_macro/attr.route.html) that serves a
+/// module by hand.
+///
+/// The media type is load-bearing here. `WebAssembly.compileStreaming` and
+/// `instantiateStreaming` reject any response that does not carry exactly
+/// `application/wasm`, so a module served as `application/octet-stream` fails
+/// to instantiate even though the bytes are correct.
+///
+/// # Examples
+///
+/// ```rust
+/// use topcoat::{
+///     Result,
+///     router::{content::Wasm, route},
+/// };
+/// # const ENGINE: &[u8] = b"\0asm\x01\0\0\0";
+///
+/// #[route(GET "/engine.wasm")]
+/// async fn engine() -> Result<Wasm<&'static [u8]>> {
+///     Ok(Wasm(ENGINE))
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct Wasm<T>(pub T);
+
+impl<T> From<T> for Wasm<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> IntoResponse for Wasm<T>
+where
+    T: Into<Body>,
+{
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        (
+            [(CONTENT_TYPE, HeaderValue::from_static("application/wasm"))],
+            self.0.into(),
+        )
+            .into_response(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topcoat_core::context::Cx;
+
+    use super::*;
+    use crate::to_bytes;
+
+    #[tokio::test]
+    async fn into_response_sets_wasm_content_type() {
+        // The four-byte module preamble: `\0asm` and version 1.
+        let response = Wasm(b"\0asm\x01\0\0\0".as_slice())
+            .into_response(&Cx::default())
+            .expect("response builds");
+
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .map(http::HeaderValue::as_bytes),
+            Some(b"application/wasm".as_slice())
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("reading the response body");
+        assert_eq!(&body[..], b"\0asm\x01\0\0\0");
+    }
+
+    /// The streaming entry points match the media type exactly, so a charset
+    /// parameter would break them the way `application/octet-stream` does.
+    #[tokio::test]
+    async fn into_response_sends_the_media_type_without_parameters() {
+        let response = Wasm(b"\0asm\x01\0\0\0".as_slice())
+            .into_response(&Cx::default())
+            .expect("response builds");
+
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .expect("a content type is set");
+
+        assert!(!content_type.contains(';'), "{content_type}");
+    }
+}


### PR DESCRIPTION
## Summary

`Css` already wraps a body and sets its media type for a route that serves a stylesheet by hand. Scripts and WebAssembly modules had no equivalent, so serving either meant attaching the header through a tuple at every call site.

Those two are worth a wrapper each because their media type is **checked, not sniffed**:

- A browser refuses to execute a `<script type="module">` whose response does not carry a JavaScript media type. It surfaces as a MIME type mismatch in the console rather than a script error, which is a confusing way to find out.
- `WebAssembly.compileStreaming` and `instantiateStreaming` reject any response that is not exactly `application/wasm`. A module served as `application/octet-stream` fails to instantiate with perfectly correct bytes.

Both come out of serving a hand-rolled script and a wasm engine from routes rather than through the asset bundle.

## Shape

`Js<T>` sets `text/javascript; charset=utf-8`, `Wasm<T>` sets `application/wasm`, both over any `T: Into<Body>` — the same shape as `Css`'s response half.

They are response-only. Neither is a body a server reads from a request, so there is no extractor half to mirror, and adding one would be surface with no caller.

## Testing

One test each for the status quo: the media type set, and the body passed through unchanged. `Wasm` gets a second one asserting the header carries no parameters, since a `; charset=...` would break the streaming entry points exactly the way the wrong type does — that is the failure the wrapper exists to prevent, so it is worth pinning rather than assuming.

## Checks

`cargo fmt --all --check`, `cargo clippy -p topcoat-router --all-targets --all-features` (0 warnings), `cargo test -p topcoat-router` (301 + 72 passed), doctests for both wrappers.
