### PR TITLE
fix(asset): ignore false-positive asset scans with empty paths

### DIFF
--- a/crates/topcoat-asset/src/asset.rs
+++ b/crates/topcoat-asset/src/asset.rs
@@ -166,6 +166,7 @@ impl RawAsset {
         finder
             .find_iter(binary)
             .filter_map(|index| Self::decode(&binary[index..]))
+            .filter(|asset| !asset.path.is_empty())
             .collect()
     }
 


### PR DESCRIPTION
## Problem

`topcoat asset bundle` can fail with:

```
failed to bundle assets: io error for asset at : No such file or directory (os error 2)
```

`RawAsset::find_in_binary` scans the compiled binary for embedded asset declarations by matching the scrambled `TOPCOAT_ASSET` prefix. A string literal in the application binary can accidentally contain that byte sequence (e.g. an env var name like `TOPCOAT_ASSET_DIR`). When the bytes that follow happen to decode as a record with an **empty path**, the bundler calls `fs::read("")` and aborts the entire bundle.

## Fix

Real asset declarations always carry a non-empty path. Filter out any decode that yields an empty path before attempting to resolve it, so incidental prefix matches in binary string data are ignored.

## Notes

- Reproduced against a binary containing the literal string `TOPCOAT_ASSET_DIR`.
- After the fix the false-positive record is skipped and the two real assets (tailwind stylesheet, app bundle) resolve correctly.