### PR TITLE
fix(core): detect recursive memoized calls

### DIFF
--- a/crates/topcoat-core/macro/docs/memoize.md
+++ b/crates/topcoat-core/macro/docs/memoize.md
@@ -54,6 +54,38 @@ For async functions, concurrent callers with the same arguments share a single i
 
 Memoized functions can call themselves directly or through other memoized functions. A directly nested call that revisits the same function with equal arguments panics instead of waiting on a result that it cannot produce. Calls with different arguments continue normally, and different memoized functions always have separate entries.
 
+Recursion with different arguments uses a different cache entry for each call:
+
+```rust
+# use topcoat::context::{Cx, memoize};
+#[memoize]
+fn factorial(cx: &Cx, n: u64) -> u64 {
+    match n {
+        0 | 1 => 1,
+        _ => n * *factorial(cx, n - 1),
+    }
+}
+
+# fn example(cx: &Cx) {
+assert_eq!(*factorial(cx, 5), 120);
+# }
+```
+
+A nested call with the same arguments panics because it would otherwise wait for its own result:
+
+```should_panic
+use topcoat::context::{Cx, memoize};
+
+#[memoize]
+fn recurse(cx: &Cx, n: u64) -> u64 {
+    *recurse(cx, n)
+}
+
+fn main() {
+    recurse(&Cx::default(), 1);
+}
+```
+
 Cycle detection follows nested synchronous calls and async future polls. It cannot detect a cycle routed through separately scheduled work, such as a spawned task. Such work waits for the in-flight value as any other concurrent caller would.
 
 # What gets cached

