### PR TITLE
feat(shell-view): add streaming shell responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Topcoat is a Cargo workspace. The framework crates live in `crates/`, runnable e
 - `topcoat-cookie`: the cookie jar, `cookie!` macro, signed/private jars, and `CookieStore<T>`.
 - `topcoat-session`: bring-your-own-storage session authentication: the token/hash model, the session lifecycle, and origin checking.
 - `topcoat-mail`: the `Mail` type and `mail!` macro for declaring mail, and its delivery through pluggable transports (SMTP, file, in-memory).
+- `topcoat-shell-view`: streaming HTML containers that replace placeholders as deferred views finish.
 - `topcoat-htmx`, `topcoat-alpine-ajax`, and `topcoat-datastar`: request and response helpers for those client libraries.
 - `topcoat-tailwind`: the build-script wrapper around the standalone Tailwind CLI.
 - `topcoat-ui` (+ `registry/`): the component registry behind `topcoat ui`, which copies component source into a project.
@@ -50,6 +51,7 @@ Each crate's `docs/` directory holds the user-facing guides for that crate, embe
 - [`crates/topcoat-view/macro/docs/attributes.md`](crates/topcoat-view/macro/docs/attributes.md): The `attributes!` macro and the runtime `Attributes` value for building/forwarding attribute collections.
 - [`crates/topcoat-view/macro/docs/class.md`](crates/topcoat-view/macro/docs/class.md): The `class!` macro: assembling a space-separated class list from static and conditional entries.
 - [`crates/topcoat-view/macro/docs/props.md`](crates/topcoat-view/macro/docs/props.md): The `props!` macro for building a component's props value.
