### PR TITLE
fix(runtime): let push_str accept an owned string surrogate

### DIFF
--- a/crates/topcoat-runtime/macro/tests/expr.rs
+++ b/crates/topcoat-runtime/macro/tests/expr.rs
@@ -53,3 +53,22 @@ async fn push_str_reaches_the_generated_javascript_with_its_argument() {
 
     assert!(html.contains(".push_str("), "{html}");
 }
+
+/// `push_str` takes anything that dereferences to a string, so it accepts the
+/// owned surrogate an event field yields. `Event::target.value` is a `String`,
+/// so this is the call the method mostly exists for; the test above passes a
+/// literal, which is borrowed and so never exercised the owned case.
+#[tokio::test]
+async fn push_str_accepts_the_owned_string_from_an_event() {
+    let cx = &Cx::default();
+    let html = view! {
+        cx =>
+        signal message = String::new();
+
+        <input @input=$(|e: topcoat::runtime::Event| message.push_str(e.target.value))>
+    }
+    .unwrap()
+    .render(cx);
+
+    assert!(html.contains(".push_str("), "{html}");
+}

--- a/crates/topcoat-runtime/src/surrogate/signal.rs
+++ b/crates/topcoat-runtime/src/surrogate/signal.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use ref_cast::RefCast;
 use serde::Serialize;
 
@@ -86,11 +88,16 @@ impl SignalSurrogate<f64> {
 impl SignalSurrogate<String> {
     /// Appends a string to the end of the value.
     ///
+    /// The argument is anything that dereferences to a string, so both a
+    /// borrowed `&str` and an owned `String` work. The owned form is what an
+    /// event field yields: `Event::target.value` is a `String`, so
+    /// `message.push_str(e.target.value)` is the common call.
+    ///
     /// # Panics
     ///
     /// Always panics; signal writes can only occur in client-side expressions.
     #[track_caller]
-    pub fn push_str(&self, _s: &StrSurrogate) {
+    pub fn push_str(&self, _s: impl Deref<Target = StrSurrogate>) {
         write_in_browser_only();
     }
 }


### PR DESCRIPTION
## Summary

`Signal<String>::push_str` takes `&StrSurrogate`, which rejects the call it mostly exists for.

`Event::target.value` is typed `StringSurrogate`, so appending what a user typed reads as:

```rust
<input @input=$(|e: Event| message.push_str(e.target.value))>
```

and that does not compile:

```
error[E0308]: mismatched types
   expected `&StrSurrogate`, found `StringSurrogate`
  --> crates/topcoat-runtime/src/surrogate/signal.rs:88:12
```

There is no ergonomic way around it inside an expression — the vocabulary has no borrow operator to reach for.

## The change

Take `impl Deref<Target = StrSurrogate>`, which accepts both the borrowed form (a string literal, as today) and the owned form (an event field). The browser side is untouched; its `push_str` was never typed and already accepted either.

## Why it wasn't caught

The existing test is `push_str_reaches_the_generated_javascript_with_its_argument`, and it passes `"!"` — a literal, which is borrowed, and so is exactly the case the narrow signature accepts. The owned path had no coverage.

The new test uses the event field instead. Against the narrow signature it fails at compile time with the error above, which is the strongest form this particular regression can take.

## Checks

`cargo fmt --all --check`, `cargo clippy -p topcoat-runtime --all-targets --all-features` (0 warnings), `cargo test -p topcoat-runtime -p topcoat-runtime-macro`.

## Context

This narrowed in #214, which otherwise widened the signal API usefully — the rest of that PR is a strict improvement and this is the one call it made harder. Flagging it as a follow-up rather than a complaint.