--- a/crates/topcoat-core/macro/docs/memoize.md
+++ b/crates/topcoat-core/macro/docs/memoize.md
@@ -50,6 +50,12 @@ async fn fetch_post(cx: &Cx, slug: &str) -> Post {
 
 For async functions, concurrent callers with the same arguments share a single in-flight future. If two parts of your page render in parallel and both call `fetch_post(cx, "hello")`, the database is queried once and both callers await the same result.
 
+# Recursion
+
+Memoized functions can call themselves directly or through other memoized functions. A directly nested call that revisits the same function with equal arguments panics instead of waiting on a result that it cannot produce. Calls with different arguments continue normally, and different memoized functions always have separate entries.
+
+Cycle detection follows nested synchronous calls and async future polls. It cannot detect a cycle routed through separately scheduled work, such as a spawned task. Such work waits for the in-flight value as any other concurrent caller would.
+
 # What gets cached
 
 Every argument except `cx` is part of the cache key. Two calls hit the same cache entry if and only if every non-`cx` argument is equal.

--- a/crates/topcoat-core/macro/docs/memoize.md
+++ b/crates/topcoat-core/macro/docs/memoize.md
@@ -52,7 +52,7 @@ For async functions, concurrent callers with the same arguments share a single i
 
 # Recursion
 
-Memoized functions can call themselves directly or through other memoized functions. A directly nested call that revisits the same function with equal arguments panics instead of waiting on a result that it cannot produce. Calls with different arguments continue normally, and different memoized functions always have separate entries.
+Memoized functions can recurse if and only if recursive calls use different arguments. Recursion with identical arguments panics.
 
 Recursion with different arguments uses a different cache entry for each call:
 
@@ -71,7 +71,7 @@ assert_eq!(*factorial(cx, 5), 120);
 # }
 ```
 
-A nested call with the same arguments panics because it would otherwise wait for its own result:
+A nested call with the same arguments panics because it would otherwise deadlock:
 
 ```should_panic
 use topcoat::context::{Cx, memoize};
@@ -85,8 +85,6 @@ fn main() {
     recurse(&Cx::default(), 1);
 }
 ```
-
-Cycle detection follows nested synchronous calls and async future polls. It cannot detect a cycle routed through separately scheduled work, such as a spawned task. Such work waits for the in-flight value as any other concurrent caller would.
 
 # What gets cached
 

--- a/crates/topcoat-core/macro/tests/memoize.rs
+++ b/crates/topcoat-core/macro/tests/memoize.rs
@@ -136,3 +136,143 @@ async fn separate_memoized_functions_have_independent_caches() {
     assert_eq!(A_CALLS.load(Ordering::SeqCst), 1);
     assert_eq!(B_CALLS.load(Ordering::SeqCst), 1);
 }
+
+#[tokio::test]
+async fn sync_direct_and_indirect_recursion_with_different_keys() {
+    #[memoize]
+    fn direct(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 {
+            0
+        } else {
+            1 + *direct(cx, depth - 1)
+        }
+    }
+
+    #[memoize]
+    fn a(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 { 0 } else { 1 + *b(cx, depth - 1) }
+    }
+
+    #[memoize]
+    fn b(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 { 0 } else { 1 + *c(cx, depth - 1) }
+    }
+
+    #[memoize]
+    fn c(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 { 0 } else { 1 + *a(cx, depth - 1) }
+    }
+
+    let cx = Cx::default();
+
+    assert_eq!(*direct(&cx, 5), 5);
+    assert_eq!(*a(&cx, 5), 5);
+}
+
+#[tokio::test]
+async fn async_direct_and_indirect_recursion_with_different_keys() {
+    #[memoize]
+    async fn direct(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 {
+            0
+        } else {
+            1 + *Box::pin(direct(cx, depth - 1)).await
+        }
+    }
+
+    #[memoize]
+    async fn a(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 {
+            0
+        } else {
+            1 + *b(cx, depth - 1).await
+        }
+    }
+
+    #[memoize]
+    async fn b(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 {
+            0
+        } else {
+            1 + *c(cx, depth - 1).await
+        }
+    }
+
+    #[memoize]
+    async fn c(cx: &Cx, depth: usize) -> usize {
+        if depth == 0 {
+            0
+        } else {
+            1 + *Box::pin(a(cx, depth - 1)).await
+        }
+    }
+
+    let cx = Cx::default();
+
+    assert_eq!(*direct(&cx, 5).await, 5);
+    assert_eq!(*a(&cx, 5).await, 5);
+}
+
+#[tokio::test]
+#[should_panic(expected = "recursive `#[memoize]` initialization")]
+async fn sync_direct_recursion_with_same_key_panics() {
+    #[memoize]
+    fn recursive(cx: &Cx) -> usize {
+        *recursive(cx)
+    }
+
+    recursive(&Cx::default());
+}
+
+#[tokio::test]
+#[should_panic(expected = "recursive `#[memoize]` initialization")]
+async fn sync_indirect_recursion_with_same_key_panics() {
+    #[memoize]
+    fn a(cx: &Cx) -> usize {
+        *b(cx)
+    }
+
+    #[memoize]
+    fn b(cx: &Cx) -> usize {
+        *c(cx)
+    }
+
+    #[memoize]
+    fn c(cx: &Cx) -> usize {
+        *a(cx)
+    }
+
+    a(&Cx::default());
+}
+
+#[tokio::test]
+#[should_panic(expected = "recursive `#[memoize]` initialization")]
+async fn async_direct_recursion_with_same_key_panics() {
+    #[memoize]
+    async fn recursive(cx: &Cx) -> usize {
+        *Box::pin(recursive(cx)).await
+    }
+
+    recursive(&Cx::default()).await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "recursive `#[memoize]` initialization")]
+async fn async_indirect_recursion_with_same_key_panics() {
+    #[memoize]
+    async fn a(cx: &Cx) -> usize {
+        *b(cx).await
+    }
+
+    #[memoize]
+    async fn b(cx: &Cx) -> usize {
+        *c(cx).await
+    }
+
+    #[memoize]
+    async fn c(cx: &Cx) -> usize {
+        *Box::pin(a(cx)).await
+    }
+
+    a(&Cx::default()).await;
+}

--- a/crates/topcoat-core/src/memoize.rs
+++ b/crates/topcoat-core/src/memoize.rs
@@ -1,4 +1,5 @@
 mod eq_cache;
