### PR TITLE
feat(view): render independent peer components concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,10 +3194,12 @@ name = "topcoat-view"
 version = "0.5.0"
 dependencies = [
  "criterion",
+ "futures-util",
  "http",
  "itoa",
  "memchr",
  "smallvec",
+ "tokio",
  "topcoat",
  "topcoat-core",
 ]

--- a/crates/topcoat-view/Cargo.toml
+++ b/crates/topcoat-view/Cargo.toml
@@ -18,6 +18,7 @@ http = [
 [dependencies]
 topcoat-core.workspace = true
 
+futures-util.workspace = true
 http = { workspace = true, optional = true }
 itoa.workspace = true
 memchr.workspace = true
@@ -27,6 +28,7 @@ smallvec.workspace = true
 topcoat = { workspace = true, features = ["view"] }
 
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[bench]]
 name = "render"

--- a/crates/topcoat-view/examples/concurrent_components.rs
+++ b/crates/topcoat-view/examples/concurrent_components.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+#[component]
+async fn card(label: &'static str, delay: Duration) -> Result {
+    println!("starting {label}");
+    tokio::time::sleep(delay).await;
+    println!("finished {label}");
+
+    view! { <article>(label)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            card(label: "first", delay: Duration::from_secs(1))
+            <section>
+                card(label: "second", delay: Duration::from_secs(1))
+            </section>
+        </main>
+    }?;
+
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/grammar/src/view/component.rs
+++ b/crates/topcoat-view/grammar/src/view/component.rs
@@ -12,7 +12,7 @@ use topcoat_core_grammar::{ParseOption, paths::topcoat_view};
 
 use crate::{
     template::RuntimeExpr,
-    view::{ExprKind, Nodes, ViewWriter, WriteView},
+    view::{Nodes, ViewWriter, WriteView},
 };
 
 /// A component invocation, written as `path(name: value, ..., child_node child_node ...)`.
@@ -90,23 +90,20 @@ impl WriteView for Component {
             }
         });
 
-        writer.write_expr(
-            ExprKind::View,
-            quote_spanned! {self.paren_token.span.span()=>
-                {
-                    use #topcoat_view::Component;
-                    let props = #name::props_builder()#(#setters)*#child.build();
-                    // The marker is built via `Default` so the same construction
-                    // works for both unit-struct and generic (`PhantomData`) markers.
-                    #[allow(clippy::default_constructed_unit_structs)]
-                    Component::render(
-                        #name::default(),
-                        __cx,
-                        props,
-                    ).await?
-                }
-            },
-        );
+        writer.write_component(quote_spanned! {self.paren_token.span.span()=>
+            {
+                use #topcoat_view::Component;
+                let props = #name::props_builder()#(#setters)*#child.build();
+                // The marker is built via `Default` so the same construction
+                // works for both unit-struct and generic (`PhantomData`) markers.
+                #[allow(clippy::default_constructed_unit_structs)]
+                Component::render(
+                    #name::default(),
+                    __cx,
+                    props,
+                )
+            }
+        });
     }
 }
 

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{Expr, Ident, Pat};
 use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 
@@ -70,6 +70,11 @@ impl ViewWriter {
         self.chunks.push(Chunk::Expr { kind, tokens });
     }
 
