### PR TITLE
feat(view): add concurrent view loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,10 +3194,12 @@ name = "topcoat-view"
 version = "0.5.0"
 dependencies = [
  "criterion",
+ "futures-util",
  "http",
  "itoa",
  "memchr",
  "smallvec",
+ "tokio",
  "topcoat",
  "topcoat-core",
 ]

--- a/crates/topcoat-view/Cargo.toml
+++ b/crates/topcoat-view/Cargo.toml
@@ -18,6 +18,7 @@ http = [
 [dependencies]
 topcoat-core.workspace = true
 
+futures-util.workspace = true
 http = { workspace = true, optional = true }
 itoa.workspace = true
 memchr.workspace = true
@@ -27,6 +28,7 @@ smallvec.workspace = true
 topcoat = { workspace = true, features = ["view"] }
 
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[bench]]
 name = "render"

--- a/crates/topcoat-view/examples/concurrent_components.rs
+++ b/crates/topcoat-view/examples/concurrent_components.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+#[component]
+async fn card(label: &'static str, delay: Duration) -> Result {
+    println!("starting {label}");
+    tokio::time::sleep(delay).await;
+    println!("finished {label}");
+
+    view! { <article>(label)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            card(label: "first", delay: Duration::from_secs(1))
+            <section>
+                card(label: "second", delay: Duration::from_secs(1))
+            </section>
+        </main>
+    }?;
+
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/examples/concurrent_for.rs
+++ b/crates/topcoat-view/examples/concurrent_for.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+struct Post {
+    title: &'static str,
+    delay: Duration,
+}
+
+#[component]
+async fn post_card(post: Post) -> Result {
+    tokio::time::sleep(post.delay).await;
+    println!("finished {}", post.title);
+
+    view! { <article>(post.title)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let posts = vec![
+        Post {
+            title: "first",
+            delay: Duration::from_millis(100),
+        },
+        Post {
+            title: "second",
+            delay: Duration::from_millis(50),
+        },
+    ];
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            for concurrent post in posts {
+                post_card(post: post)
+            }
+        </main>
+    }?;
+
+    // "second" finishes first, but the generated HTML keeps iterator order.
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/grammar/src/template/template_for_loop.rs
+++ b/crates/topcoat-view/grammar/src/template/template_for_loop.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
     Expr, ExprBreak, ExprContinue, Pat, Token,
     parse::{Parse, ParseStream},
@@ -11,10 +11,23 @@ use crate::{
     view::{ViewWriter, WriteView},
 };
 
+mod kw {
+    syn::custom_keyword!(concurrent);
+}
+
+pub use kw::concurrent as ConcurrentToken;
+
+impl ParseOption for ConcurrentToken {
+    fn peek(input: ParseStream) -> bool {
+        input.peek(kw::concurrent)
+    }
+}
+
 /// A `for pat in expr { ... }` loop in view-body position. The body is
 /// rendered once per iteration.
 pub struct TemplateForLoop<T> {
     pub for_token: Token![for],
+    pub concurrent_token: Option<ConcurrentToken>,
     pub pat: Box<Pat>,
     pub in_token: Token![in],
     pub expr: Box<Expr>,
@@ -23,14 +36,26 @@ pub struct TemplateForLoop<T> {
 
 impl<T: WriteView> WriteView for TemplateForLoop<T> {
     fn write(&self, writer: &mut ViewWriter) {
-        writer.for_loop(&self.pat, &self.expr, |writer| {
-            self.body.write(writer);
-        });
+        if self.concurrent_token.is_some() {
+            writer.concurrent_for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        } else {
+            writer.for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        }
     }
 }
 
 impl<T: WriteAttribute> WriteAttribute for TemplateForLoop<T> {
     fn write(&self, writer: &mut AttributeWriter) {
+        if let Some(concurrent_token) = &self.concurrent_token {
+            writer.statement(quote_spanned! {concurrent_token.span=>
+                compile_error!("`for concurrent` is only supported in view-body position");
+            });
+            return;
+        }
         writer.for_loop(&self.pat, &self.expr, |writer| {
             self.body.write(writer);
         });
@@ -41,6 +66,7 @@ impl<T: Parse> Parse for TemplateForLoop<T> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(Self {
             for_token: input.parse()?,
+            concurrent_token: input.call(ConcurrentToken::parse_option)?,
             pat: Box::new(input.call(Pat::parse_single)?),
             in_token: input.parse()?,
             expr: Box::new(input.call(Expr::parse_without_eager_brace)?),
@@ -63,6 +89,10 @@ impl<T: topcoat_core_grammar::pretty::PrettyPrint> topcoat_core_grammar::pretty:
     fn pretty_print(&self, printer: &mut topcoat_core_grammar::pretty::Printer<'_>) {
         self.for_token.pretty_print(printer);
         " ".pretty_print(printer);
+        if self.concurrent_token.is_some() {
+            "concurrent".pretty_print(printer);
+            " ".pretty_print(printer);
+        }
         self.pat.pretty_print(printer);
         " ".pretty_print(printer);
         self.in_token.pretty_print(printer);
@@ -185,9 +215,18 @@ mod tests {
     #[test]
     fn parses_simple_for_loop() {
         let loop_ = parse(r"for x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_none());
         assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
         assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
         assert_eq!(loop_.body.children.len(), 1);
+    }
+
+    #[test]
+    fn parses_concurrent_for_loop() {
+        let loop_ = parse(r"for concurrent x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_some());
+        assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
+        assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/component.rs
+++ b/crates/topcoat-view/grammar/src/view/component.rs
@@ -12,7 +12,7 @@ use topcoat_core_grammar::{ParseOption, paths::topcoat_view};
 
 use crate::{
     template::RuntimeExpr,
-    view::{ExprKind, Nodes, ViewWriter, WriteView},
+    view::{Nodes, ViewWriter, WriteView},
 };
 
 /// A component invocation, written as `path(name: value, ..., child_node child_node ...)`.
@@ -90,23 +90,20 @@ impl WriteView for Component {
             }
         });
 
-        writer.write_expr(
-            ExprKind::View,
-            quote_spanned! {self.paren_token.span.span()=>
-                {
-                    use #topcoat_view::Component;
-                    let props = #name::props_builder()#(#setters)*#child.build();
-                    // The marker is built via `Default` so the same construction
-                    // works for both unit-struct and generic (`PhantomData`) markers.
-                    #[allow(clippy::default_constructed_unit_structs)]
-                    Component::render(
-                        #name::default(),
-                        __cx,
-                        props,
-                    ).await?
-                }
-            },
-        );
+        writer.write_component(quote_spanned! {self.paren_token.span.span()=>
+            {
+                use #topcoat_view::Component;
+                let props = #name::props_builder()#(#setters)*#child.build();
+                // The marker is built via `Default` so the same construction
+                // works for both unit-struct and generic (`PhantomData`) markers.
+                #[allow(clippy::default_constructed_unit_structs)]
+                Component::render(
+                    #name::default(),
+                    __cx,
+                    props,
+                )
+            }
+        });
     }
 }
 

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{Expr, Ident, Pat};
 use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 
@@ -70,6 +70,11 @@ impl ViewWriter {
         self.chunks.push(Chunk::Expr { kind, tokens });
     }
 
+    pub fn write_component(&mut self, tokens: TokenStream) {
+        self.flush();
+        self.chunks.push(Chunk::Component { tokens });
+    }
+
     pub fn local_binding(&mut self, pat: &Pat, expr: &Expr) {
         self.flush();
         self.chunks.push(Chunk::Local {
@@ -133,8 +138,67 @@ impl ViewWriter {
             } else {
                 fn build_parts(chunks: &[Chunk]) -> TokenStream {
                     let mut output = TokenStream::new();
-                    for chunk in chunks {
-                        match chunk {
+                    let mut index = 0;
+                    while index < chunks.len() {
+                        // Static markup cannot introduce a dependency between component calls.
+                        if matches!(
+                            &chunks[index],
+                            Chunk::Static { .. } | Chunk::Component { .. }
+                        ) {
+                            let start = index;
+                            while index < chunks.len()
+                                && matches!(
+                                    &chunks[index],
+                                    Chunk::Static { .. } | Chunk::Component { .. }
+                                )
+                            {
+                                index += 1;
+                            }
+                            let region = &chunks[start..index];
+                            let components = region
+                                .iter()
+                                .filter_map(|chunk| match chunk {
+                                    Chunk::Component { tokens } => Some(tokens),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>();
+                            let results = (0..components.len())
+                                .map(|index| format_ident!("__component_result_{index}"))
+                                .collect::<Vec<_>>();
+                            // Avoid joining when there is only one component to await.
+                            let wait = match components.as_slice() {
+                                [] => TokenStream::new(),
+                                [component] => {
+                                    let result = &results[0];
+                                    quote! { let #result = #component.await; }
+                                }
+                                _ => quote! {
+                                    let (#(#results,)*) = __join!(#(#components),*);
+                                },
+                            };
+                            let mut result_index = 0;
+                            let region_parts = region.iter().map(|chunk| match chunk {
+                                Chunk::Static { string } => {
+                                    let helper = ExprKind::Unescaped.helper();
+                                    quote! { #helper(__cx, &mut __parts, #string); }
+                                }
+                                Chunk::Component { .. } => {
+                                    let result = &results[result_index];
+                                    result_index += 1;
+                                    let helper = ExprKind::View.helper();
+                                    quote! { #helper(__cx, &mut __parts, #result?); }
+                                }
+                                _ => unreachable!(),
+                            });
+                            quote! {{
+                                #wait
+                                #(#region_parts)*
+                            }}
+                            .to_tokens(&mut output);
+                            continue;
+                        }
+
+                        match &chunks[index] {
                             Chunk::Static { string } => {
                                 let helper = ExprKind::Unescaped.helper();
                                 let tokens = quote! { #string };
@@ -144,6 +208,7 @@ impl ViewWriter {
                                 let helper = kind.helper();
                                 quote! { #helper(__cx, &mut __parts, #tokens); }
                             }
+                            Chunk::Component { .. } => unreachable!(),
                             Chunk::Local { pat, expr } => {
                                 quote! { let #pat = #expr; }
                             }
@@ -191,6 +256,7 @@ impl ViewWriter {
                             }
                         }
                         .to_tokens(&mut output);
+                        index += 1;
                     }
                     output
                 }
@@ -253,6 +319,9 @@ enum Chunk {
     },
     Expr {
         kind: ExprKind,
+        tokens: TokenStream,
+    },
+    Component {
         tokens: TokenStream,
     },
     Local {
@@ -362,6 +431,19 @@ mod tests {
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"<p>\")"));
         assert!(out.contains("__node (__cx , & mut __parts , value)"));
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"</p>\")"));
+    }
+
+    #[test]
+    fn static_markup_does_not_split_component_join() {
+        let mut writer = ViewWriter::new();
+        writer.write_str_unescaped("<main>");
+        writer.write_component(quote! { first() });
+        writer.write_str_unescaped("<aside>");
+        writer.write_component(quote! { second() });
+        writer.write_str_unescaped("</aside></main>");
+        let out = rendered(writer);
+
+        assert!(out.contains("__join ! (first () , second ())"));
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -100,6 +100,18 @@ impl ViewWriter {
         });
     }
 
+    pub fn concurrent_for_loop(&mut self, pat: &Pat, expr: &Expr, f: impl FnOnce(&mut ViewWriter)) {
+        self.flush();
+        let mut body = ViewWriter::new();
+        f(&mut body);
+        body.flush();
+        self.chunks.push(Chunk::ConcurrentFor {
+            pat: pat.clone(),
+            expr: Box::new(expr.clone()),
+            body: Box::new(body),
+        });
+    }
+
     pub fn if_else(&mut self, expr: &Expr, f: impl FnOnce(&mut ViewWriter, &mut ViewWriter)) {
         self.flush();
         let mut then_branch = ViewWriter::new();
@@ -239,6 +251,27 @@ impl ViewWriter {
                                     }
                                 }
                             }
+                            Chunk::ConcurrentFor { pat, expr, body } => {
+                                let body = build_parts(&body.chunks);
+                                quote! {
+                                    {
+                                        let __render_iteration = async |#pat| {
+                                            let mut __parts = #topcoat_view::ViewParts::new();
+                                            #body
+                                            ::core::result::Result::<
+                                                #topcoat_view::View,
+                                                #topcoat_error::Error,
+                                            >::Ok(#topcoat_view::View::new(__parts))
+                                        };
+                                        let __iterations = (#expr)
+                                            .into_iter()
+                                            .map(__render_iteration);
+                                        for __iteration in __join_all(__iterations).await {
+                                            __view(__cx, &mut __parts, __iteration?);
+                                        }
+                                    }
+                                }
+                            }
                             Chunk::Match { expr, arms } => {
                                 let arm_tokens = arms.iter().map(|arm| {
                                     let pat = &arm.pat;
@@ -332,6 +365,11 @@ enum Chunk {
         tokens: TokenStream,
     },
     For {
+        pat: Pat,
+        expr: Box<Expr>,
+        body: Box<ViewWriter>,
+    },
+    ConcurrentFor {
         pat: Pat,
         expr: Box<Expr>,
         body: Box<ViewWriter>,
@@ -479,6 +517,18 @@ mod tests {
         });
         let out = rendered(writer);
         assert!(out.contains("for x in xs"));
+    }
+
+    #[test]
+    fn concurrent_for_loop_joins_iteration_futures() {
+        let mut writer = ViewWriter::new();
+        writer.concurrent_for_loop(&syn::parse_quote!(x), &syn::parse_quote!(xs), |body| {
+            body.write_expr(ExprKind::Node, quote! { x });
+        });
+        let out = rendered(writer);
+
+        assert!(out.contains("let __render_iteration = async | x |"));
+        assert!(out.contains("__join_all (__iterations) . await"));
     }
 
     #[test]

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -187,6 +187,26 @@ view! {
 # }
 ```
 
+Use `for concurrent` when iterations perform independent async component work:
+
+```rust
+# use topcoat::{Result, view::*};
+# struct Post { title: &'static str }
+# #[component]
+# async fn post_card(post: Post) -> Result { view! { <article>(post.title)</article> } }
+# #[component]
+# async fn example() -> Result {
+# let posts = vec![Post { title: "A" }, Post { title: "B" }];
+view! {
+    for concurrent post in posts {
+        post_card(post: post)
+    }
+}
+# }
+```
+
+The iterations render concurrently, but their completed views are inserted in iterator order. Use this form only when iterations are independent. An ordinary `for` remains sequential and can mutate or mutably borrow shared state. `for concurrent` is available in view-body position, not in an element's attribute list.
+
 ## `match`
 
 Use `match` to choose markup from patterns. Match arms can also use guards.

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -345,6 +345,10 @@ view! {
 
 See how to define components in the [`component`] macro guide.
 
+Component calls in the same straight-line view body render concurrently. Static HTML between the calls does not split the group, and the completed views are inserted in source order. A Rust expression, local binding, statement, or control-flow construct ends the group because later component props may depend on it.
+
+Each control-flow body forms its own group. An ordinary `for` loop still renders its iterations in order, but peer components within one iteration can render concurrently.
+
 # Boolean And Conditional Attributes
 
 [Boolean HTML attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) such as `disabled`, `required`, and `checked` are true when the attribute is present and false when it is absent. HTML expects a present boolean attribute to have an empty value.

--- a/crates/topcoat-view/macro/tests/component.rs
+++ b/crates/topcoat-view/macro/tests/component.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use topcoat::{
     Result,
     context::Cx,
@@ -93,6 +95,68 @@ async fn component_can_call_other_components_and_forward_child_views() {
 
     assert!(html.contains("<h2>Outer</h2>"));
     assert!(html.contains("<em>inner</em>"));
+}
+
+#[component]
+async fn concurrent_peer(log: Arc<Mutex<Vec<String>>>, label: &'static str) -> Result {
+    log.lock().unwrap().push(format!("enter {label}"));
+    tokio::task::yield_now().await;
+    log.lock().unwrap().push(format!("exit {label}"));
+
+    view! { <span>(label)</span> }
+}
+
+#[tokio::test]
+async fn peer_components_render_concurrently_across_static_markup() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            <aside>concurrent_peer(log: Arc::clone(&log), label: "b")</aside>
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        ["enter a", "enter b", "exit a", "exit b"],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><aside><span>b</span></aside></main>",
+    );
+}
+
+#[tokio::test]
+async fn control_flow_and_loops_split_concurrent_component_groups() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            if true {
+                <section>concurrent_peer(log: Arc::clone(&log), label: "b")</section>
+            }
+            for label in ["c", "d"] {
+                concurrent_peer(log: Arc::clone(&log), label: label)
+            }
+            concurrent_peer(log: Arc::clone(&log), label: "e")
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        [
+            "enter a", "exit a", "enter b", "exit b", "enter c", "exit c", "enter d", "exit d",
+            "enter e", "exit e",
+        ],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><section><span>b</span></section><span>c</span><span>d</span><span>e</span></main>",
+    );
 }
 
 #[component]

--- a/crates/topcoat-view/macro/tests/control_flow.rs
+++ b/crates/topcoat-view/macro/tests/control_flow.rs
@@ -1,4 +1,17 @@
-use topcoat::{context::Cx, view::view};
+use std::{
+    future::poll_fn,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::Poll,
+};
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
 
 fn r(v: topcoat::Result) -> String {
     v.unwrap().render(&Cx::default())
@@ -101,6 +114,50 @@ async fn for_loop_renders_body_per_item() {
         <ul>
             for title in posts {
                 <li>(title)</li>
+            }
+        </ul>
+    });
+
+    assert_eq!(html, "<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>");
+}
+
+#[component]
+async fn concurrent_loop_item(
+    started: Arc<AtomicUsize>,
+    expected: usize,
+    label: &'static str,
+) -> Result {
+    let mut first_poll = true;
+    poll_fn(|cx| {
+        if first_poll {
+            first_poll = false;
+            started.fetch_add(1, Ordering::SeqCst);
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        } else {
+            assert_eq!(started.load(Ordering::SeqCst), expected);
+            Poll::Ready(())
+        }
+    })
+    .await;
+
+    view! { <li>(label)</li> }
+}
+
+#[tokio::test]
+async fn concurrent_for_loop_polls_iterations_together_and_preserves_order() {
+    let labels = ["alpha", "beta", "gamma"];
+    let started = Arc::new(AtomicUsize::new(0));
+    let cx = &Cx::default();
+    let html = r(view! {
+        cx =>
+        <ul>
+            for concurrent label in labels {
+                concurrent_loop_item(
+                    started: Arc::clone(&started),
+                    expected: labels.len(),
+                    label: label
+                )
             }
         </ul>
     });

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,8 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    use core::future::Future;
+
     pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
@@ -44,6 +46,15 @@ pub mod internal {
     #[inline]
     pub fn __view(_cx: &Cx, parts: &mut ViewParts, view: View) {
         parts.push_view(view);
+    }
+
+    #[inline]
+    pub async fn __join_all<I>(futures: I) -> Vec<<I::Item as Future>::Output>
+    where
+        I: IntoIterator,
+        I::Item: Future,
+    {
+        futures_util::future::join_all(futures).await
     }
 
     #[inline]

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,7 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
     use crate::{


### PR DESCRIPTION
## Summary

- Add `for concurrent` view syntax that starts every loop iteration together and preserves iteration order in the rendered output.
- Add a runnable timing example, syntax documentation, code-generation tests, and runtime regression coverage.

This draft follows #284. Until that draft lands, GitHub also shows its prerequisite component-rendering commit in this PR.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI disclosure

OpenAI Codex (GPT-5) helped implement, test, and prepare this change for review.