+mod recursion;
 
 pub use eq_cache::*;
 

--- a/crates/topcoat-core/src/memoize/eq_cache.rs
+++ b/crates/topcoat-core/src/memoize/eq_cache.rs
@@ -5,69 +5,20 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     ops::{Deref, DerefMut},
-    sync::{
-        Mutex, OnceLock,
-        atomic::{AtomicPtr, Ordering},
-    },
+    sync::{Mutex, OnceLock},
 };
 
 use hashbrown::{Equivalent, HashMap};
 use tokio::sync::OnceCell;
 
+use super::recursion;
 use crate::context::Cx;
 
-// Its address identifies the synchronous call stack or async poll currently running on a thread.
-std::thread_local!(static INITIALIZATION_TOKEN: u8 = const { 0 });
-
-/// A cached value and the token currently running its initializer, if any.
+/// A cached value and the guard detecting recursive initialization of it.
 #[derive(Default)]
 struct MemoizeCell<T> {
     value: T,
-    // This is recursion metadata, not the initialization lock. `OnceLock::get_or_init` and
-    // `OnceCell::get_or_init` select one initializer at a time, so only the active initializer
-    // writes `owner`.
-    //
-    // Relaxed ordering is enough because this pointer publishes no data. A recursive read happens
-    // on the initializing thread after its own store. A caller on another thread may see null or a
-    // foreign token, but either result safely falls through to the once cell for synchronization.
-    owner: AtomicPtr<u8>,
-}
-
-impl<T> MemoizeCell<T> {
-    #[inline]
-    fn assert_not_recursive<F>(&self) {
-        let owner = self.owner.load(Ordering::Relaxed);
-        if !owner.is_null()
-            && INITIALIZATION_TOKEN.with(|token| owner == std::ptr::from_ref(token).cast_mut())
-        {
-            panic!(
-                "recursive `#[memoize]` initialization of `{}` with the same arguments",
-                std::any::type_name::<F>()
-            );
-        }
-    }
-
-    #[inline]
-    fn scope<R>(&self, f: impl FnOnce() -> R) -> R {
-        INITIALIZATION_TOKEN.with(|token| {
-            debug_assert!(self.owner.load(Ordering::Relaxed).is_null());
-            self.owner
-                .store(std::ptr::from_ref(token).cast_mut(), Ordering::Relaxed);
-            let _guard = InitializationGuard { owner: &self.owner };
-            f()
-        })
-    }
-}
-
-struct InitializationGuard<'a> {
-    owner: &'a AtomicPtr<u8>,
-}
-
-impl Drop for InitializationGuard<'_> {
-    #[inline]
-    fn drop(&mut self) {
-        self.owner.store(std::ptr::null_mut(), Ordering::Relaxed);
-    }
+    recursion: recursion::Guard,
 }
 
 /// The per-request store backing `#[memoize]`.
@@ -138,8 +89,9 @@ impl MemoizeEqCache {
         if let Some(value) = cell.value.get() {
             return value;
         }
-        cell.assert_not_recursive::<F>();
-        cell.value.get_or_init(|| cell.scope(|| f(cx, params)))
+        cell.recursion.assert_not_recursive::<F>();
+        cell.value
+            .get_or_init(|| cell.recursion.scope(|| f(cx, params)))
     }
 
     /// Returns the already-computed value for `(F, key)`, or `None` if nothing has been
@@ -198,13 +150,13 @@ impl MemoizeEqCache {
         if let Some(value) = cell.value.get() {
             return value;
         }
-        cell.assert_not_recursive::<F>();
+        cell.recursion.assert_not_recursive::<F>();
         cell.value
             .get_or_init(|| async {
-                let mut future = std::pin::pin!(cell.scope(|| f(cx, params)));
+                let mut future = std::pin::pin!(cell.recursion.scope(|| f(cx, params)));
                 // Clear ownership after every poll so sibling futures can wait on this cell and
                 // the initializer can move between executor threads.
-                poll_fn(|task| cell.scope(|| future.as_mut().poll(task))).await
+                poll_fn(|task| cell.recursion.scope(|| future.as_mut().poll(task))).await
             })
             .await
     }
