### PR TITLE
fix(view): allow keyword element names

### DIFF
--- a/crates/topcoat-view/grammar/src/view/element_name.rs
+++ b/crates/topcoat-view/grammar/src/view/element_name.rs
@@ -4,6 +4,7 @@ use proc_macro2::Span;
 use quote::ToTokens;
 use syn::{
     Expr, Ident, LitStr,
+    ext::IdentExt,
     parse::{Parse, ParseStream},
     spanned::Spanned,
     token::Paren,
@@ -103,7 +104,7 @@ impl Display for ElementName {
 impl Parse for ElementName {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(Ident) {
+        if lookahead.peek(Ident::peek_any) {
             Ok(Self::Ident(HtmlIdent::parse_dash_only(input)?))
         } else if lookahead.peek(LitStr) {
             Ok(Self::LitStr(input.parse()?))
@@ -138,6 +139,13 @@ mod tests {
     fn ident_name_returns_string_name() {
         let name = parse("div");
         assert_eq!(name.string_name().as_deref(), Some("div"));
+        assert!(name.expr().is_none());
+    }
+
+    #[test]
+    fn rust_keyword_name_returns_string_name() {
+        let name = parse("use");
+        assert_eq!(name.string_name().as_deref(), Some("use"));
         assert!(name.expr().is_none());
     }
 

--- a/crates/topcoat-view/macro/tests/render.rs
+++ b/crates/topcoat-view/macro/tests/render.rs
@@ -38,6 +38,12 @@ async fn nested_elements_render_in_order() {
 }
 
 #[tokio::test]
+async fn rust_keyword_element_names_render() {
+    let html = r(view! { <svg><use href="#icon"></use></svg> });
+    assert_eq!(html, r##"<svg><use href="#icon"></use></svg>"##);
+}
+
+#[tokio::test]
 async fn literal_attributes_render_quoted() {
     let html = r(view! { <a href="/x" class="link">"go"</a> });
     assert_eq!(html, r#"<a href="/x" class="link">go</a>"#);


### PR DESCRIPTION
## Summary

- accept Rust keywords when parsing static element names
- cover the SVG `<use>` element through the full `view!` render path

The parser already uses `Ident::parse_any` after lookahead, but the lookahead only accepted non-keyword identifiers. That made valid SVG markup fail before parsing.

## Testing

- `cargo +nightly fmt --all`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`
- formatter CLI repro with `<svg><use href="#icon"></use></svg>`