+    pub fn write_component(&mut self, tokens: TokenStream) {
+        self.flush();
+        self.chunks.push(Chunk::Component { tokens });
+    }
+
     pub fn local_binding(&mut self, pat: &Pat, expr: &Expr) {
         self.flush();
         self.chunks.push(Chunk::Local {
@@ -133,8 +138,67 @@ impl ViewWriter {
             } else {
                 fn build_parts(chunks: &[Chunk]) -> TokenStream {
                     let mut output = TokenStream::new();
-                    for chunk in chunks {
-                        match chunk {
+                    let mut index = 0;
+                    while index < chunks.len() {
+                        // Static markup cannot introduce a dependency between component calls.
+                        if matches!(
+                            &chunks[index],
+                            Chunk::Static { .. } | Chunk::Component { .. }
+                        ) {
+                            let start = index;
+                            while index < chunks.len()
+                                && matches!(
+                                    &chunks[index],
+                                    Chunk::Static { .. } | Chunk::Component { .. }
+                                )
+                            {
+                                index += 1;
+                            }
+                            let region = &chunks[start..index];
+                            let components = region
+                                .iter()
+                                .filter_map(|chunk| match chunk {
+                                    Chunk::Component { tokens } => Some(tokens),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>();
+                            let results = (0..components.len())
+                                .map(|index| format_ident!("__component_result_{index}"))
+                                .collect::<Vec<_>>();
+                            // Avoid joining when there is only one component to await.
+                            let wait = match components.as_slice() {
+                                [] => TokenStream::new(),
+                                [component] => {
+                                    let result = &results[0];
+                                    quote! { let #result = #component.await; }
+                                }
+                                _ => quote! {
+                                    let (#(#results,)*) = __join!(#(#components),*);
+                                },
+                            };
+                            let mut result_index = 0;
+                            let region_parts = region.iter().map(|chunk| match chunk {
+                                Chunk::Static { string } => {
+                                    let helper = ExprKind::Unescaped.helper();
+                                    quote! { #helper(__cx, &mut __parts, #string); }
+                                }
+                                Chunk::Component { .. } => {
+                                    let result = &results[result_index];
+                                    result_index += 1;
+                                    let helper = ExprKind::View.helper();
+                                    quote! { #helper(__cx, &mut __parts, #result?); }
+                                }
+                                _ => unreachable!(),
+                            });
+                            quote! {{
+                                #wait
+                                #(#region_parts)*
+                            }}
+                            .to_tokens(&mut output);
+                            continue;
+                        }
+
+                        match &chunks[index] {
                             Chunk::Static { string } => {
                                 let helper = ExprKind::Unescaped.helper();
                                 let tokens = quote! { #string };
@@ -144,6 +208,7 @@ impl ViewWriter {
                                 let helper = kind.helper();
                                 quote! { #helper(__cx, &mut __parts, #tokens); }
                             }
+                            Chunk::Component { .. } => unreachable!(),
                             Chunk::Local { pat, expr } => {
                                 quote! { let #pat = #expr; }
                             }
@@ -191,6 +256,7 @@ impl ViewWriter {
                             }
                         }
                         .to_tokens(&mut output);
+                        index += 1;
                     }
                     output
                 }
@@ -253,6 +319,9 @@ enum Chunk {
     },
     Expr {
         kind: ExprKind,
+        tokens: TokenStream,
+    },
+    Component {
         tokens: TokenStream,
     },
     Local {
@@ -362,6 +431,19 @@ mod tests {
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"<p>\")"));
         assert!(out.contains("__node (__cx , & mut __parts , value)"));
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"</p>\")"));
+    }
+
+    #[test]
+    fn static_markup_does_not_split_component_join() {
+        let mut writer = ViewWriter::new();
+        writer.write_str_unescaped("<main>");
+        writer.write_component(quote! { first() });
+        writer.write_str_unescaped("<aside>");
+        writer.write_component(quote! { second() });
+        writer.write_str_unescaped("</aside></main>");
+        let out = rendered(writer);
+
+        assert!(out.contains("__join ! (first () , second ())"));
     }
 
     #[test]

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -345,6 +345,10 @@ view! {
 
 See how to define components in the [`component`] macro guide.
 
+Component calls in the same straight-line view body render concurrently. Static HTML between the calls does not split the group, and the completed views are inserted in source order. A Rust expression, local binding, statement, or control-flow construct ends the group because later component props may depend on it.
+
+Each control-flow body forms its own group. An ordinary `for` loop still renders its iterations in order, but peer components within one iteration can render concurrently.
+
 # Boolean And Conditional Attributes
 
 [Boolean HTML attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) such as `disabled`, `required`, and `checked` are true when the attribute is present and false when it is absent. HTML expects a present boolean attribute to have an empty value.

--- a/crates/topcoat-view/macro/tests/component.rs
+++ b/crates/topcoat-view/macro/tests/component.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use topcoat::{
     Result,
     context::Cx,
@@ -93,6 +95,68 @@ async fn component_can_call_other_components_and_forward_child_views() {
 
     assert!(html.contains("<h2>Outer</h2>"));
     assert!(html.contains("<em>inner</em>"));
+}
+
+#[component]
+async fn concurrent_peer(log: Arc<Mutex<Vec<String>>>, label: &'static str) -> Result {
+    log.lock().unwrap().push(format!("enter {label}"));
+    tokio::task::yield_now().await;
+    log.lock().unwrap().push(format!("exit {label}"));
+
+    view! { <span>(label)</span> }
+}
+
+#[tokio::test]
+async fn peer_components_render_concurrently_across_static_markup() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            <aside>concurrent_peer(log: Arc::clone(&log), label: "b")</aside>
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        ["enter a", "enter b", "exit a", "exit b"],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><aside><span>b</span></aside></main>",
+    );
+}
+
+#[tokio::test]
+async fn control_flow_and_loops_split_concurrent_component_groups() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            if true {
+                <section>concurrent_peer(log: Arc::clone(&log), label: "b")</section>
+            }
+            for label in ["c", "d"] {
+                concurrent_peer(log: Arc::clone(&log), label: label)
+            }
+            concurrent_peer(log: Arc::clone(&log), label: "e")
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        [
+            "enter a", "exit a", "enter b", "exit b", "enter c", "exit c", "enter d", "exit d",
+            "enter e", "exit e",
+        ],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><section><span>b</span></section><span>c</span><span>d</span><span>e</span></main>",
+    );
 }
 
 #[component]

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,7 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
     use crate::{


### PR DESCRIPTION
## Motivation

Async component calls currently render sequentially because `view!` awaits each component as it encounters it. This creates a waterfall even when peer components are independent:

```rust
view! {
    <main>
        profile()
        <aside>recommendations()</aside>
    </main>
}
```

`recommendations()` does not begin rendering until `profile()` finishes, although the static HTML between them introduces no dependency.

## What changes

`view!` now polls independent peer component renders concurrently and inserts their completed views in source order.

Conceptually, generated code changes from:

```rust
let profile = profile().await?;
let recommendations = recommendations().await?;
```

to:

```rust
let (profile, recommendations) =
    futures_util::join!(profile(), recommendations());

render(profile?);
render(recommendations?);
```

This is structured concurrency: component renders are joined within the current render future. It does not spawn tasks, require `Send`, or move work onto additional threads.

Static markup does not end a concurrent group, so components may render concurrently even when they are not consecutive siblings. Rust expressions, local bindings, statements, and control-flow constructs do end the group because subsequent component arguments may depend on them. Each control-flow body forms its own group.

A single component retains the direct `.await` path.

## Alternative: unresolved view trees

[#292](https://github.com/tokio-rs/topcoat/pull/292) explores a broader and more intrusive design that builds an unresolved view tree. It can overlap components across control flow, loop iterations, and parent/child component boundaries.

| | This PR | #292 |
|---|---|---|
| Concurrency | Peer components within an emitter group | Components throughout the selected tree, including loop iterations and nested component boundaries |
| Boundaries | Rust expressions, bindings, statements, and control flow end a group | Selected control flow becomes part of the concurrent tree |
| Runtime changes | None to `View`; concurrency is emitted as local joins | Adds runtime tree nodes, boxed futures, and child-view placeholders |
| Component children | Remain completed `View` values before the parent starts | Use placeholders so parent and child work can overlap |
| Compatibility | Smaller timing change; no new `Send` requirement | Broader side-effect timing changes; pending tree futures must be `Send`; synchronously rendering a child inside its component is incompatible with an unresolved placeholder |
| Cost | Generated tuple joins for each group | Allocation for pending nodes plus placeholder synchronization |

This PR favors a focused optimization with fewer semantic and runtime changes. #292 favors maximum automatic concurrency and serves as a design prototype for evaluating whether those additional costs are worthwhile.

## Observable behavior

- Independent peer components can make progress concurrently.
- Final HTML remains in source order, regardless of completion order.
- All components in a group finish before their results are inserted.
- If a component returns an error, results are still examined in source order; peers in that group may already have completed.

## Coverage

- Adds a regression test whose components record `enter`, yield once, and then record `exit`. The test requires both `enter` events before either `exit`.
- Covers components separated by nested static markup.
- Adds a runnable example with two one-second components.
- Documents grouping and ordering semantics in the `view!` guide.

## Validation

- `cargo +nightly fmt --all`
- `cargo topcoat fmt`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI disclosure

OpenAI Codex (GPT-5) helped implement, test, and prepare this change for review.