@@ -443,27 +395,6 @@ mod tests {
 
         assert!(first.is_err());
         assert_eq!(*cache.memoize(&cx, (), (), f), 42);
-    }
-
-    #[test]
-    fn initialization_on_another_thread_is_not_recursive() {
-        let cell = MemoizeCell::<()>::default();
-        let entered = std::sync::Barrier::new(2);
-        let release = std::sync::Barrier::new(2);
-
-        std::thread::scope(|scope| {
-            scope.spawn(|| {
-                cell.scope(|| {
-                    entered.wait();
-                    release.wait();
-                });
-            });
-            entered.wait();
-
-            cell.assert_not_recursive::<fn()>();
-
-            release.wait();
-        });
     }
 
     #[tokio::test]

--- a/crates/topcoat-core/src/memoize/eq_cache.rs
+++ b/crates/topcoat-core/src/memoize/eq_cache.rs
@@ -1,17 +1,74 @@
 use std::{
     any::Any,
     collections::hash_map::RandomState,
-    future::Future,
+    future::{Future, poll_fn},
     hash::Hash,
     marker::PhantomData,
     ops::{Deref, DerefMut},
-    sync::{Mutex, OnceLock},
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicPtr, Ordering},
+    },
 };
 
 use hashbrown::{Equivalent, HashMap};
 use tokio::sync::OnceCell;
 
 use crate::context::Cx;
+
+// Its address identifies the synchronous call stack or async poll currently running on a thread.
+std::thread_local!(static INITIALIZATION_TOKEN: u8 = const { 0 });
+
+/// A cached value and the token currently running its initializer, if any.
+#[derive(Default)]
+struct MemoizeCell<T> {
+    value: T,
+    // This is recursion metadata, not the initialization lock. `OnceLock::get_or_init` and
+    // `OnceCell::get_or_init` select one initializer at a time, so only the active initializer
+    // writes `owner`.
+    //
+    // Relaxed ordering is enough because this pointer publishes no data. A recursive read happens
+    // on the initializing thread after its own store. A caller on another thread may see null or a
+    // foreign token, but either result safely falls through to the once cell for synchronization.
+    owner: AtomicPtr<u8>,
+}
+
+impl<T> MemoizeCell<T> {
+    #[inline]
+    fn assert_not_recursive<F>(&self) {
+        let owner = self.owner.load(Ordering::Relaxed);
+        if !owner.is_null()
+            && INITIALIZATION_TOKEN.with(|token| owner == std::ptr::from_ref(token).cast_mut())
+        {
+            panic!(
+                "recursive `#[memoize]` initialization of `{}` with the same arguments",
+                std::any::type_name::<F>()
+            );
+        }
+    }
+
+    #[inline]
+    fn scope<R>(&self, f: impl FnOnce() -> R) -> R {
+        INITIALIZATION_TOKEN.with(|token| {
+            debug_assert!(self.owner.load(Ordering::Relaxed).is_null());
+            self.owner
+                .store(std::ptr::from_ref(token).cast_mut(), Ordering::Relaxed);
+            let _guard = InitializationGuard { owner: &self.owner };
+            f()
+        })
+    }
+}
+
+struct InitializationGuard<'a> {
+    owner: &'a AtomicPtr<u8>,
+}
+
+impl Drop for InitializationGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.owner.store(std::ptr::null_mut(), Ordering::Relaxed);
+    }
+}
 
 /// The per-request store backing `#[memoize]`.
 ///
@@ -20,8 +77,8 @@ use crate::context::Cx;
 ///
 /// `entries` maps an `(F, K)` shape to an index into `values` via [`anymap3::Map`], where `F` is
 /// the memoized function (used as a marker type to keep different functions' caches disjoint) and