+- [`crates/topcoat/docs/shell_view.md`](crates/topcoat/docs/shell_view.md): `ShellView` streaming responses, deferred placeholders, components, and composition.
 
 ### UI components
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,6 +2307,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-view"
+version = "0.5.0"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2795,7 @@ dependencies = [
  "topcoat-runtime",
  "topcoat-runtime-macro",
  "topcoat-session",
+ "topcoat-shell-view",
  "topcoat-tailwind",
  "topcoat-ui-registry",
  "topcoat-view",
@@ -3157,6 +3166,23 @@ dependencies = [
  "topcoat-core",
  "topcoat-router",
  "web-time",
+]
+
+[[package]]
+name = "topcoat-shell-view"
+version = "0.5.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "serde_json",
+ "tokio",
+ "topcoat",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,10 +3194,12 @@ name = "topcoat-view"
 version = "0.5.0"
 dependencies = [
  "criterion",
+ "futures-util",
  "http",
  "itoa",
  "memchr",
  "smallvec",
+ "tokio",
  "topcoat",
  "topcoat-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/topcoat-mail",
     "crates/topcoat-mail/grammar",
     "crates/topcoat-mail/macro",
+    "crates/topcoat-shell-view",
     "crates/topcoat-router",
     "crates/topcoat-router/grammar",
     "crates/topcoat-router/macro",
@@ -48,6 +49,7 @@ members = [
     "examples/manual-router",
     "examples/module-router",
     "examples/path-query-params",
+    "examples/shell-view",
     "examples/procedure",
     "examples/request-response",
     "examples/runtime",
@@ -127,6 +129,7 @@ topcoat-icon-macro = { version = "0.5.0", path = "crates/topcoat-icon/macro" }
 topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
 topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
 topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
+topcoat-shell-view = { version = "0.5.0", path = "crates/topcoat-shell-view" }
 topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
 topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
 topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 **Rendering**
 - [The `view!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.view.html): templating syntax, control flow, conditional attributes.
 - [The `#[component]` macro](https://docs.rs/topcoat/latest/topcoat/view/attr.component.html): async functions as components, with child content.
+- [`ShellView`](https://docs.rs/topcoat/latest/topcoat/shell_view/index.html): stream placeholders first and replace them as deferred views finish.
 - [The `attributes!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.attributes.html): reusable runtime attribute fragments.
 - [The `class!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.class.html): space-separated class lists from static and conditional entries.
 

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -19,9 +19,9 @@ use crate::{abort::AbortStore, memoize::MemoizeCache};
 pub struct Cx {
     id: CxId,
     app_context: Arc<ContextMap>,
-    request_context: ContextMap,
-    memoize_cache: MemoizeCache,
-    abort_store: AbortStore,
+    request_context: Arc<ContextMap>,
+    memoize_cache: Arc<MemoizeCache>,
+    abort_store: Arc<AbortStore>,
 }
 
 impl Cx {
@@ -30,16 +30,59 @@ impl Cx {
         Self {
             id: CxId::new(),
             app_context,
-            request_context,
-            memoize_cache: MemoizeCache::new(),
-            abort_store: AbortStore::new(),
+            request_context: Arc::new(request_context),
+            memoize_cache: Arc::new(MemoizeCache::new()),
+            abort_store: Arc::new(AbortStore::new()),
         }
     }
 
     /// Returns this context's unique [`CxId`].
     #[inline]
+    #[must_use]
     pub fn id(&self) -> CxId {
         self.id
+    }
+
+    /// Returns an owned handle to this request context.
+    ///
+    /// The handle keeps request and app context values alive for work that
+    /// continues while a streaming response is sent.
+    #[must_use]
+    pub fn handle(&self) -> CxHandle {
+        CxHandle(Self {
+            id: self.id,
+            app_context: Arc::clone(&self.app_context),
+            request_context: Arc::clone(&self.request_context),
+            memoize_cache: Arc::clone(&self.memoize_cache),
+            abort_store: Arc::clone(&self.abort_store),
+        })
+    }
+}
+
+/// An owned handle to a request [`Cx`].
+///
+/// This is useful for response streams and other work that must own the
+/// request context. It dereferences to `Cx`, so context helpers accept `&handle`.
+#[derive(Debug)]
+pub struct CxHandle(Cx);
+
+impl Clone for CxHandle {
+    fn clone(&self) -> Self {
+        self.0.handle()
+    }
+}
+
+impl AsRef<Cx> for CxHandle {
+    fn as_ref(&self) -> &Cx {
+        &self.0
+    }
+}
+
+impl Deref for CxHandle {
+    type Target = Cx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -71,11 +114,18 @@ impl CxBuilder {
     ///
     /// A type can hold only one value at a time, so registering a type that is
     /// already present replaces it and hands back the displaced value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     pub fn insert<T>(&mut self, value: T) -> Option<T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.insert(value)
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .insert(value)
     }
 
     /// Returns `true` if a value of type `T` has been registered on the request
@@ -100,12 +150,19 @@ impl CxBuilder {
 
     /// Returns a mutable reference to the request context value of type `T`, or
     /// `None` if no such value has been registered.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     #[must_use]
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.get_mut::<T>()
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .get_mut::<T>()
     }
 
     /// Consumes the builder, returning the finished [`Cx`].
@@ -169,12 +226,14 @@ impl CxTestBuilder {
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn memoize_cache(cx: &Cx) -> &MemoizeCache {
     &cx.memoize_cache
 }
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn abort_store(cx: &Cx) -> &AbortStore {
     &cx.abort_store
 }

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -66,6 +66,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn app_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,
@@ -131,6 +132,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn request_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -78,6 +78,7 @@ impl PageFn {
     }
 
     /// Renders the page, returning a [`Result`].
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,
@@ -124,6 +125,7 @@ impl LayoutFn {
     }
 
     /// Renders the layout, embedding the given child content [`Result`]`<`[`View`]`>` as its slot.
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,

--- a/crates/topcoat-shell-view/Cargo.toml
+++ b/crates/topcoat-shell-view/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "topcoat-shell-view"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+topcoat-core.workspace = true
+topcoat-router.workspace = true
+topcoat-view = { workspace = true, features = ["http"] }
+
+bytes.workspace = true
+futures-util.workspace = true
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/topcoat-shell-view/src/lib.rs
+++ b/crates/topcoat-shell-view/src/lib.rs
@@ -1,0 +1,279 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use bytes::Bytes;
+use futures_util::{
+    StreamExt as _,
+    stream::{self, FuturesUnordered},
+};
+use http::{HeaderValue, header::CONTENT_TYPE};
+use http_body::Frame;
+use http_body_util::StreamBody;
+use topcoat_core::{
+    context::{Cx, CxHandle},
+    error::Result,
+};
+use topcoat_router::{
+    Body,
+    response::{IntoResponse, Response},
+};
+use topcoat_view::{HtmlContext, PartsWriter, View, ViewParts};
+
+type DeferredFuture = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'static>>;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+const HTML: HeaderValue = HeaderValue::from_static("text/html; charset=utf-8");
+
+/// Builds a streaming [`ShellView`] from a normal view shell and deferred views.
+pub struct ShellViewBuilder {
+    cx: CxHandle,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellViewBuilder {
+    /// Defers a view and returns its placeholder for insertion into the shell.
+    ///
+    /// `render` receives an owned request context handle. Its future starts
+    /// when the response body is polled, and all deferred futures are polled
+    /// concurrently. Completed views replace their placeholders immediately.
+    pub fn defer<F, Fut>(&mut self, placeholder: View, render: F) -> View
+    where
+        F: FnOnce(CxHandle) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<View>> + Send + 'static,
+    {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let cx = self.cx.clone();
+        self.deferred.push(Box::pin(async move {
+            let view = render(cx.clone()).await?;
+            Ok(Bytes::from(patch(id, &view.render(&cx))))
+        }));
+        placeholder_view(id, placeholder)
+    }
+
+    /// Inserts a child shell view and adopts its deferred work.
+    ///
+    /// Put the returned shell view into the parent shell. Deferred fragments
+    /// from both views then share the same response stream.
+    #[must_use]
+    pub fn include(&mut self, child: ShellView) -> View {
+        self.deferred.extend(child.deferred);
+        child.shell
+    }
+
+    /// Finishes the builder with the view sent as the first response chunk.
+    #[must_use]
+    pub fn finish(self, shell: View) -> ShellView {
+        ShellView {
+            shell,
+            deferred: self.deferred,
+        }
+    }
+}
+
+/// An HTML response that streams deferred views into placeholders.
+pub struct ShellView {
+    shell: View,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellView {
+    /// Starts a shell view builder for `cx`.
+    #[must_use]
+    pub fn builder(cx: &Cx) -> ShellViewBuilder {
+        ShellViewBuilder {
+            cx: cx.handle(),
+            deferred: Vec::new(),
+        }
+    }
+
+    /// Creates a shell view with no deferred fragments.
+    #[must_use]
+    pub fn from_view(view: View) -> Self {
+        Self {
+            shell: view,
+            deferred: Vec::new(),
+        }
+    }
+}
+
+impl IntoResponse for ShellView {
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        let rendered = self.shell.render_response(cx);
+        let initial = stream::once(async move {
+            Ok::<_, topcoat_core::error::Error>(Frame::data(Bytes::from(rendered.html)))
+        });
+        let deferred = self
+            .deferred
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .map(|result| result.map(Frame::data));
+        let body = Body::new(StreamBody::new(initial.chain(deferred)));
+        let mut response = Response::new(body);
+        *response.status_mut() = rendered.status_code.unwrap_or_default();
+        response.headers_mut().insert(CONTENT_TYPE, HTML);
+        response.headers_mut().extend(rendered.headers);
+        Ok(response)
+    }
+}
+
+fn placeholder_view(id: u64, placeholder: View) -> View {
+    let mut parts = ViewParts::new();
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped(format!(
+        r#"<topcoat-shell id="topcoat-shell-{id}" style="display: contents">"#,
+    ));
+    parts.push_view(placeholder);
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped("</topcoat-shell>");
+    View::new(parts)
+}
+
+fn patch(id: u64, html: &str) -> String {
+    let html = serde_json::to_string(html)
+        .expect("serializing a string cannot fail")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026");
+    format!(
+        r#"<script>(()=>{{const p=document.getElementById("topcoat-shell-{id}");if(!p)return;const t=document.createElement("template");t.innerHTML={html};p.replaceWith(t.content)}})()</script>"#,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use futures_util::StreamExt as _;
+    use topcoat::{
+        context::{Cx, request_context},
+        router::{response::IntoResponse as _, to_bytes},
+        shell_view::ShellView,
+        view::view,
+    };
+
+    #[tokio::test]
+    async fn streams_shell_then_fragments_in_completion_order() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let mut page = ShellView::builder(&cx);
+
+        let slow_completed = Arc::clone(&completed);
+        let slow = page.defer(
+            view! { cx_ref => <p>"slow placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                slow_completed.lock().unwrap().push("slow");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"slow result"</p> }
+            },
+        );
+        let fast_completed = Arc::clone(&completed);
+        let fast = page.defer(
+            view! { cx_ref => <p>"fast placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                fast_completed.lock().unwrap().push("fast");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"fast result"</p> }
+            },
+        );
+        let response = page
+            .finish(
+                view! {
+                    cx_ref =>
+                    <main>
+                        (slow)
+                        (fast)
+                    </main>
+                }
+                .unwrap(),
+            )
+            .into_response(&cx)
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+
+        let shell = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(shell.contains("slow placeholder"));
+        assert!(shell.contains("fast placeholder"));
+
+        let first_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(first_patch.contains("fast result"));
+        let second_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(second_patch.contains("slow result"));
+        assert_eq!(*completed.lock().unwrap(), ["fast", "slow"]);
+    }
+
+    #[tokio::test]
+    async fn deferred_view_keeps_request_context_alive() {
+        struct Name(&'static str);
+
+        let cx = topcoat::context::CxTestBuilder::new()
+            .request_context(Name("Ada"))
+            .build();
+        let cx_ref = &cx;
+        let mut page = ShellView::builder(&cx);
+        let greeting = page.defer(view! { cx_ref => "Loading" }.unwrap(), |cx| async move {
+            let name = request_context::<Name>(&cx).0;
+            let cx_ref = cx.as_ref();
+            view! {
+                cx_ref =>
+                <p>
+                    "Hello, "
+                    (name)
+                </p>
+            }
+        });
+        let response = page
+            .finish(view! { cx_ref => (greeting) }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Hello, "));
+        assert!(html.contains("Ada"));
+    }
+
+    #[tokio::test]
+    async fn includes_child_shell_views() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let mut child = ShellView::builder(&cx);
+        let child_slot = child.defer(
+            view! { cx_ref => "Child loading" }.unwrap(),
+            |cx| async move {
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"Child ready"</p> }
+            },
+        );
+        let child = child.finish(view! { cx_ref => <aside>(child_slot)</aside> }.unwrap());
+
+        let mut parent = ShellView::builder(&cx);
+        let child = parent.include(child);
+        let response = parent
+            .finish(view! { cx_ref => <main>(child)</main> }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(html.contains("<aside>"));
+        assert!(html.contains("Child loading"));
+        assert!(html.contains("Child ready"));
+    }
+
+    #[test]
+    fn patch_html_cannot_close_its_script() {
+        let patch = super::patch(7, "</script><script>alert('xss')</script>");
+
+        assert!(!patch.contains("</script><script>"));
+        assert!(patch.contains(r"\u003c/script\u003e"));
+    }
+}

--- a/crates/topcoat-view/Cargo.toml
+++ b/crates/topcoat-view/Cargo.toml
@@ -18,6 +18,7 @@ http = [
 [dependencies]
 topcoat-core.workspace = true
 
+futures-util.workspace = true
 http = { workspace = true, optional = true }
 itoa.workspace = true
 memchr.workspace = true
@@ -27,6 +28,7 @@ smallvec.workspace = true
 topcoat = { workspace = true, features = ["view"] }
 
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[bench]]
 name = "render"

--- a/crates/topcoat-view/examples/concurrent_components.rs
+++ b/crates/topcoat-view/examples/concurrent_components.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+#[component]
+async fn card(label: &'static str, delay: Duration) -> Result {
+    println!("starting {label}");
+    tokio::time::sleep(delay).await;
+    println!("finished {label}");
+
+    view! { <article>(label)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            card(label: "first", delay: Duration::from_secs(1))
+            <section>
+                card(label: "second", delay: Duration::from_secs(1))
+            </section>
+        </main>
+    }?;
+
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/examples/concurrent_for.rs
+++ b/crates/topcoat-view/examples/concurrent_for.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+struct Post {
+    title: &'static str,
+    delay: Duration,
+}
+
+#[component]
+async fn post_card(post: Post) -> Result {
+    tokio::time::sleep(post.delay).await;
+    println!("finished {}", post.title);
+
+    view! { <article>(post.title)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let posts = vec![
+        Post {
+            title: "first",
+            delay: Duration::from_millis(100),
+        },
+        Post {
+            title: "second",
+            delay: Duration::from_millis(50),
+        },
+    ];
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            for concurrent post in posts {
+                post_card(post: post)
+            }
+        </main>
+    }?;
+
+    // "second" finishes first, but the generated HTML keeps iterator order.
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/grammar/src/template/template_for_loop.rs
+++ b/crates/topcoat-view/grammar/src/template/template_for_loop.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
     Expr, ExprBreak, ExprContinue, Pat, Token,
     parse::{Parse, ParseStream},
@@ -11,10 +11,23 @@ use crate::{
     view::{ViewWriter, WriteView},
 };
 
+mod kw {
+    syn::custom_keyword!(concurrent);
+}
+
+pub use kw::concurrent as ConcurrentToken;
+
+impl ParseOption for ConcurrentToken {
+    fn peek(input: ParseStream) -> bool {
+        input.peek(kw::concurrent)
+    }
+}
+
 /// A `for pat in expr { ... }` loop in view-body position. The body is
 /// rendered once per iteration.
 pub struct TemplateForLoop<T> {
     pub for_token: Token![for],
+    pub concurrent_token: Option<ConcurrentToken>,
     pub pat: Box<Pat>,
     pub in_token: Token![in],
     pub expr: Box<Expr>,
@@ -23,14 +36,26 @@ pub struct TemplateForLoop<T> {
 
 impl<T: WriteView> WriteView for TemplateForLoop<T> {
     fn write(&self, writer: &mut ViewWriter) {
-        writer.for_loop(&self.pat, &self.expr, |writer| {
-            self.body.write(writer);
-        });
+        if self.concurrent_token.is_some() {
+            writer.concurrent_for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        } else {
+            writer.for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        }
     }
 }
 
 impl<T: WriteAttribute> WriteAttribute for TemplateForLoop<T> {
     fn write(&self, writer: &mut AttributeWriter) {
+        if let Some(concurrent_token) = &self.concurrent_token {
+            writer.statement(quote_spanned! {concurrent_token.span=>
+                compile_error!("`for concurrent` is only supported in view-body position");
+            });
+            return;
+        }
         writer.for_loop(&self.pat, &self.expr, |writer| {
             self.body.write(writer);
         });
@@ -41,6 +66,7 @@ impl<T: Parse> Parse for TemplateForLoop<T> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(Self {
             for_token: input.parse()?,
+            concurrent_token: input.call(ConcurrentToken::parse_option)?,
             pat: Box::new(input.call(Pat::parse_single)?),
             in_token: input.parse()?,
             expr: Box::new(input.call(Expr::parse_without_eager_brace)?),
@@ -63,6 +89,10 @@ impl<T: topcoat_core_grammar::pretty::PrettyPrint> topcoat_core_grammar::pretty:
     fn pretty_print(&self, printer: &mut topcoat_core_grammar::pretty::Printer<'_>) {
         self.for_token.pretty_print(printer);
         " ".pretty_print(printer);
+        if self.concurrent_token.is_some() {
+            "concurrent".pretty_print(printer);
+            " ".pretty_print(printer);
+        }
         self.pat.pretty_print(printer);
         " ".pretty_print(printer);
         self.in_token.pretty_print(printer);
@@ -185,9 +215,18 @@ mod tests {
     #[test]
     fn parses_simple_for_loop() {
         let loop_ = parse(r"for x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_none());
         assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
         assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
         assert_eq!(loop_.body.children.len(), 1);
+    }
+
+    #[test]
+    fn parses_concurrent_for_loop() {
+        let loop_ = parse(r"for concurrent x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_some());
+        assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
+        assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/component.rs
+++ b/crates/topcoat-view/grammar/src/view/component.rs
@@ -12,7 +12,7 @@ use topcoat_core_grammar::{ParseOption, paths::topcoat_view};
 
 use crate::{
     template::RuntimeExpr,
-    view::{ExprKind, Nodes, ViewWriter, WriteView},
+    view::{Nodes, ViewWriter, WriteView},
 };
 
 /// A component invocation, written as `path(name: value, ..., child_node child_node ...)`.
@@ -90,23 +90,20 @@ impl WriteView for Component {
             }
         });
 
-        writer.write_expr(
-            ExprKind::View,
-            quote_spanned! {self.paren_token.span.span()=>
-                {
-                    use #topcoat_view::Component;
-                    let props = #name::props_builder()#(#setters)*#child.build();
-                    // The marker is built via `Default` so the same construction
-                    // works for both unit-struct and generic (`PhantomData`) markers.
-                    #[allow(clippy::default_constructed_unit_structs)]
-                    Component::render(
-                        #name::default(),
-                        __cx,
-                        props,
-                    ).await?
-                }
-            },
-        );
+        writer.write_component(quote_spanned! {self.paren_token.span.span()=>
+            {
+                use #topcoat_view::Component;
+                let props = #name::props_builder()#(#setters)*#child.build();
+                // The marker is built via `Default` so the same construction
+                // works for both unit-struct and generic (`PhantomData`) markers.
+                #[allow(clippy::default_constructed_unit_structs)]
+                Component::render(
+                    #name::default(),
+                    __cx,
+                    props,
+                )
+            }
+        });
     }
 }
 

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{Expr, Ident, Pat};
 use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 
@@ -70,6 +70,11 @@ impl ViewWriter {
         self.chunks.push(Chunk::Expr { kind, tokens });
     }
 
+    pub fn write_component(&mut self, tokens: TokenStream) {
+        self.flush();
+        self.chunks.push(Chunk::Component { tokens });
+    }
+
     pub fn local_binding(&mut self, pat: &Pat, expr: &Expr) {
         self.flush();
         self.chunks.push(Chunk::Local {
@@ -133,8 +138,67 @@ impl ViewWriter {
             } else {
                 fn build_parts(chunks: &[Chunk]) -> TokenStream {
                     let mut output = TokenStream::new();
-                    for chunk in chunks {
-                        match chunk {
+                    let mut index = 0;
+                    while index < chunks.len() {
+                        // Static markup cannot introduce a dependency between component calls.
+                        if matches!(
+                            &chunks[index],
+                            Chunk::Static { .. } | Chunk::Component { .. }
+                        ) {
+                            let start = index;
+                            while index < chunks.len()
+                                && matches!(
+                                    &chunks[index],
+                                    Chunk::Static { .. } | Chunk::Component { .. }
+                                )
+                            {
+                                index += 1;
+                            }
+                            let region = &chunks[start..index];
+                            let components = region
+                                .iter()
+                                .filter_map(|chunk| match chunk {
+                                    Chunk::Component { tokens } => Some(tokens),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>();
+                            let results = (0..components.len())
+                                .map(|index| format_ident!("__component_result_{index}"))
+                                .collect::<Vec<_>>();
+                            // Avoid joining when there is only one component to await.
+                            let wait = match components.as_slice() {
+                                [] => TokenStream::new(),
+                                [component] => {
+                                    let result = &results[0];
+                                    quote! { let #result = #component.await; }
+                                }
+                                _ => quote! {
+                                    let (#(#results,)*) = __join!(#(#components),*);
+                                },
+                            };
+                            let mut result_index = 0;
+                            let region_parts = region.iter().map(|chunk| match chunk {
+                                Chunk::Static { string } => {
+                                    let helper = ExprKind::Unescaped.helper();
+                                    quote! { #helper(__cx, &mut __parts, #string); }
+                                }
+                                Chunk::Component { .. } => {
+                                    let result = &results[result_index];
+                                    result_index += 1;
+                                    let helper = ExprKind::View.helper();
+                                    quote! { #helper(__cx, &mut __parts, #result?); }
+                                }
+                                _ => unreachable!(),
+                            });
+                            quote! {{
+                                #wait
+                                #(#region_parts)*
+                            }}
+                            .to_tokens(&mut output);
+                            continue;
+                        }
+
+                        match &chunks[index] {
                             Chunk::Static { string } => {
                                 let helper = ExprKind::Unescaped.helper();
                                 let tokens = quote! { #string };
@@ -144,6 +208,7 @@ impl ViewWriter {
                                 let helper = kind.helper();
                                 quote! { #helper(__cx, &mut __parts, #tokens); }
                             }
+                            Chunk::Component { .. } => unreachable!(),
                             Chunk::Local { pat, expr } => {
                                 quote! { let #pat = #expr; }
                             }
@@ -191,6 +256,7 @@ impl ViewWriter {
                             }
                         }
                         .to_tokens(&mut output);
+                        index += 1;
                     }
                     output
                 }
@@ -253,6 +319,9 @@ enum Chunk {
     },
     Expr {
         kind: ExprKind,
+        tokens: TokenStream,
+    },
+    Component {
         tokens: TokenStream,
     },
     Local {
@@ -362,6 +431,19 @@ mod tests {
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"<p>\")"));
         assert!(out.contains("__node (__cx , & mut __parts , value)"));
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"</p>\")"));
+    }
+
+    #[test]
+    fn static_markup_does_not_split_component_join() {
+        let mut writer = ViewWriter::new();
+        writer.write_str_unescaped("<main>");
+        writer.write_component(quote! { first() });
+        writer.write_str_unescaped("<aside>");
+        writer.write_component(quote! { second() });
+        writer.write_str_unescaped("</aside></main>");
+        let out = rendered(writer);
+
+        assert!(out.contains("__join ! (first () , second ())"));
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -100,6 +100,18 @@ impl ViewWriter {
         });
     }
 
+    pub fn concurrent_for_loop(&mut self, pat: &Pat, expr: &Expr, f: impl FnOnce(&mut ViewWriter)) {
+        self.flush();
+        let mut body = ViewWriter::new();
+        f(&mut body);
+        body.flush();
+        self.chunks.push(Chunk::ConcurrentFor {
+            pat: pat.clone(),
+            expr: Box::new(expr.clone()),
+            body: Box::new(body),
+        });
+    }
+
     pub fn if_else(&mut self, expr: &Expr, f: impl FnOnce(&mut ViewWriter, &mut ViewWriter)) {
         self.flush();
         let mut then_branch = ViewWriter::new();
@@ -239,6 +251,27 @@ impl ViewWriter {
                                     }
                                 }
                             }
+                            Chunk::ConcurrentFor { pat, expr, body } => {
+                                let body = build_parts(&body.chunks);
+                                quote! {
+                                    {
+                                        let __render_iteration = async |#pat| {
+                                            let mut __parts = #topcoat_view::ViewParts::new();
+                                            #body
+                                            ::core::result::Result::<
+                                                #topcoat_view::View,
+                                                #topcoat_error::Error,
+                                            >::Ok(#topcoat_view::View::new(__parts))
+                                        };
+                                        let __iterations = (#expr)
+                                            .into_iter()
+                                            .map(__render_iteration);
+                                        for __iteration in __join_all(__iterations).await {
+                                            __view(__cx, &mut __parts, __iteration?);
+                                        }
+                                    }
+                                }
+                            }
                             Chunk::Match { expr, arms } => {
                                 let arm_tokens = arms.iter().map(|arm| {
                                     let pat = &arm.pat;
@@ -332,6 +365,11 @@ enum Chunk {
         tokens: TokenStream,
     },
     For {
+        pat: Pat,
+        expr: Box<Expr>,
+        body: Box<ViewWriter>,
+    },
+    ConcurrentFor {
         pat: Pat,
         expr: Box<Expr>,
         body: Box<ViewWriter>,
@@ -479,6 +517,18 @@ mod tests {
         });
         let out = rendered(writer);
         assert!(out.contains("for x in xs"));
+    }
+
+    #[test]
+    fn concurrent_for_loop_joins_iteration_futures() {
+        let mut writer = ViewWriter::new();
+        writer.concurrent_for_loop(&syn::parse_quote!(x), &syn::parse_quote!(xs), |body| {
+            body.write_expr(ExprKind::Node, quote! { x });
+        });
+        let out = rendered(writer);
+
+        assert!(out.contains("let __render_iteration = async | x |"));
+        assert!(out.contains("__join_all (__iterations) . await"));
     }
 
     #[test]

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -187,6 +187,26 @@ view! {
 # }
 ```
 
+Use `for concurrent` when iterations perform independent async component work:
+
+```rust
+# use topcoat::{Result, view::*};
+# struct Post { title: &'static str }
+# #[component]
+# async fn post_card(post: Post) -> Result { view! { <article>(post.title)</article> } }
+# #[component]
+# async fn example() -> Result {
+# let posts = vec![Post { title: "A" }, Post { title: "B" }];
+view! {
+    for concurrent post in posts {
+        post_card(post: post)
+    }
+}
+# }
+```
+
+The iterations render concurrently, but their completed views are inserted in iterator order. Use this form only when iterations are independent. An ordinary `for` remains sequential and can mutate or mutably borrow shared state. `for concurrent` is available in view-body position, not in an element's attribute list.
+
 ## `match`
 
 Use `match` to choose markup from patterns. Match arms can also use guards.

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -345,6 +345,10 @@ view! {
 
 See how to define components in the [`component`] macro guide.
 
+Component calls in the same straight-line view body render concurrently. Static HTML between the calls does not split the group, and the completed views are inserted in source order. A Rust expression, local binding, statement, or control-flow construct ends the group because later component props may depend on it.
+
+Each control-flow body forms its own group. An ordinary `for` loop still renders its iterations in order, but peer components within one iteration can render concurrently.
+
 # Boolean And Conditional Attributes
 
 [Boolean HTML attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) such as `disabled`, `required`, and `checked` are true when the attribute is present and false when it is absent. HTML expects a present boolean attribute to have an empty value.

--- a/crates/topcoat-view/macro/tests/component.rs
+++ b/crates/topcoat-view/macro/tests/component.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use topcoat::{
     Result,
     context::Cx,
@@ -93,6 +95,68 @@ async fn component_can_call_other_components_and_forward_child_views() {
 
     assert!(html.contains("<h2>Outer</h2>"));
     assert!(html.contains("<em>inner</em>"));
+}
+
+#[component]
+async fn concurrent_peer(log: Arc<Mutex<Vec<String>>>, label: &'static str) -> Result {
+    log.lock().unwrap().push(format!("enter {label}"));
+    tokio::task::yield_now().await;
+    log.lock().unwrap().push(format!("exit {label}"));
+
+    view! { <span>(label)</span> }
+}
+
+#[tokio::test]
+async fn peer_components_render_concurrently_across_static_markup() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            <aside>concurrent_peer(log: Arc::clone(&log), label: "b")</aside>
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        ["enter a", "enter b", "exit a", "exit b"],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><aside><span>b</span></aside></main>",
+    );
+}
+
+#[tokio::test]
+async fn control_flow_and_loops_split_concurrent_component_groups() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            if true {
+                <section>concurrent_peer(log: Arc::clone(&log), label: "b")</section>
+            }
+            for label in ["c", "d"] {
+                concurrent_peer(log: Arc::clone(&log), label: label)
+            }
+            concurrent_peer(log: Arc::clone(&log), label: "e")
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        [
+            "enter a", "exit a", "enter b", "exit b", "enter c", "exit c", "enter d", "exit d",
+            "enter e", "exit e",
+        ],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><section><span>b</span></section><span>c</span><span>d</span><span>e</span></main>",
+    );
 }
 
 #[component]

--- a/crates/topcoat-view/macro/tests/control_flow.rs
+++ b/crates/topcoat-view/macro/tests/control_flow.rs
@@ -1,4 +1,17 @@
-use topcoat::{context::Cx, view::view};
+use std::{
+    future::poll_fn,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::Poll,
+};
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
 
 fn r(v: topcoat::Result) -> String {
     v.unwrap().render(&Cx::default())
@@ -101,6 +114,50 @@ async fn for_loop_renders_body_per_item() {
         <ul>
             for title in posts {
                 <li>(title)</li>
+            }
+        </ul>
+    });
+
+    assert_eq!(html, "<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>");
+}
+
+#[component]
+async fn concurrent_loop_item(
+    started: Arc<AtomicUsize>,
+    expected: usize,
+    label: &'static str,
+) -> Result {
+    let mut first_poll = true;
+    poll_fn(|cx| {
+        if first_poll {
+            first_poll = false;
+            started.fetch_add(1, Ordering::SeqCst);
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        } else {
+            assert_eq!(started.load(Ordering::SeqCst), expected);
+            Poll::Ready(())
+        }
+    })
+    .await;
+
+    view! { <li>(label)</li> }
+}
+
+#[tokio::test]
+async fn concurrent_for_loop_polls_iterations_together_and_preserves_order() {
+    let labels = ["alpha", "beta", "gamma"];
+    let started = Arc::new(AtomicUsize::new(0));
+    let cx = &Cx::default();
+    let html = r(view! {
+        cx =>
+        <ul>
+            for concurrent label in labels {
+                concurrent_loop_item(
+                    started: Arc::clone(&started),
+                    expected: labels.len(),
+                    label: label
+                )
             }
         </ul>
     });

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,8 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    use core::future::Future;
+
     pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
@@ -44,6 +46,15 @@ pub mod internal {
     #[inline]
     pub fn __view(_cx: &Cx, parts: &mut ViewParts, view: View) {
         parts.push_view(view);
+    }
+
+    #[inline]
+    pub async fn __join_all<I>(futures: I) -> Vec<<I::Item as Future>::Output>
+    where
+        I: IntoIterator,
+        I::Item: Future,
+    {
+        futures_util::future::join_all(futures).await
     }
 
     #[inline]

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,7 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
     use crate::{

--- a/crates/topcoat-view/src/view.rs
+++ b/crates/topcoat-view/src/view.rs
@@ -68,6 +68,7 @@ impl View {
     /// Panics if a dynamic attribute key or element name in the view contains
     /// a character that could break out of the identifier.
     #[track_caller]
+    #[must_use]
     pub fn render(&self, cx: &Cx) -> String {
         let mut buf = String::with_capacity(self.part.size_hint());
         let mut f = Formatter::new(&mut buf);

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -40,6 +40,7 @@ full = [
 	"mail",
 	"mail-smtp",
 	"multipart",
+	"shell-view",
 	"router",
 	"runtime",
 	"serve",
@@ -115,6 +116,10 @@ multipart = [
 	"router",
 	"topcoat-router/multipart",
 ]
+shell-view = [
+	"dep:topcoat-shell-view",
+	"router",
+]
 router = [
 	"dep:topcoat-router",
 	"dep:topcoat-router-macro",
@@ -180,6 +185,7 @@ topcoat-icon = { workspace = true, optional = true }
 topcoat-icon-macro = { workspace = true, optional = true }
 topcoat-mail = { workspace = true, optional = true }
 topcoat-mail-macro = { workspace = true, optional = true }
+topcoat-shell-view = { workspace = true, optional = true }
 topcoat-router = { workspace = true, optional = true }
 topcoat-router-macro = { workspace = true, optional = true }
 topcoat-runtime = { workspace = true, optional = true }

--- a/crates/topcoat/docs/shell_view.md
+++ b/crates/topcoat/docs/shell_view.md
@@ -1,0 +1,85 @@
+`ShellView` streams a page shell first, then replaces placeholders as deferred views finish. It is useful when a page has a fast container and slower independent sections. Return it from a [`route`](crate::router::route) container; pages, layouts, and components continue to return ordinary views and can be rendered inside that container.
+
+Enable the `shell-view` feature, then build the response around ordinary [`View`](crate::view::View) values:
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    shell_view::ShellView,
+    router::route,
+    view::view,
+};
+
+# async fn load_activity() -> Result<&'static str> { Ok("Signed in") }
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading activity..."</p> }?,
+        |cx| async move {
+            let message = load_activity().await?;
+            let cx = cx.as_ref();
+            view! { cx => <p>(message)</p> }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <h1>"Dashboard"</h1>
+                (activity)
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+```
+
+[`defer`](ShellViewBuilder::defer) returns a normal `View` containing the placeholder. Insert it anywhere a view expression is accepted. The render closure receives an owned [`CxHandle`](crate::context::CxHandle), so request context stays available after the handler returns. Bind `handle.as_ref()` to an identifier when using the explicit `cx =>` form of `view!` inside the closure.
+
+The shell is the first response chunk. Deferred futures start when the response body is polled, run concurrently, and emit replacement scripts in completion order. A slow fragment does not delay a faster one.
+
+# Components
+
+A deferred closure can render components through a nested `view!` call:
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::{component, view}};
+# #[component]
+# async fn recommendations() -> Result { view! { <p>"Recommendations"</p> } }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let mut page = ShellView::builder(cx);
+let recommendations_slot = page.defer(
+    view! { <p>"Finding recommendations..."</p> }?,
+    |cx| async move {
+        let cx = cx.as_ref();
+        view! { cx => recommendations() }
+    },
+);
+
+let shell = view! { cx => <section>(recommendations_slot)</section> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Composition
+
+Shell views compose at their container boundary. Pass a child to [`include`](ShellViewBuilder::include), insert the returned shell into the parent, then finish the parent. The parent adopts the child's deferred work, so all fragments use one response stream.
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::view};
+# async fn sidebar(cx: &Cx) -> Result<ShellView> { Ok(ShellView::from_view(view! { cx => <aside></aside> }?)) }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let child = sidebar(cx).await?;
+let mut page = ShellView::builder(cx);
+let child = page.include(child);
+let shell = view! { cx => <main>(child)</main> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Response behavior
+
+Status codes and headers declared by the shell are applied before streaming begins. Declarations in deferred views cannot change headers that were already sent. Each completed fragment is delivered by a small inline script, so the page's Content Security Policy must allow those scripts.

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -42,6 +42,9 @@ pub mod icon;
 #[cfg(feature = "mail")]
 pub mod mail;
 
+#[cfg(feature = "shell-view")]
+pub mod shell_view;
+
 #[cfg(feature = "router")]
 pub mod router;
 

--- a/crates/topcoat/src/shell_view.rs
+++ b/crates/topcoat/src/shell_view.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../docs/shell_view.md")]
+
+pub use topcoat_shell_view::*;

--- a/examples/shell-view/Cargo.toml
+++ b/examples/shell-view/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "shell-view"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/examples/shell-view/README.md
+++ b/examples/shell-view/README.md
@@ -1,0 +1,13 @@
+# Shell view
+
+This example streams a dashboard shell with two placeholders, then replaces each placeholder when its component finishes.
+
+## Run the example
+
+From the repository root, run:
+
+```sh
+cargo run --manifest-path examples/shell-view/Cargo.toml
+```
+
+Open `http://127.0.0.1:3000/`. The shell appears first, recent activity appears after one second, and recommendations appear after two seconds.

--- a/examples/shell-view/src/main.rs
+++ b/examples/shell-view/src/main.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{Router, RouterBuilderDiscoverExt, route},
+    shell_view::ShellView,
+    view::{component, view},
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(Router::builder().discover().build())
+        .await
+        .unwrap();
+}
+
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading recent activity..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recent_activity() }
+        },
+    );
+    let recommendations_slot = page.defer(
+        view! { <p aria-busy="true">"Loading recommendations..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recommendations() }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>"Shell view"</title>
+                topcoat::dev::script()
+            </head>
+            <body>
+                <h1>"Dashboard"</h1>
+                <section>
+                    <h2>"Recent activity"</h2>
+                    (activity)
+                </section>
+                <section>
+                    <h2>"Recommendations"</h2>
+                    (recommendations_slot)
+                </section>
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+
+#[component]
+async fn recent_activity() -> Result {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    view! { <p>"You published a new post."</p> }
+}
+
+#[component]
+async fn recommendations() -> Result {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    view! { <p>"Follow the Topcoat release feed."</p> }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -49,6 +49,7 @@ changelog_include = [
     "topcoat-mail",
     "topcoat-mail-grammar",
     "topcoat-mail-macro",
+    "topcoat-shell-view",
     "topcoat-router",
     "topcoat-router-grammar",
     "topcoat-router-macro",
@@ -151,6 +152,11 @@ version_group = "topcoat"
 
 [[package]]
 name = "topcoat-mail-macro"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-shell-view"
 release = true
 version_group = "topcoat"
 


### PR DESCRIPTION
## Summary

- Add the optional `topcoat-shell-view` crate and facade feature for streaming a container shell before deferred component results.
- Replace placeholders as deferred views complete while keeping request context alive and supporting nested shell views.
- Add user documentation, runtime tests, and a runnable shell-view example.

This draft follows #285. Until the preceding drafts land, GitHub also shows their prerequisite commits in this PR.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI disclosure

OpenAI Codex (GPT-5) helped implement, test, and prepare this change for review.