### PR TITLE
fix(core): keep macro bodies intact when formatting rust snippets

### DIFF
--- a/crates/topcoat-core/grammar/src/pretty/rust.rs
+++ b/crates/topcoat-core/grammar/src/pretty/rust.rs
@@ -2,7 +2,37 @@ use quote::ToTokens;
 use syn::spanned::Spanned;
 
 use super::{PrettyPrint, Printer, TextMode};
-use crate::pretty::pretty_print_str;
+use crate::pretty::{MacroSnippet, pretty_print_str};
+
+/// Restores each macro body in `formatted` from the corresponding body in
+/// `original`.
+///
+/// `prettyplease` reprints a macro body from its token stream, which separates
+/// tokens the Topcoat grammars require to be adjacent: `aria-label` comes back
+/// as `aria - label`, which no longer parses as an HTML identifier. Neither
+/// pass formats those bodies (the caller's registry does that afterwards), so
+/// carrying the original text through the Rust pass keeps them parseable.
+fn restore_macro_bodies(original: &syn::File, formatted: &str) -> String {
+    let Ok(formatted_file) = syn::parse_file(formatted) else {
+        return formatted.to_owned();
+    };
+
+    // `prettyplease` neither adds nor removes macro invocations, so the two
+    // collections line up in source order.
+    let originals = MacroSnippet::collect_from_file(original);
+    let replacements = MacroSnippet::collect_from_file(&formatted_file);
+
+    let mut output = String::new();
+    let mut current_index = 0;
+    for (replacement, original) in replacements.iter().zip(&originals) {
+        let range = replacement.span().byte_range();
+        output.push_str(&formatted[current_index..range.start]);
+        output.push_str(original.source_text());
+        current_index = range.end;
+    }
+    output.push_str(&formatted[current_index..]);
+    output
+}
 
 fn format_rust_snippet(
     printer: &mut Printer<'_>,
@@ -24,6 +54,7 @@ fn format_rust_snippet(
 
     let file = syn::parse_file(&input).expect("failed to parse rust snippet for formatting");
     let formatted = prettyplease::unparse(&file);
+    let formatted = restore_macro_bodies(&file, &formatted);
     let formatted = pretty_print_str(printer.registry(), &formatted).unwrap();
 
     let mut stripped = formatted.trim();

--- a/crates/topcoat-view/grammar/tests/fixtures/pretty/attributes_macro_html_ident.expected
+++ b/crates/topcoat-view/grammar/tests/fixtures/pretty/attributes_macro_html_ident.expected
@@ -1,0 +1,1 @@
+view! { button(attrs: attributes! { aria-label="Increment" data-role="counter" }, "+") }

--- a/crates/topcoat-view/grammar/tests/fixtures/pretty/attributes_macro_html_ident.input
+++ b/crates/topcoat-view/grammar/tests/fixtures/pretty/attributes_macro_html_ident.input
@@ -1,0 +1,6 @@
+view! {
+    button(
+        attrs: attributes! {  aria-label="Increment"  data-role="counter"  },
+        "+"
+    )
+}

--- a/crates/topcoat-view/grammar/tests/pretty.rs
+++ b/crates/topcoat-view/grammar/tests/pretty.rs
@@ -94,6 +94,7 @@ fixture_test!(attributes_long);
 fixture_test!(attributes_overflow);
 fixture_test!(attributes_macro_short);
 fixture_test!(attributes_macro_long);
+fixture_test!(attributes_macro_html_ident);
 fixture_test!(attribute_expr_value);
 
 // -- Text nodes --------------------------------------------------------------


### PR DESCRIPTION
## Summary

`topcoat fmt` panicked on any file where a Topcoat macro sits in a Rust expression the formatter reprints, which covers every `attributes!` passed as a component prop:

```rust
button(attrs: attributes! { aria-label="Increment" }, "+")
```

`format_rust_snippet` handed the snippet to `prettyplease::unparse` and re-parsed the output. `prettyplease` reprints a macro body from its token stream, and tokens carry no adjacency information, so `aria-label` came back as `aria - label`. `HtmlIdent::parse_inner` requires separators to be adjacent to the segments around them, so the re-parse failed with "whitespace is not allowed inside an HTML identifier", and the `unwrap` on that result turned it into a panic (exit code 101) rather than a diagnostic. One such call site made the whole file unformattable.

`restore_macro_bodies` now puts each macro body back from the original source between the `unparse` and the re-parse. The Rust pass never formats those bodies; the registry formats them afterwards, so carrying the original text through it changes nothing else. `prettyplease` neither adds nor removes macro invocations, so the two `MacroSnippet::collect_from_file` collections line up in source order. If the formatted snippet does not parse, the function returns it untouched and the existing error path reports it.

The mangling applied to every nested macro body (`view!`, `class!`, `attributes!`), but only turned fatal where the grammar is whitespace-sensitive, which is `HtmlIdent`: `-`, `:`, and `.` separated names such as `aria-label`, `data-role`, `xmlns:xlink`, and `x-target.422`. Attributes written directly on an element (`<div aria-label="x">`) were never affected, since `prettyplease` does not reprint them.

`attributes_macro_html_ident` covers the reported case. It panics without the fix and passes with it.

Closes #272

## Testing

- `cargo test -p topcoat-view-grammar -p topcoat-core-grammar --all-features` (new fixture verified red before the change)
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +nightly fmt --all`, `cargo topcoat fmt` (529 files, 0 modified; the 5 failures under `benchmarks/leptos` are Leptos `view!` bodies and fail the same way on `main`)
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`
- Checked the original repro out of tree: `topcoat fmt --stdin` on the snippet above now exits 0 and leaves `aria-label` intact.

## Disclaimer

Bug and fix was discovered by coworking with Claude Opus 5. Together, we reproduced the panic, bisected it to the `unparse`/re-parse round trip, wrote the fix and the fixture, and ran every check listed above. 

I read the diff and the surrounding code and can explain and defend every line.