-/// `K` is the owned key type. `values` holds the actual cells (`OnceLock<V>` / `OnceCell<V>`)
-/// behind a stable address so we can hand out `&V` references whose lifetime is tied to the cache.
+/// `K` is the owned key type. `values` holds the actual cells behind a stable address so we can
+/// hand out `&V` references whose lifetime is tied to the cache.
 #[derive(Default)]
 #[doc(hidden)]
 pub struct MemoizeEqCache {
@@ -77,8 +134,12 @@ impl MemoizeEqCache {
         V: Send + Sync + 'static,
         F: (FnOnce(&'a Cx, P) -> V) + 'static,
     {
-        let cell = self.get_or_insert_cell::<F, _, OnceLock<V>>(key);
-        cell.get_or_init(|| f(cx, params))
+        let cell = self.get_or_insert_cell::<F, _, MemoizeCell<OnceLock<V>>>(key);
+        if let Some(value) = cell.value.get() {
+            return value;
+        }
+        cell.assert_not_recursive::<F>();
+        cell.value.get_or_init(|| cell.scope(|| f(cx, params)))
     }
 
     /// Returns the already-computed value for `(F, key)`, or `None` if nothing has been
@@ -91,9 +152,9 @@ impl MemoizeEqCache {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned, or if a stored cell cannot be
-    /// downcast back to `OnceLock<V>` (which indicates a marker/type mismatch
-    /// between the caller and the function that originally memoized the value).
+    /// Panics if the internal mutex is poisoned, or if a stored cell cannot be downcast back to
+    /// its expected type. A failed downcast indicates a marker/type mismatch between the caller
+    /// and the function that originally memoized the value.
     #[allow(clippy::needless_pass_by_value)]
     #[track_caller]
     pub fn get<K, V, F>(&self, marker: F, key: K) -> Option<&V>
@@ -111,8 +172,9 @@ impl MemoizeEqCache {
                 guard.get::<MarkedHashMap<F, <MemoizeKey<K> as ToOwnedKey>::Owned, usize>>()?;
             *cache.get(&MemoizeKey(key))?
         };
-        let cell: &OnceLock<V> = self.values.get(index).unwrap().downcast_ref().unwrap();
-        cell.get()
+        let cell: &MemoizeCell<OnceLock<V>> =
+            self.values.get(index).unwrap().downcast_ref().unwrap();
+        cell.value.get()
     }
 
     /// Async counterpart to [`memoize`](Self::memoize). Concurrent callers with the same key
@@ -132,8 +194,19 @@ impl MemoizeEqCache {
         F: (FnOnce(&'a Cx, P) -> Fut) + 'static,
         Fut: Future<Output = V>,
     {
-        let cell = self.get_or_insert_cell::<F, _, OnceCell<V>>(key);
-        cell.get_or_init(|| async { f(cx, params).await }).await
+        let cell = self.get_or_insert_cell::<F, _, MemoizeCell<OnceCell<V>>>(key);
+        if let Some(value) = cell.value.get() {
+            return value;
+        }
+        cell.assert_not_recursive::<F>();
+        cell.value
+            .get_or_init(|| async {
+                let mut future = std::pin::pin!(cell.scope(|| f(cx, params)));
+                // Clear ownership after every poll so sibling futures can wait on this cell and
+                // the initializer can move between executor threads.
+                poll_fn(|task| cell.scope(|| future.as_mut().poll(task))).await
+            })
+            .await
     }
 }
 
@@ -354,18 +427,60 @@ mod tests {
         assert_eq!(n.load(Ordering::SeqCst), 1);
     }
 
+    #[test]
+    fn sync_panicked_initializer_can_retry() {
+        let cache = MemoizeEqCache::new();
+        let cx = Cx::default();
+        let n = counter();
+        let f = move |_: &Cx, (): ()| {
+            assert_ne!(n.fetch_add(1, Ordering::SeqCst), 0, "first attempt");
+            42
+        };
+
+        let first = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            cache.memoize(&cx, (), (), f);
+        }));
+
+        assert!(first.is_err());
+        assert_eq!(*cache.memoize(&cx, (), (), f), 42);
+    }
+
+    #[test]
+    fn initialization_on_another_thread_is_not_recursive() {
+        let cell = MemoizeCell::<()>::default();
+        let entered = std::sync::Barrier::new(2);
+        let release = std::sync::Barrier::new(2);
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                cell.scope(|| {
+                    entered.wait();
+                    release.wait();
+                });
+            });
+            entered.wait();
+
+            cell.assert_not_recursive::<fn()>();
+
+            release.wait();
+        });
+    }
+
     #[tokio::test]
-    async fn async_same_key_runs_body_once() {
+    async fn async_concurrent_same_key_runs_body_once() {
         let cache = MemoizeEqCache::new();
         let cx = Cx::default();
         let n = counter();
         let f = async move |_: &Cx, (x, y): (i32, i32)| {
             n.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
             x + y
         };
 
-        let a = cache.memoize_async(&cx, (&1i32, &2i32), (1, 2), f).await;
-        let b = cache.memoize_async(&cx, (&1i32, &2i32), (1, 2), f).await;
+        let (a, b) = tokio::join!(
+            cache.memoize_async(&cx, (&1i32, &2i32), (1, 2), f),
+            cache.memoize_async(&cx, (&1i32, &2i32), (1, 2), f),
+        );
 
         assert_eq!(*a, 3);
         assert_eq!(*b, 3);
@@ -387,5 +502,29 @@ mod tests {
         cache.memoize_async(&cx, (&1i32, &2i32), (1, 2), f).await;
 
         assert_eq!(n.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn async_cancelled_initializer_can_retry() {
+        let cache = MemoizeEqCache::new();
+        let cx = Cx::default();
+        let n = counter();
+        let f = async move |_: &Cx, (): ()| {
+            if n.fetch_add(1, Ordering::SeqCst) == 0 {
+                std::future::pending::<()>().await;
+            }
+            42
+        };
+
+        {
+            let mut first = std::pin::pin!(cache.memoize_async(&cx, (), (), f));
+            poll_fn(|task| {
+                assert!(first.as_mut().poll(task).is_pending());
+                std::task::Poll::Ready(())
+            })
+            .await;
+        }
+
+        assert_eq!(*cache.memoize_async(&cx, (), (), f).await, 42);
     }
 }

--- a/crates/topcoat-core/src/memoize/recursion.rs
+++ b/crates/topcoat-core/src/memoize/recursion.rs
@@ -29,13 +29,11 @@ impl Guard {
     /// memoized function `F`.
     #[inline]
     pub(super) fn assert_not_recursive<F>(&self) {
-        let owner = self.owner.load(Ordering::Relaxed);
-        if !owner.is_null() && TOKEN.with(|token| owner == ptr::from_ref(token).cast_mut()) {
-            panic!(
-                "recursive `#[memoize]` initialization of `{}` with the same arguments",
-                std::any::type_name::<F>()
-            );
-        }
+        assert!(
+            !self.is_owned_by_caller(),
+            "recursive `#[memoize]` initialization of `{}` with the same arguments",
+            std::any::type_name::<F>()
+        );
     }
 
     /// Runs `f` with this guard marked as owned by the current thread.
@@ -51,6 +49,13 @@ impl Guard {
             let _scope = Scope { owner: &self.owner };
             f()
         })
+    }
+
+    /// Returns whether the caller is running inside this guard's [`scope`](Self::scope).
+    #[inline]
+    fn is_owned_by_caller(&self) -> bool {
+        let owner = self.owner.load(Ordering::Relaxed);
+        !owner.is_null() && TOKEN.with(|token| owner == ptr::from_ref(token).cast_mut())
     }
 }
 

--- a/crates/topcoat-core/src/memoize/recursion.rs
+++ b/crates/topcoat-core/src/memoize/recursion.rs
@@ -1,0 +1,113 @@
+use std::{
+    ptr,
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+// Its address identifies the synchronous call stack or async poll currently running on a thread.
+thread_local!(static TOKEN: u8 = const { 0 });
+
+/// Detects reentry into an initializer from the call stack or poll already running it.
+///
+/// A memoized value is produced once, so a nested call for the same key would wait on a result
+/// only the waiting caller can produce. Reporting that as a panic keeps it from surfacing as a
+/// hang. Callers reaching the same key from another thread or task are ordinary concurrency and
+/// are left to wait.
+#[derive(Default)]
+pub(super) struct Guard {
+    // This is recursion metadata, not the initialization lock. `OnceLock::get_or_init` and
+    // `OnceCell::get_or_init` select one initializer at a time, so only the active initializer
+    // writes `owner`.
+    //
+    // Relaxed ordering is enough because this pointer publishes no data. A recursive read happens
+    // on the initializing thread after its own store. A caller on another thread may see null or a
+    // foreign token, but either result safely falls through to the once cell for synchronization.
+    owner: AtomicPtr<u8>,
+}
+
+impl Guard {
+    /// Panics if the caller is already inside this guard's [`scope`](Self::scope), naming the
+    /// memoized function `F`.
+    #[inline]
+    pub(super) fn assert_not_recursive<F>(&self) {
+        let owner = self.owner.load(Ordering::Relaxed);
+        if !owner.is_null() && TOKEN.with(|token| owner == ptr::from_ref(token).cast_mut()) {
+            panic!(
+                "recursive `#[memoize]` initialization of `{}` with the same arguments",
+                std::any::type_name::<F>()
+            );
+        }
+    }
+
+    /// Runs `f` with this guard marked as owned by the current thread.
+    ///
+    /// Ownership lasts only for the call, so an async initializer wraps each individual poll
+    /// rather than the future as a whole.
+    #[inline]
+    pub(super) fn scope<R>(&self, f: impl FnOnce() -> R) -> R {
+        TOKEN.with(|token| {
+            debug_assert!(self.owner.load(Ordering::Relaxed).is_null());
+            self.owner
+                .store(ptr::from_ref(token).cast_mut(), Ordering::Relaxed);
+            let _scope = Scope { owner: &self.owner };
+            f()
+        })
+    }
+}
+
+/// Releases ownership of a [`Guard`] when the scope that took it ends, including through an
+/// unwind, so a panicking initializer can be retried.
+struct Scope<'a> {
+    owner: &'a AtomicPtr<u8>,
+}
+
+impl Drop for Scope<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.owner.store(ptr::null_mut(), Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+
+    use super::*;
+
+    #[test]
+    fn scope_is_released_after_it_ends() {
+        let guard = Guard::default();
+
+        guard.scope(|| {});
+
+        guard.assert_not_recursive::<fn()>();
+    }
+
+    #[test]
+    #[should_panic(expected = "recursive `#[memoize]` initialization")]
+    fn reentry_from_the_owning_stack_panics() {
+        let guard = Guard::default();
+
+        guard.scope(|| guard.assert_not_recursive::<fn()>());
+    }
+
+    #[test]
+    fn scope_on_another_thread_is_not_recursive() {
+        let guard = Guard::default();
+        let entered = Barrier::new(2);
+        let release = Barrier::new(2);
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                guard.scope(|| {
+                    entered.wait();
+                    release.wait();
+                });
+            });
+            entered.wait();
+
+            guard.assert_not_recursive::<fn()>();
+
+            release.wait();
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- detect directly nested sync and async `#[memoize]` calls that revisit the same cache key, panicking instead of deadlocking
- retain once-cell coordination for concurrent callers, recursive calls with different keys, and retries after panic or cancellation
- document recursion semantics and add direct, indirect, concurrency, and recovery coverage

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt` (known Leptos parse errors; 0 files modified)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## Disclaimer

Created with OpenAI Codex (GPT-5), which implemented, reviewed, and verified the change under maintainer direction.