### PR TITLE
feat(vercel): add Build Output API deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Topcoat is a Cargo workspace. The framework crates live in `crates/`, runnable e
 - `topcoat-htmx`, `topcoat-alpine-ajax`, and `topcoat-datastar`: request and response helpers for those client libraries.
 - `topcoat-tailwind`: the build-script wrapper around the standalone Tailwind CLI.
 - `topcoat-ui` (+ `registry/`): the component registry behind `topcoat ui`, which copies component source into a project.
+- `topcoat-vercel`: the Vercel runtime adapter and the `topcoat-vercel` CLI, which emits Build Output API deployments.
 - `topcoat-cli`: the `topcoat` binary. Each subcommand has its own module under `src/`.
 
 A crate that backs proc-macros comes as a trio. The base crate holds the runtime types the generated code calls into. Its `grammar/` crate parses the macro body and generates the code, and is only used at compile time. Its `macro/` crate is a thin proc-macro entry point over `grammar/`. Where a macro body is formattable, the `grammar/` crate's `pretty` feature adds the pretty-printer `topcoat fmt` uses.
@@ -89,6 +90,10 @@ Each crate's `docs/` directory holds the user-facing guides for that crate, embe
 - [`crates/topcoat/docs/htmx.md`](crates/topcoat/docs/htmx.md): htmx: reading its request headers and setting its response headers from a handler.
 - [`crates/topcoat/docs/alpine-ajax.md`](crates/topcoat/docs/alpine-ajax.md): Alpine AJAX: reading its request headers to render partial responses.
 - [`crates/topcoat/docs/datastar.md`](crates/topcoat/docs/datastar.md): Datastar: reading the signals sent with a request and patching elements and signals over server-sent events.
+
+### Deployment
+
+- [`crates/topcoat/docs/vercel.md`](crates/topcoat/docs/vercel.md): Running a Topcoat application on Vercel and generating a Build Output API deployment with `topcoat-vercel`.
 
 ### Tooling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Topcoat is a Cargo workspace. The framework crates live in `crates/`, runnable e
 - `topcoat-cookie`: the cookie jar, `cookie!` macro, signed/private jars, and `CookieStore<T>`.
 - `topcoat-session`: bring-your-own-storage session authentication: the token/hash model, the session lifecycle, and origin checking.
 - `topcoat-mail`: the `Mail` type and `mail!` macro for declaring mail, and its delivery through pluggable transports (SMTP, file, in-memory).
+- `topcoat-shell-view`: streaming HTML containers that replace placeholders as deferred views finish.
 - `topcoat-htmx`, `topcoat-alpine-ajax`, and `topcoat-datastar`: request and response helpers for those client libraries.
 - `topcoat-tailwind`: the build-script wrapper around the standalone Tailwind CLI.
 - `topcoat-ui` (+ `registry/`): the component registry behind `topcoat ui`, which copies component source into a project.
@@ -50,6 +51,7 @@ Each crate's `docs/` directory holds the user-facing guides for that crate, embe
 - [`crates/topcoat-view/macro/docs/attributes.md`](crates/topcoat-view/macro/docs/attributes.md): The `attributes!` macro and the runtime `Attributes` value for building/forwarding attribute collections.
 - [`crates/topcoat-view/macro/docs/class.md`](crates/topcoat-view/macro/docs/class.md): The `class!` macro: assembling a space-separated class list from static and conditional entries.
 - [`crates/topcoat-view/macro/docs/props.md`](crates/topcoat-view/macro/docs/props.md): The `props!` macro for building a component's props value.
+- [`crates/topcoat/docs/shell_view.md`](crates/topcoat/docs/shell_view.md): `ShellView` streaming responses, deferred placeholders, components, and composition.
 
 ### UI components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Topcoat is a Cargo workspace. The framework crates live in `crates/`, runnable e
 - `topcoat-cookie`: the cookie jar, `cookie!` macro, signed/private jars, and `CookieStore<T>`.
 - `topcoat-session`: bring-your-own-storage session authentication: the token/hash model, the session lifecycle, and origin checking.
 - `topcoat-mail`: the `Mail` type and `mail!` macro for declaring mail, and its delivery through pluggable transports (SMTP, file, in-memory).
-- `topcoat-shell-view`: streaming HTML containers that replace placeholders as deferred views finish.
+- `topcoat-shell-view`: streaming HTML containers, the `shell_view!` macro, and placeholders replaced as deferred views finish.
 - `topcoat-htmx`, `topcoat-alpine-ajax`, and `topcoat-datastar`: request and response helpers for those client libraries.
 - `topcoat-tailwind`: the build-script wrapper around the standalone Tailwind CLI.
 - `topcoat-ui` (+ `registry/`): the component registry behind `topcoat ui`, which copies component source into a project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,6 +2307,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-view"
+version = "0.5.0"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2795,7 @@ dependencies = [
  "topcoat-runtime",
  "topcoat-runtime-macro",
  "topcoat-session",
+ "topcoat-shell-view",
  "topcoat-tailwind",
  "topcoat-ui-registry",
  "topcoat-view",
@@ -3157,6 +3166,23 @@ dependencies = [
  "topcoat-core",
  "topcoat-router",
  "web-time",
+]
+
+[[package]]
+name = "topcoat-shell-view"
+version = "0.5.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "serde_json",
+ "tokio",
+ "topcoat",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,10 +3194,12 @@ name = "topcoat-view"
 version = "0.5.0"
 dependencies = [
  "criterion",
+ "futures-util",
  "http",
  "itoa",
  "memchr",
  "smallvec",
+ "tokio",
  "topcoat",
  "topcoat-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1198,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1190,12 +1207,24 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1401,6 +1430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1485,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2451,6 +2492,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tailwind"
 version = "0.5.0"
 dependencies = [
@@ -2798,6 +2860,7 @@ dependencies = [
  "topcoat-shell-view",
  "topcoat-tailwind",
  "topcoat-ui-registry",
+ "topcoat-vercel",
  "topcoat-view",
  "topcoat-view-macro",
  "uuid",
@@ -3237,6 +3300,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "topcoat-vercel"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "topcoat-asset",
+ "topcoat-core",
+ "topcoat-router",
+ "vercel_runtime",
+]
+
+[[package]]
 name = "topcoat-view"
 version = "0.5.0"
 dependencies = [
@@ -3354,6 +3434,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -3511,6 +3597,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vercel_runtime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9040702f825410b853e11779c07d90c826ba17fdf3a3df47902c3c6dd3f724f"
+dependencies = [
+ "base64",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,6 +3630,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3702,6 +3817,35 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,28 @@ dependencies = [
  "topcoat",
  "topcoat-core",
  "topcoat-router",
+ "topcoat-shell-view-macro",
  "topcoat-view",
+]
+
+[[package]]
+name = "topcoat-shell-view-grammar"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "topcoat-core-grammar",
+ "topcoat-view-grammar",
+]
+
+[[package]]
+name = "topcoat-shell-view-macro"
+version = "0.5.0"
+dependencies = [
+ "syn",
+ "topcoat",
+ "topcoat-shell-view-grammar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/topcoat-tailwind",
     "crates/topcoat-ui",
     "crates/topcoat-ui/registry",
+    "crates/topcoat-vercel",
     "crates/topcoat-view",
     "crates/topcoat-view/grammar",
     "crates/topcoat-view/macro",
@@ -144,6 +145,7 @@ topcoat-session = { version = "0.5.0", path = "crates/topcoat-session" }
 topcoat-tailwind = { version = "0.5.0", path = "crates/topcoat-tailwind" }
 topcoat-ui = { version = "0.5.0", path = "crates/topcoat-ui" }
 topcoat-ui-registry = { version = "0.5.0", path = "crates/topcoat-ui/registry" }
+topcoat-vercel = { version = "0.5.0", path = "crates/topcoat-vercel", default-features = false }
 topcoat-view = { version = "0.5.0", path = "crates/topcoat-view" }
 topcoat-view-grammar = { version = "0.5.0", path = "crates/topcoat-view/grammar" }
 topcoat-view-macro = { version = "0.5.0", path = "crates/topcoat-view/macro" }
@@ -200,10 +202,12 @@ thiserror = "2.0.18"
 time = "0.3"
 toasty = "0.7"
 tokio = "1.51.1"
+tokio-stream = "0.1"
 toml = "1.1.2"
 tokio-tungstenite = { version = "0.29", default-features = false }
 tower = "0.5"
 tower-http = "0.7"
 ureq = "3.3"
 uuid = "1.23"
+vercel_runtime = "2.4.0"
 web-time = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ members = [
     "crates/topcoat-mail/grammar",
     "crates/topcoat-mail/macro",
     "crates/topcoat-shell-view",
+    "crates/topcoat-shell-view/grammar",
+    "crates/topcoat-shell-view/macro",
     "crates/topcoat-router",
     "crates/topcoat-router/grammar",
     "crates/topcoat-router/macro",
@@ -130,6 +132,8 @@ topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
 topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
 topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
 topcoat-shell-view = { version = "0.5.0", path = "crates/topcoat-shell-view" }
+topcoat-shell-view-grammar = { version = "0.5.0", path = "crates/topcoat-shell-view/grammar" }
+topcoat-shell-view-macro = { version = "0.5.0", path = "crates/topcoat-shell-view/macro" }
 topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
 topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
 topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/topcoat-mail",
     "crates/topcoat-mail/grammar",
     "crates/topcoat-mail/macro",
+    "crates/topcoat-shell-view",
     "crates/topcoat-router",
     "crates/topcoat-router/grammar",
     "crates/topcoat-router/macro",
@@ -48,6 +49,7 @@ members = [
     "examples/manual-router",
     "examples/module-router",
     "examples/path-query-params",
+    "examples/shell-view",
     "examples/procedure",
     "examples/request-response",
     "examples/runtime",
@@ -127,6 +129,7 @@ topcoat-icon-macro = { version = "0.5.0", path = "crates/topcoat-icon/macro" }
 topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
 topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
 topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
+topcoat-shell-view = { version = "0.5.0", path = "crates/topcoat-shell-view" }
 topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
 topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
 topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 
 **Start here**
 - [Getting started](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat/docs/getting_started.md): create a new project, install the CLI, run the dev server.
+- [Deploy to Vercel](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat/docs/vercel.md): build a streaming Rust function with the Vercel Build Output API.
 - [Source code formatting](https://github.com/tokio-rs/topcoat/blob/main/crates/topcoat-cli/docs/fmt.md): `topcoat fmt` for macro bodies.
 
 **Rendering**

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 **Rendering**
 - [The `view!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.view.html): templating syntax, control flow, conditional attributes.
 - [The `#[component]` macro](https://docs.rs/topcoat/latest/topcoat/view/attr.component.html): async functions as components, with child content.
+- [`ShellView`](https://docs.rs/topcoat/latest/topcoat/shell_view/index.html): stream placeholders first and replace them as deferred views finish.
 - [The `attributes!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.attributes.html): reusable runtime attribute fragments.
 - [The `class!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.class.html): space-separated class lists from static and conditional entries.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 **Rendering**
 - [The `view!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.view.html): templating syntax, control flow, conditional attributes.
 - [The `#[component]` macro](https://docs.rs/topcoat/latest/topcoat/view/attr.component.html): async functions as components, with child content.
-- [`ShellView`](https://docs.rs/topcoat/latest/topcoat/shell_view/index.html): stream placeholders first and replace them as deferred views finish.
+- [`ShellView`](https://docs.rs/topcoat/latest/topcoat/shell_view/index.html): stream placeholders first with builder or inline `shell_view!` syntax.
 - [The `attributes!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.attributes.html): reusable runtime attribute fragments.
 - [The `class!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.class.html): space-separated class lists from static and conditional entries.
 

--- a/crates/topcoat-core/grammar/src/paths.rs
+++ b/crates/topcoat-core/grammar/src/paths.rs
@@ -217,6 +217,16 @@ pub const topcoat_runtime: Crate = Crate::new("runtime", "topcoat-runtime", "");
 #[allow(non_upper_case_globals)]
 pub const topcoat_runtime_macro: Crate = Crate::new("runtime", "topcoat-runtime-macro", "");
 
+/// `::topcoat::shell_view`, or `topcoat_shell_view` standalone.
+#[allow(non_upper_case_globals)]
+pub const topcoat_shell_view: Crate = Crate::new("shell_view", "topcoat-shell-view", "");
+
+/// The `shell_view!` macro: `::topcoat::shell_view`, or
+/// `topcoat_shell_view_macro` standalone.
+#[allow(non_upper_case_globals)]
+pub const topcoat_shell_view_macro: Crate =
+    Crate::new("shell_view", "topcoat-shell-view-macro", "");
+
 /// `::topcoat::view`, or `topcoat_view` standalone.
 #[allow(non_upper_case_globals)]
 pub const topcoat_view: Crate = Crate::new("view", "topcoat-view", "");

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -19,9 +19,9 @@ use crate::{abort::AbortStore, memoize::MemoizeCache};
 pub struct Cx {
     id: CxId,
     app_context: Arc<ContextMap>,
-    request_context: ContextMap,
-    memoize_cache: MemoizeCache,
-    abort_store: AbortStore,
+    request_context: Arc<ContextMap>,
+    memoize_cache: Arc<MemoizeCache>,
+    abort_store: Arc<AbortStore>,
 }
 
 impl Cx {
@@ -30,16 +30,59 @@ impl Cx {
         Self {
             id: CxId::new(),
             app_context,
-            request_context,
-            memoize_cache: MemoizeCache::new(),
-            abort_store: AbortStore::new(),
+            request_context: Arc::new(request_context),
+            memoize_cache: Arc::new(MemoizeCache::new()),
+            abort_store: Arc::new(AbortStore::new()),
         }
     }
 
     /// Returns this context's unique [`CxId`].
     #[inline]
+    #[must_use]
     pub fn id(&self) -> CxId {
         self.id
+    }
+
+    /// Returns an owned handle to this request context.
+    ///
+    /// The handle keeps request and app context values alive for work that
+    /// continues while a streaming response is sent.
+    #[must_use]
+    pub fn handle(&self) -> CxHandle {
+        CxHandle(Self {
+            id: self.id,
+            app_context: Arc::clone(&self.app_context),
+            request_context: Arc::clone(&self.request_context),
+            memoize_cache: Arc::clone(&self.memoize_cache),
+            abort_store: Arc::clone(&self.abort_store),
+        })
+    }
+}
+
+/// An owned handle to a request [`Cx`].
+///
+/// This is useful for response streams and other work that must own the
+/// request context. It dereferences to `Cx`, so context helpers accept `&handle`.
+#[derive(Debug)]
+pub struct CxHandle(Cx);
+
+impl Clone for CxHandle {
+    fn clone(&self) -> Self {
+        self.0.handle()
+    }
+}
+
+impl AsRef<Cx> for CxHandle {
+    fn as_ref(&self) -> &Cx {
+        &self.0
+    }
+}
+
+impl Deref for CxHandle {
+    type Target = Cx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -71,11 +114,18 @@ impl CxBuilder {
     ///
     /// A type can hold only one value at a time, so registering a type that is
     /// already present replaces it and hands back the displaced value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     pub fn insert<T>(&mut self, value: T) -> Option<T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.insert(value)
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .insert(value)
     }
 
     /// Returns `true` if a value of type `T` has been registered on the request
@@ -100,12 +150,19 @@ impl CxBuilder {
 
     /// Returns a mutable reference to the request context value of type `T`, or
     /// `None` if no such value has been registered.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     #[must_use]
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.get_mut::<T>()
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .get_mut::<T>()
     }
 
     /// Consumes the builder, returning the finished [`Cx`].
@@ -169,12 +226,14 @@ impl CxTestBuilder {
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn memoize_cache(cx: &Cx) -> &MemoizeCache {
     &cx.memoize_cache
 }
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn abort_store(cx: &Cx) -> &AbortStore {
     &cx.abort_store
 }

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -66,6 +66,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn app_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,
@@ -131,6 +132,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn request_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -78,6 +78,7 @@ impl PageFn {
     }
 
     /// Renders the page, returning a [`Result`].
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,
@@ -124,6 +125,7 @@ impl LayoutFn {
     }
 
     /// Renders the layout, embedding the given child content [`Result`]`<`[`View`]`>` as its slot.
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,

--- a/crates/topcoat-shell-view/Cargo.toml
+++ b/crates/topcoat-shell-view/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "topcoat-shell-view"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+topcoat-core.workspace = true
+topcoat-router.workspace = true
+topcoat-view = { workspace = true, features = ["http"] }
+
+bytes.workspace = true
+futures-util.workspace = true
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/topcoat-shell-view/grammar/Cargo.toml
+++ b/crates/topcoat-shell-view/grammar/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "topcoat-shell-view-grammar"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+topcoat-core-grammar.workspace = true
+topcoat-view-grammar.workspace = true
+
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/topcoat-shell-view/grammar/src/lib.rs
+++ b/crates/topcoat-shell-view/grammar/src/lib.rs
@@ -1,0 +1,215 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
+use quote::{ToTokens as _, format_ident, quote, quote_spanned};
+use syn::parse::{Parse, ParseStream};
+use topcoat_core_grammar::{
+    ParseOption,
+    paths::{topcoat_error, topcoat_shell_view, topcoat_view_macro},
+};
+use topcoat_view_grammar::{
+    leading_cx::LeadingCx,
+    view::{Component, Nodes},
+};
+
+/// The parsed body of a `shell_view!` invocation.
+pub struct ShellView {
+    /// The optional request context binding supplied by `cx =>`.
+    pub cx: Option<LeadingCx>,
+    /// The shell markup, including any inline `defer` nodes.
+    pub body: TokenStream,
+}
+
+impl ShellView {
+    /// Expands the shell and its inline deferred components.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a `defer` node does not contain a valid component
+    /// invocation and placeholder view.
+    pub fn expand(&self) -> syn::Result<TokenStream> {
+        let (body, deferred) = rewrite(self.body.clone())?;
+        let builder = format_ident!("__shell_view_builder", span = Span::mixed_site());
+        let shell = format_ident!("__shell_view_shell", span = Span::mixed_site());
+        let ambient_cx = format_ident!("__cx", span = Span::call_site());
+        let cx = self.cx.as_ref().map_or(&ambient_cx, |leading| &leading.cx);
+        let leading_cx = &self.cx;
+        let bindings = deferred.iter().enumerate().map(|(index, deferred)| {
+            let slot = slot_ident(index);
+            let owned_cx = format_ident!("__shell_view_owned_cx", span = Span::mixed_site());
+            let deferred_cx = format_ident!("__shell_view_deferred_cx", span = Span::mixed_site());
+            let component = &deferred.component;
+            let placeholder = &deferred.placeholder;
+
+            quote_spanned! {deferred.span=>
+                let #slot = #builder.defer(
+                    #topcoat_view_macro::view! { #leading_cx #placeholder }?,
+                    move |#owned_cx| async move {
+                        let #deferred_cx = #owned_cx.as_ref();
+                        #topcoat_view_macro::view! { #deferred_cx => #component }
+                    },
+                );
+            }
+        });
+
+        Ok(quote! {
+            async {
+                let mut #builder = #topcoat_shell_view::ShellView::builder(#cx);
+                #(#bindings)*
+                let #shell = #topcoat_view_macro::view! { #leading_cx #body }?;
+                ::core::result::Result::<
+                    #topcoat_shell_view::ShellView,
+                    #topcoat_error::Error,
+                >::Ok(#builder.finish(#shell))
+            }
+            .await
+        })
+    }
+}
+
+impl Parse for ShellView {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            cx: input.call(LeadingCx::parse_option)?,
+            body: input.parse()?,
+        })
+    }
+}
+
+struct DeferredRender {
+    span: Span,
+    component: TokenStream,
+    placeholder: TokenStream,
+}
+
+fn rewrite(body: TokenStream) -> syn::Result<(TokenStream, Vec<DeferredRender>)> {
+    let trees = body.into_iter().collect::<Vec<_>>();
+    let mut rewritten = TokenStream::new();
+    let mut deferred = Vec::new();
+    let mut index = 0;
+
+    while index < trees.len() {
+        let Some(ident) = ident_named(&trees[index], "defer") else {
+            rewritten.extend([trees[index].clone()]);
+            index += 1;
+            continue;
+        };
+        let Some(paren_index) = trees[index + 1..]
+            .iter()
+            .position(|tree| matches!(tree, TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis))
+            .map(|offset| index + 1 + offset)
+        else {
+            rewritten.extend([trees[index].clone()]);
+            index += 1;
+            continue;
+        };
+        if paren_index == index + 1 {
+            return Err(syn::Error::new(
+                ident.span(),
+                "expected a component after `defer`",
+            ));
+        }
+        let component = trees[index + 1..=paren_index]
+            .iter()
+            .cloned()
+            .collect::<TokenStream>();
+        if syn::parse2::<Component>(component.clone()).is_err() {
+            rewritten.extend([trees[index].clone()]);
+            index += 1;
+            continue;
+        }
+        let Some(TokenTree::Group(placeholder)) = trees.get(paren_index + 1) else {
+            return Err(syn::Error::new(
+                ident.span(),
+                "expected a placeholder block after the deferred component",
+            ));
+        };
+        if placeholder.delimiter() != Delimiter::Brace {
+            return Err(syn::Error::new(
+                placeholder.span(),
+                "expected a placeholder block after the deferred component",
+            ));
+        }
+
+        syn::parse2::<Nodes>(placeholder.stream())?;
+
+        let slot = slot_ident(deferred.len());
+        quote_spanned! {ident.span()=> (#slot)}.to_tokens(&mut rewritten);
+        deferred.push(DeferredRender {
+            span: ident.span(),
+            component,
+            placeholder: placeholder.stream(),
+        });
+        index = paren_index + 2;
+    }
+
+    Ok((rewritten, deferred))
+}
+
+fn ident_named<'a>(tree: &'a TokenTree, name: &str) -> Option<&'a proc_macro2::Ident> {
+    match tree {
+        TokenTree::Ident(ident) if ident == name => Some(ident),
+        _ => None,
+    }
+}
+
+fn slot_ident(index: usize) -> proc_macro2::Ident {
+    format_ident!("__shell_view_deferred_{index}", span = Span::mixed_site())
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens as _;
+
+    use super::*;
+
+    fn expand(source: &str) -> String {
+        syn::parse_str::<ShellView>(source)
+            .unwrap()
+            .expand()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn expands_inline_defer_inside_markup() {
+        let output = expand(
+            r#"cx => <main><section>defer newsfeed(limit: 3) { <p>"Loading"</p> }</section></main>"#,
+        );
+
+        assert!(output.contains("ShellView :: builder (cx)"));
+        assert!(output.contains(". defer"));
+        assert!(output.contains("newsfeed (limit : 3)"));
+        assert!(output.contains("Loading"));
+        assert!(output.contains("__shell_view_deferred_0"));
+    }
+
+    #[test]
+    fn expands_multiple_deferred_components() {
+        let output = expand(r#"defer first() { "One" } <div>defer second() { "Two" }</div>"#);
+
+        assert!(output.contains("__shell_view_deferred_0"));
+        assert!(output.contains("__shell_view_deferred_1"));
+    }
+
+    #[test]
+    fn rejects_a_missing_placeholder() {
+        let shell = syn::parse_str::<ShellView>("defer newsfeed()").unwrap();
+        assert!(
+            shell
+                .expand()
+                .unwrap_err()
+                .to_string()
+                .contains("expected a placeholder block")
+        );
+    }
+
+    #[test]
+    fn retains_plain_view_tokens() {
+        let shell = syn::parse_str::<ShellView>(r#"cx => <p>"Hello"</p>"#).unwrap();
+        assert_eq!(
+            shell.body.to_token_stream().to_string(),
+            r#"< p > "Hello" </ p >"#
+        );
+    }
+}

--- a/crates/topcoat-shell-view/macro/Cargo.toml
+++ b/crates/topcoat-shell-view/macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "topcoat-shell-view"
+name = "topcoat-shell-view-macro"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -10,23 +10,16 @@ keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
 
-[dependencies]
-topcoat-core.workspace = true
-topcoat-router.workspace = true
-topcoat-shell-view-macro.workspace = true
-topcoat-view = { workspace = true, features = ["http"] }
+[lib]
+proc-macro = true
 
-bytes.workspace = true
-futures-util.workspace = true
-http.workspace = true
-http-body.workspace = true
-http-body-util.workspace = true
-serde_json.workspace = true
+[dependencies]
+topcoat-shell-view-grammar.workspace = true
+
+syn.workspace = true
 
 [dev-dependencies]
 topcoat = { workspace = true, features = ["shell-view"] }
-
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [lints]
 workspace = true

--- a/crates/topcoat-shell-view/macro/docs/shell_view.md
+++ b/crates/topcoat-shell-view/macro/docs/shell_view.md
@@ -1,0 +1,21 @@
+Builds a streaming shell with inline deferred components.
+
+Write the deferred component after `defer`. The block that follows it is sent as its placeholder:
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::{ShellView, shell_view}, view::{component, view}};
+# #[component]
+# async fn newsfeed() -> Result { view! { <p>"News"</p> } }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+shell_view! {
+    cx =>
+    <main>
+        defer newsfeed() {
+            <p aria-busy="true">"Loading news..."</p>
+        }
+    </main>
+}
+# }
+```
+
+Each inline deferred component runs concurrently and replaces its placeholder when it finishes.

--- a/crates/topcoat-shell-view/macro/src/lib.rs
+++ b/crates/topcoat-shell-view/macro/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use proc_macro::TokenStream;
+
+#[doc = include_str!("../docs/shell_view.md")]
+#[proc_macro]
+pub fn shell_view(tokens: TokenStream) -> TokenStream {
+    match syn::parse::<topcoat_shell_view_grammar::ShellView>(tokens)
+        .and_then(|shell| shell.expand())
+    {
+        Ok(tokens) => tokens.into(),
+        Err(error) => error.to_compile_error().into(),
+    }
+}

--- a/crates/topcoat-shell-view/src/lib.rs
+++ b/crates/topcoat-shell-view/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+extern crate self as topcoat_shell_view;
+
 use std::{
     future::Future,
     pin::Pin,
@@ -22,6 +24,7 @@ use topcoat_router::{
     Body,
     response::{IntoResponse, Response},
 };
+pub use topcoat_shell_view_macro::shell_view;
 use topcoat_view::{HtmlContext, PartsWriter, View, ViewParts};
 
 type DeferredFuture = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'static>>;
@@ -154,9 +157,14 @@ mod tests {
     use topcoat::{
         context::{Cx, request_context},
         router::{response::IntoResponse as _, to_bytes},
-        shell_view::ShellView,
-        view::view,
+        shell_view::{ShellView, shell_view},
+        view::{component, view},
     };
+
+    #[component]
+    async fn inline_card() -> topcoat::Result {
+        view! { <p>"Inline result"</p> }
+    }
 
     #[tokio::test]
     async fn streams_shell_then_fragments_in_completion_order() {
@@ -267,6 +275,27 @@ mod tests {
         assert!(html.contains("<aside>"));
         assert!(html.contains("Child loading"));
         assert!(html.contains("Child ready"));
+    }
+
+    #[tokio::test]
+    async fn shell_view_macro_streams_inline_deferred_components() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let shell = shell_view! {
+            cx_ref =>
+            <main>
+                defer inline_card() {
+                    <p>"Inline placeholder"</p>
+                }
+            </main>
+        }
+        .unwrap();
+        let response = shell.into_response(&cx).unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(html.contains("Inline placeholder"));
+        assert!(html.contains("Inline result"));
     }
 
     #[test]

--- a/crates/topcoat-shell-view/src/lib.rs
+++ b/crates/topcoat-shell-view/src/lib.rs
@@ -1,0 +1,279 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use bytes::Bytes;
+use futures_util::{
+    StreamExt as _,
+    stream::{self, FuturesUnordered},
+};
+use http::{HeaderValue, header::CONTENT_TYPE};
+use http_body::Frame;
+use http_body_util::StreamBody;
+use topcoat_core::{
+    context::{Cx, CxHandle},
+    error::Result,
+};
+use topcoat_router::{
+    Body,
+    response::{IntoResponse, Response},
+};
+use topcoat_view::{HtmlContext, PartsWriter, View, ViewParts};
+
+type DeferredFuture = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'static>>;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+const HTML: HeaderValue = HeaderValue::from_static("text/html; charset=utf-8");
+
+/// Builds a streaming [`ShellView`] from a normal view shell and deferred views.
+pub struct ShellViewBuilder {
+    cx: CxHandle,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellViewBuilder {
+    /// Defers a view and returns its placeholder for insertion into the shell.
+    ///
+    /// `render` receives an owned request context handle. Its future starts
+    /// when the response body is polled, and all deferred futures are polled
+    /// concurrently. Completed views replace their placeholders immediately.
+    pub fn defer<F, Fut>(&mut self, placeholder: View, render: F) -> View
+    where
+        F: FnOnce(CxHandle) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<View>> + Send + 'static,
+    {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let cx = self.cx.clone();
+        self.deferred.push(Box::pin(async move {
+            let view = render(cx.clone()).await?;
+            Ok(Bytes::from(patch(id, &view.render(&cx))))
+        }));
+        placeholder_view(id, placeholder)
+    }
+
+    /// Inserts a child shell view and adopts its deferred work.
+    ///
+    /// Put the returned shell view into the parent shell. Deferred fragments
+    /// from both views then share the same response stream.
+    #[must_use]
+    pub fn include(&mut self, child: ShellView) -> View {
+        self.deferred.extend(child.deferred);
+        child.shell
+    }
+
+    /// Finishes the builder with the view sent as the first response chunk.
+    #[must_use]
+    pub fn finish(self, shell: View) -> ShellView {
+        ShellView {
+            shell,
+            deferred: self.deferred,
+        }
+    }
+}
+
+/// An HTML response that streams deferred views into placeholders.
+pub struct ShellView {
+    shell: View,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellView {
+    /// Starts a shell view builder for `cx`.
+    #[must_use]
+    pub fn builder(cx: &Cx) -> ShellViewBuilder {
+        ShellViewBuilder {
+            cx: cx.handle(),
+            deferred: Vec::new(),
+        }
+    }
+
+    /// Creates a shell view with no deferred fragments.
+    #[must_use]
+    pub fn from_view(view: View) -> Self {
+        Self {
+            shell: view,
+            deferred: Vec::new(),
+        }
+    }
+}
+
+impl IntoResponse for ShellView {
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        let rendered = self.shell.render_response(cx);
+        let initial = stream::once(async move {
+            Ok::<_, topcoat_core::error::Error>(Frame::data(Bytes::from(rendered.html)))
+        });
+        let deferred = self
+            .deferred
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .map(|result| result.map(Frame::data));
+        let body = Body::new(StreamBody::new(initial.chain(deferred)));
+        let mut response = Response::new(body);
+        *response.status_mut() = rendered.status_code.unwrap_or_default();
+        response.headers_mut().insert(CONTENT_TYPE, HTML);
+        response.headers_mut().extend(rendered.headers);
+        Ok(response)
+    }
+}
+
+fn placeholder_view(id: u64, placeholder: View) -> View {
+    let mut parts = ViewParts::new();
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped(format!(
+        r#"<topcoat-shell id="topcoat-shell-{id}" style="display: contents">"#,
+    ));
+    parts.push_view(placeholder);
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped("</topcoat-shell>");
+    View::new(parts)
+}
+
+fn patch(id: u64, html: &str) -> String {
+    let html = serde_json::to_string(html)
+        .expect("serializing a string cannot fail")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026");
+    format!(
+        r#"<script>(()=>{{const p=document.getElementById("topcoat-shell-{id}");if(!p)return;const t=document.createElement("template");t.innerHTML={html};p.replaceWith(t.content)}})()</script>"#,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use futures_util::StreamExt as _;
+    use topcoat::{
+        context::{Cx, request_context},
+        router::{response::IntoResponse as _, to_bytes},
+        shell_view::ShellView,
+        view::view,
+    };
+
+    #[tokio::test]
+    async fn streams_shell_then_fragments_in_completion_order() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let mut page = ShellView::builder(&cx);
+
+        let slow_completed = Arc::clone(&completed);
+        let slow = page.defer(
+            view! { cx_ref => <p>"slow placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                slow_completed.lock().unwrap().push("slow");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"slow result"</p> }
+            },
+        );
+        let fast_completed = Arc::clone(&completed);
+        let fast = page.defer(
+            view! { cx_ref => <p>"fast placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                fast_completed.lock().unwrap().push("fast");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"fast result"</p> }
+            },
+        );
+        let response = page
+            .finish(
+                view! {
+                    cx_ref =>
+                    <main>
+                        (slow)
+                        (fast)
+                    </main>
+                }
+                .unwrap(),
+            )
+            .into_response(&cx)
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+
+        let shell = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(shell.contains("slow placeholder"));
+        assert!(shell.contains("fast placeholder"));
+
+        let first_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(first_patch.contains("fast result"));
+        let second_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(second_patch.contains("slow result"));
+        assert_eq!(*completed.lock().unwrap(), ["fast", "slow"]);
+    }
+
+    #[tokio::test]
+    async fn deferred_view_keeps_request_context_alive() {
+        struct Name(&'static str);
+
+        let cx = topcoat::context::CxTestBuilder::new()
+            .request_context(Name("Ada"))
+            .build();
+        let cx_ref = &cx;
+        let mut page = ShellView::builder(&cx);
+        let greeting = page.defer(view! { cx_ref => "Loading" }.unwrap(), |cx| async move {
+            let name = request_context::<Name>(&cx).0;
+            let cx_ref = cx.as_ref();
+            view! {
+                cx_ref =>
+                <p>
+                    "Hello, "
+                    (name)
+                </p>
+            }
+        });
+        let response = page
+            .finish(view! { cx_ref => (greeting) }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Hello, "));
+        assert!(html.contains("Ada"));
+    }
+
+    #[tokio::test]
+    async fn includes_child_shell_views() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let mut child = ShellView::builder(&cx);
+        let child_slot = child.defer(
+            view! { cx_ref => "Child loading" }.unwrap(),
+            |cx| async move {
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"Child ready"</p> }
+            },
+        );
+        let child = child.finish(view! { cx_ref => <aside>(child_slot)</aside> }.unwrap());
+
+        let mut parent = ShellView::builder(&cx);
+        let child = parent.include(child);
+        let response = parent
+            .finish(view! { cx_ref => <main>(child)</main> }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(html.contains("<aside>"));
+        assert!(html.contains("Child loading"));
+        assert!(html.contains("Child ready"));
+    }
+
+    #[test]
+    fn patch_html_cannot_close_its_script() {
+        let patch = super::patch(7, "</script><script>alert('xss')</script>");
+
+        assert!(!patch.contains("</script><script>"));
+        assert!(patch.contains(r"\u003c/script\u003e"));
+    }
+}

--- a/crates/topcoat-vercel/Cargo.toml
+++ b/crates/topcoat-vercel/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "topcoat-vercel"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+default-run = "topcoat-vercel"
+
+[features]
+default = ["cli"]
+cli = [
+	"dep:anyhow",
+	"dep:clap",
+	"dep:serde",
+	"dep:serde_json",
+	"dep:topcoat-asset",
+	"dep:topcoat-core",
+]
+
+[[bin]]
+name = "topcoat-vercel"
+path = "src/bin/topcoat_vercel.rs"
+required-features = ["cli"]
+
+[dependencies]
+topcoat-asset = { workspace = true, optional = true, features = ["bundler"] }
+topcoat-core = { workspace = true, optional = true, features = ["build"] }
+topcoat-router.workspace = true
+
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true, features = ["derive"] }
+http-body-util.workspace = true
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream.workspace = true
+vercel_runtime.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/topcoat-vercel/README.md
+++ b/crates/topcoat-vercel/README.md
@@ -1,0 +1,4 @@
+# Topcoat for Vercel
+
+This crate runs a Topcoat application on Vercel and provides the
+`topcoat-vercel` deployment CLI.

--- a/crates/topcoat-vercel/src/bin/topcoat_vercel.rs
+++ b/crates/topcoat-vercel/src/bin/topcoat_vercel.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    topcoat_vercel::cli::run()
+}

--- a/crates/topcoat-vercel/src/cli.rs
+++ b/crates/topcoat-vercel/src/cli.rs
@@ -1,0 +1,30 @@
+mod build;
+mod common;
+mod init;
+
+use anyhow::Result;
+use build::BuildCommand;
+use clap::{Parser, Subcommand};
+use init::InitCommand;
+
+#[derive(Parser)]
+#[command(name = "topcoat-vercel", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Generate the Vercel project configuration
+    Init(InitCommand),
+    /// Build a Vercel Build Output API deployment
+    Build(BuildCommand),
+}
+
+pub fn run() -> Result<()> {
+    match Cli::parse().command {
+        Command::Init(command) => command.run(),
+        Command::Build(command) => command.run(),
+    }
+}

--- a/crates/topcoat-vercel/src/cli/build.rs
+++ b/crates/topcoat-vercel/src/cli/build.rs
@@ -1,0 +1,201 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use serde_json::json;
+use topcoat_asset::{Bundler, BundlerConfig, MANIFEST_NAME};
+
+use super::common::{Metadata, cargo, copy_dir};
+
+const ASSET_CACHE_SCOPE: &str = "assets";
+
+#[derive(Args)]
+pub(super) struct BuildCommand {
+    /// Binary containing the Topcoat application
+    #[arg(long)]
+    bin: Option<String>,
+}
+
+impl BuildCommand {
+    pub(super) fn run(self) -> Result<()> {
+        ensure_build_platform()?;
+
+        let metadata = Metadata::load()?;
+        let binary = metadata.current_package()?.binary(self.bin.as_deref())?;
+        cargo(["build", "--release", "--bin", binary])?;
+
+        let executable = metadata.target_directory.join("release").join(binary);
+        let assets = metadata.target_directory.join("release/assets");
+        bundle_assets(&metadata.target_directory, &executable, &assets)?;
+        write_output(Path::new(".vercel/output"), &executable, &assets)?;
+
+        println!("built Vercel output in .vercel/output");
+        Ok(())
+    }
+}
+
+fn ensure_build_platform() -> Result<()> {
+    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Ok(())
+    } else {
+        bail!(
+            "native Vercel builds require Linux x86_64; run this command in Vercel's build environment"
+        )
+    }
+}
+
+fn bundle_assets(target: &Path, executable: &Path, assets: &Path) -> Result<()> {
+    let bytes =
+        fs::read(executable).with_context(|| format!("failed to read {}", executable.display()))?;
+    let cache = topcoat_core::cache::cache_dir_in(target, ASSET_CACHE_SCOPE);
+    let config = BundlerConfig::new().cache_dir(cache);
+    Bundler::new(&config)
+        .bundle(&bytes, assets)
+        .context("failed to bundle Topcoat assets")?;
+    Ok(())
+}
+
+fn write_output(output: &Path, executable: &Path, assets: &Path) -> Result<()> {
+    if output.exists() {
+        fs::remove_dir_all(output)
+            .with_context(|| format!("failed to clear {}", output.display()))?;
+    }
+
+    let function = output.join("functions/index.func");
+    fs::create_dir_all(&function)
+        .with_context(|| format!("failed to create {}", function.display()))?;
+    let deployed_executable = function.join("executable");
+    fs::copy(executable, &deployed_executable).with_context(|| {
+        format!(
+            "failed to copy {} to {}",
+            executable.display(),
+            deployed_executable.display()
+        )
+    })?;
+    make_executable(&deployed_executable)?;
+    copy_dir(assets, &function.join("assets"))?;
+
+    let static_assets = output.join("static/_topcoat/assets");
+    fs::create_dir_all(&static_assets)
+        .with_context(|| format!("failed to create {}", static_assets.display()))?;
+    for entry in
+        fs::read_dir(assets).with_context(|| format!("failed to read {}", assets.display()))?
+    {
+        let entry = entry?;
+        if entry.file_type()?.is_file() && entry.file_name() != MANIFEST_NAME {
+            fs::copy(entry.path(), static_assets.join(entry.file_name()))?;
+        }
+    }
+
+    write_json(
+        &function.join(".vc-config.json"),
+        &json!({
+            "handler": "executable",
+            "runtime": "executable",
+            "runtimeLanguage": "rust",
+            "architecture": "x86_64",
+            "supportsResponseStreaming": true,
+        }),
+    )?;
+    write_json(
+        &output.join("config.json"),
+        &json!({
+            "version": 3,
+            "routes": [
+                { "handle": "filesystem" },
+                { "src": "/(.*)", "dest": "/index" },
+            ],
+            "framework": {
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+        }),
+    )
+}
+
+fn write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
+    let mut contents = serde_json::to_string_pretty(value)?;
+    contents.push('\n');
+    fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    struct TempDir(std::path::PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let sequence = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "topcoat-vercel-build-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+
+    #[test]
+    fn writes_a_streaming_function_and_static_assets() {
+        let root = TempDir::new();
+        let executable = root.0.join("app");
+        let assets = root.0.join("assets");
+        let output = root.0.join("output");
+        fs::write(&executable, "binary").unwrap();
+        fs::create_dir(&assets).unwrap();
+        fs::write(assets.join(MANIFEST_NAME), "version = 1\n").unwrap();
+        fs::write(assets.join("app-123.css"), "body {}").unwrap();
+
+        write_output(&output, &executable, &assets).unwrap();
+
+        let function_config: serde_json::Value = serde_json::from_slice(
+            &fs::read(output.join("functions/index.func/.vc-config.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(function_config["runtime"], "executable");
+        assert_eq!(function_config["runtimeLanguage"], "rust");
+        assert_eq!(function_config["supportsResponseStreaming"], true);
+        assert!(
+            output
+                .join("functions/index.func/assets/manifest.toml")
+                .is_file()
+        );
+        assert!(output.join("static/_topcoat/assets/app-123.css").is_file());
+        assert!(!output.join("static/_topcoat/assets/manifest.toml").exists());
+
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(output.join("config.json")).unwrap()).unwrap();
+        assert_eq!(config["version"], 3);
+        assert_eq!(config["routes"][0]["handle"], "filesystem");
+        assert_eq!(config["routes"][1]["dest"], "/index");
+    }
+}

--- a/crates/topcoat-vercel/src/cli/common.rs
+++ b/crates/topcoat-vercel/src/cli/common.rs
@@ -1,0 +1,121 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(super) struct Metadata {
+    pub(super) packages: Vec<Package>,
+    pub(super) target_directory: PathBuf,
+}
+
+impl Metadata {
+    pub(super) fn load() -> Result<Self> {
+        let output = cargo(["metadata", "--format-version", "1", "--no-deps"])?;
+        serde_json::from_slice(&output.stdout).context("failed to read cargo metadata")
+    }
+
+    pub(super) fn current_package(&self) -> Result<&Package> {
+        let output = cargo(["locate-project", "--message-format", "plain"])?;
+        let manifest = Path::new(
+            std::str::from_utf8(&output.stdout)
+                .context("cargo returned a non-UTF-8 manifest path")?
+                .trim(),
+        )
+        .canonicalize()
+        .context("failed to resolve the current Cargo manifest")?;
+
+        self.packages
+            .iter()
+            .find(|package| {
+                package
+                    .manifest_path
+                    .canonicalize()
+                    .is_ok_and(|path| path == manifest)
+            })
+            .context("the current Cargo manifest is not a package")
+    }
+}
+
+#[derive(Deserialize)]
+pub(super) struct Package {
+    pub(super) default_run: Option<String>,
+    pub(super) manifest_path: PathBuf,
+    pub(super) targets: Vec<Target>,
+}
+
+impl Package {
+    pub(super) fn binary(&self, requested: Option<&str>) -> Result<&str> {
+        let binaries = self
+            .targets
+            .iter()
+            .filter(|target| target.kind.iter().any(|kind| kind == "bin"))
+            .collect::<Vec<_>>();
+
+        if let Some(requested) = requested {
+            return binaries
+                .into_iter()
+                .find(|target| target.name == requested)
+                .map(|target| target.name.as_str())
+                .with_context(|| format!("package has no `{requested}` binary"));
+        }
+
+        if let Some(default) = self.default_run.as_deref() {
+            return Ok(default);
+        }
+
+        match binaries.as_slice() {
+            [binary] => Ok(&binary.name),
+            [] => bail!("package has no binary target"),
+            _ => bail!("package has several binaries; pass `--bin <name>`"),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub(super) struct Target {
+    pub(super) kind: Vec<String>,
+    pub(super) name: String,
+}
+
+pub(super) fn cargo<const N: usize>(args: [&str; N]) -> Result<Output> {
+    let mut command = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    if env::var_os("VERCEL").is_some() {
+        command.arg(concat!("+", env!("CARGO_PKG_RUST_VERSION")));
+    }
+    let output = command.args(args).output().context("failed to run cargo")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("cargo failed: {}", stderr.trim());
+    }
+    Ok(output)
+}
+
+pub(super) fn copy_dir(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+
+    for entry in
+        fs::read_dir(source).with_context(|| format!("failed to read {}", source.display()))?
+    {
+        let entry = entry?;
+        let source = entry.path();
+        let destination = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&source, &destination)?;
+        } else {
+            fs::copy(&source, &destination).with_context(|| {
+                format!(
+                    "failed to copy {} to {}",
+                    source.display(),
+                    destination.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/crates/topcoat-vercel/src/cli/init.rs
+++ b/crates/topcoat-vercel/src/cli/init.rs
@@ -1,0 +1,153 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use serde_json::json;
+
+const RUST_VERSION: &str = "1.95.0";
+
+#[derive(Args)]
+pub(super) struct InitCommand {
+    /// Binary to build when the package contains more than one
+    #[arg(long)]
+    bin: Option<String>,
+    /// Replace an existing vercel.json
+    #[arg(long)]
+    force: bool,
+}
+
+impl InitCommand {
+    pub(super) fn run(self) -> Result<()> {
+        init(Path::new("."), self.bin.as_deref(), self.force)?;
+        println!("created vercel.json");
+        Ok(())
+    }
+}
+
+fn init(root: &Path, binary: Option<&str>, force: bool) -> Result<()> {
+    let config_path = root.join("vercel.json");
+    if config_path.exists() && !force {
+        bail!(
+            "{} already exists; pass `--force` to replace it",
+            config_path.display()
+        );
+    }
+
+    let build_command = binary.map_or_else(
+        || "topcoat-vercel build".to_owned(),
+        |binary| format!("topcoat-vercel build --bin {binary}"),
+    );
+    let install_command = format!(
+        "rustup toolchain install {RUST_VERSION} --profile minimal && \
+         cargo +{RUST_VERSION} install topcoat-vercel --version {} --locked",
+        env!("CARGO_PKG_VERSION")
+    );
+    let config = json!({
+        "$schema": "https://openapi.vercel.sh/vercel.json",
+        "framework": null,
+        "installCommand": install_command,
+        "buildCommand": build_command,
+    });
+    let mut contents = serde_json::to_string_pretty(&config)?;
+    contents.push('\n');
+    fs::write(&config_path, contents)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    add_rust_toolchain(root)?;
+    add_gitignore(root)
+}
+
+fn add_rust_toolchain(root: &Path) -> Result<()> {
+    let path = root.join("rust-toolchain.toml");
+    if path.exists() {
+        return Ok(());
+    }
+    fs::write(
+        path,
+        format!("[toolchain]\nchannel = \"{RUST_VERSION}\"\nprofile = \"minimal\"\n"),
+    )
+    .context("failed to write rust-toolchain.toml")
+}
+
+fn add_gitignore(root: &Path) -> Result<()> {
+    const ENTRY: &str = ".vercel/output/";
+    let path = root.join(".gitignore");
+    let mut contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error).context("failed to read .gitignore"),
+    };
+    if contents.lines().any(|line| line.trim() == ENTRY) {
+        return Ok(());
+    }
+    if !contents.is_empty() && !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push_str(ENTRY);
+    contents.push('\n');
+    fs::write(path, contents).context("failed to update .gitignore")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    struct TempDir(std::path::PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let sequence = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+            let path = env::temp_dir().join(format!(
+                "topcoat-vercel-init-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+
+    #[test]
+    fn writes_build_output_configuration() {
+        let root = TempDir::new();
+        init(&root.0, Some("store"), false).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(root.0.join("vercel.json")).unwrap()).unwrap();
+        assert_eq!(config["buildCommand"], "topcoat-vercel build --bin store");
+        assert!(config.get("outputDirectory").is_none());
+        assert_eq!(
+            fs::read_to_string(root.0.join(".gitignore")).unwrap(),
+            ".vercel/output/\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.0.join("rust-toolchain.toml")).unwrap(),
+            "[toolchain]\nchannel = \"1.95.0\"\nprofile = \"minimal\"\n"
+        );
+    }
+
+    #[test]
+    fn preserves_an_existing_gitignore_entry() {
+        let root = TempDir::new();
+        fs::write(root.0.join(".gitignore"), "target/\n.vercel/output/\n").unwrap();
+
+        init(&root.0, None, false).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(root.0.join(".gitignore")).unwrap(),
+            "target/\n.vercel/output/\n"
+        );
+    }
+}

--- a/crates/topcoat-vercel/src/lib.rs
+++ b/crates/topcoat-vercel/src/lib.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
+
+mod runtime;
+
+pub use runtime::*;
+
+#[cfg(feature = "cli")]
+#[doc(hidden)]
+pub mod cli;

--- a/crates/topcoat-vercel/src/runtime.rs
+++ b/crates/topcoat-vercel/src/runtime.rs
@@ -1,0 +1,63 @@
+use std::{fmt, sync::Arc};
+
+use http_body_util::{BodyExt, StreamBody};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use topcoat_router::{Body, Router};
+use vercel_runtime::{Request, Response, ResponseBody, run as run_runtime, service_fn};
+
+/// An error returned by the Vercel runtime.
+#[derive(Debug)]
+pub struct Error(vercel_runtime::Error);
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
+/// Starts a Topcoat router using the Vercel Rust runtime.
+///
+/// The same entry point works under `vercel dev` and in a deployed Vercel
+/// Function. Response frames are forwarded as they arrive so streaming views
+/// are not buffered.
+///
+/// # Errors
+///
+/// Returns an error if the Vercel runtime cannot start or stops unexpectedly.
+pub async fn run(router: Router) -> Result<(), Error> {
+    let router = Arc::new(router);
+
+    run_runtime(service_fn(move |request| {
+        let router = Arc::clone(&router);
+        async move { handle(router, request).await }
+    }))
+    .await
+    .map_err(Error)
+}
+
+async fn handle(
+    router: Arc<Router>,
+    request: Request,
+) -> Result<Response<ResponseBody>, vercel_runtime::Error> {
+    let response = router.handle(request.map(Body::new)).await;
+    let (parts, mut body) = response.into_parts();
+    let (sender, receiver) = mpsc::channel(10);
+
+    tokio::spawn(async move {
+        while let Some(frame) = body.frame().await {
+            if sender.send(frame).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let body = StreamBody::new(ReceiverStream::new(receiver));
+    Ok(Response::from_parts(parts, body.into()))
+}

--- a/crates/topcoat-view/Cargo.toml
+++ b/crates/topcoat-view/Cargo.toml
@@ -18,6 +18,7 @@ http = [
 [dependencies]
 topcoat-core.workspace = true
 
+futures-util.workspace = true
 http = { workspace = true, optional = true }
 itoa.workspace = true
 memchr.workspace = true
@@ -27,6 +28,7 @@ smallvec.workspace = true
 topcoat = { workspace = true, features = ["view"] }
 
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[bench]]
 name = "render"

--- a/crates/topcoat-view/examples/concurrent_components.rs
+++ b/crates/topcoat-view/examples/concurrent_components.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+#[component]
+async fn card(label: &'static str, delay: Duration) -> Result {
+    println!("starting {label}");
+    tokio::time::sleep(delay).await;
+    println!("finished {label}");
+
+    view! { <article>(label)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            card(label: "first", delay: Duration::from_secs(1))
+            <section>
+                card(label: "second", delay: Duration::from_secs(1))
+            </section>
+        </main>
+    }?;
+
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/examples/concurrent_for.rs
+++ b/crates/topcoat-view/examples/concurrent_for.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
+
+struct Post {
+    title: &'static str,
+    delay: Duration,
+}
+
+#[component]
+async fn post_card(post: Post) -> Result {
+    tokio::time::sleep(post.delay).await;
+    println!("finished {}", post.title);
+
+    view! { <article>(post.title)</article> }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let posts = vec![
+        Post {
+            title: "first",
+            delay: Duration::from_millis(100),
+        },
+        Post {
+            title: "second",
+            delay: Duration::from_millis(50),
+        },
+    ];
+    let cx = Cx::default();
+    let cx = &cx;
+    let page = view! {
+        cx =>
+        <main>
+            for concurrent post in posts {
+                post_card(post: post)
+            }
+        </main>
+    }?;
+
+    // "second" finishes first, but the generated HTML keeps iterator order.
+    println!("{}", page.render(cx));
+    Ok(())
+}

--- a/crates/topcoat-view/grammar/src/template/template_for_loop.rs
+++ b/crates/topcoat-view/grammar/src/template/template_for_loop.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
     Expr, ExprBreak, ExprContinue, Pat, Token,
     parse::{Parse, ParseStream},
@@ -11,10 +11,23 @@ use crate::{
     view::{ViewWriter, WriteView},
 };
 
+mod kw {
+    syn::custom_keyword!(concurrent);
+}
+
+pub use kw::concurrent as ConcurrentToken;
+
+impl ParseOption for ConcurrentToken {
+    fn peek(input: ParseStream) -> bool {
+        input.peek(kw::concurrent)
+    }
+}
+
 /// A `for pat in expr { ... }` loop in view-body position. The body is
 /// rendered once per iteration.
 pub struct TemplateForLoop<T> {
     pub for_token: Token![for],
+    pub concurrent_token: Option<ConcurrentToken>,
     pub pat: Box<Pat>,
     pub in_token: Token![in],
     pub expr: Box<Expr>,
@@ -23,14 +36,26 @@ pub struct TemplateForLoop<T> {
 
 impl<T: WriteView> WriteView for TemplateForLoop<T> {
     fn write(&self, writer: &mut ViewWriter) {
-        writer.for_loop(&self.pat, &self.expr, |writer| {
-            self.body.write(writer);
-        });
+        if self.concurrent_token.is_some() {
+            writer.concurrent_for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        } else {
+            writer.for_loop(&self.pat, &self.expr, |writer| {
+                self.body.write(writer);
+            });
+        }
     }
 }
 
 impl<T: WriteAttribute> WriteAttribute for TemplateForLoop<T> {
     fn write(&self, writer: &mut AttributeWriter) {
+        if let Some(concurrent_token) = &self.concurrent_token {
+            writer.statement(quote_spanned! {concurrent_token.span=>
+                compile_error!("`for concurrent` is only supported in view-body position");
+            });
+            return;
+        }
         writer.for_loop(&self.pat, &self.expr, |writer| {
             self.body.write(writer);
         });
@@ -41,6 +66,7 @@ impl<T: Parse> Parse for TemplateForLoop<T> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(Self {
             for_token: input.parse()?,
+            concurrent_token: input.call(ConcurrentToken::parse_option)?,
             pat: Box::new(input.call(Pat::parse_single)?),
             in_token: input.parse()?,
             expr: Box::new(input.call(Expr::parse_without_eager_brace)?),
@@ -63,6 +89,10 @@ impl<T: topcoat_core_grammar::pretty::PrettyPrint> topcoat_core_grammar::pretty:
     fn pretty_print(&self, printer: &mut topcoat_core_grammar::pretty::Printer<'_>) {
         self.for_token.pretty_print(printer);
         " ".pretty_print(printer);
+        if self.concurrent_token.is_some() {
+            "concurrent".pretty_print(printer);
+            " ".pretty_print(printer);
+        }
         self.pat.pretty_print(printer);
         " ".pretty_print(printer);
         self.in_token.pretty_print(printer);
@@ -185,9 +215,18 @@ mod tests {
     #[test]
     fn parses_simple_for_loop() {
         let loop_ = parse(r"for x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_none());
         assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
         assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
         assert_eq!(loop_.body.children.len(), 1);
+    }
+
+    #[test]
+    fn parses_concurrent_for_loop() {
+        let loop_ = parse(r"for concurrent x in xs { (x) }");
+        assert!(loop_.concurrent_token.is_some());
+        assert_eq!(loop_.pat.to_token_stream().to_string(), "x");
+        assert_eq!(loop_.expr.to_token_stream().to_string(), "xs");
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/component.rs
+++ b/crates/topcoat-view/grammar/src/view/component.rs
@@ -12,7 +12,7 @@ use topcoat_core_grammar::{ParseOption, paths::topcoat_view};
 
 use crate::{
     template::RuntimeExpr,
-    view::{ExprKind, Nodes, ViewWriter, WriteView},
+    view::{Nodes, ViewWriter, WriteView},
 };
 
 /// A component invocation, written as `path(name: value, ..., child_node child_node ...)`.
@@ -90,23 +90,20 @@ impl WriteView for Component {
             }
         });
 
-        writer.write_expr(
-            ExprKind::View,
-            quote_spanned! {self.paren_token.span.span()=>
-                {
-                    use #topcoat_view::Component;
-                    let props = #name::props_builder()#(#setters)*#child.build();
-                    // The marker is built via `Default` so the same construction
-                    // works for both unit-struct and generic (`PhantomData`) markers.
-                    #[allow(clippy::default_constructed_unit_structs)]
-                    Component::render(
-                        #name::default(),
-                        __cx,
-                        props,
-                    ).await?
-                }
-            },
-        );
+        writer.write_component(quote_spanned! {self.paren_token.span.span()=>
+            {
+                use #topcoat_view::Component;
+                let props = #name::props_builder()#(#setters)*#child.build();
+                // The marker is built via `Default` so the same construction
+                // works for both unit-struct and generic (`PhantomData`) markers.
+                #[allow(clippy::default_constructed_unit_structs)]
+                Component::render(
+                    #name::default(),
+                    __cx,
+                    props,
+                )
+            }
+        });
     }
 }
 

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{Expr, Ident, Pat};
 use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 
@@ -70,6 +70,11 @@ impl ViewWriter {
         self.chunks.push(Chunk::Expr { kind, tokens });
     }
 
+    pub fn write_component(&mut self, tokens: TokenStream) {
+        self.flush();
+        self.chunks.push(Chunk::Component { tokens });
+    }
+
     pub fn local_binding(&mut self, pat: &Pat, expr: &Expr) {
         self.flush();
         self.chunks.push(Chunk::Local {
@@ -133,8 +138,67 @@ impl ViewWriter {
             } else {
                 fn build_parts(chunks: &[Chunk]) -> TokenStream {
                     let mut output = TokenStream::new();
-                    for chunk in chunks {
-                        match chunk {
+                    let mut index = 0;
+                    while index < chunks.len() {
+                        // Static markup cannot introduce a dependency between component calls.
+                        if matches!(
+                            &chunks[index],
+                            Chunk::Static { .. } | Chunk::Component { .. }
+                        ) {
+                            let start = index;
+                            while index < chunks.len()
+                                && matches!(
+                                    &chunks[index],
+                                    Chunk::Static { .. } | Chunk::Component { .. }
+                                )
+                            {
+                                index += 1;
+                            }
+                            let region = &chunks[start..index];
+                            let components = region
+                                .iter()
+                                .filter_map(|chunk| match chunk {
+                                    Chunk::Component { tokens } => Some(tokens),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>();
+                            let results = (0..components.len())
+                                .map(|index| format_ident!("__component_result_{index}"))
+                                .collect::<Vec<_>>();
+                            // Avoid joining when there is only one component to await.
+                            let wait = match components.as_slice() {
+                                [] => TokenStream::new(),
+                                [component] => {
+                                    let result = &results[0];
+                                    quote! { let #result = #component.await; }
+                                }
+                                _ => quote! {
+                                    let (#(#results,)*) = __join!(#(#components),*);
+                                },
+                            };
+                            let mut result_index = 0;
+                            let region_parts = region.iter().map(|chunk| match chunk {
+                                Chunk::Static { string } => {
+                                    let helper = ExprKind::Unescaped.helper();
+                                    quote! { #helper(__cx, &mut __parts, #string); }
+                                }
+                                Chunk::Component { .. } => {
+                                    let result = &results[result_index];
+                                    result_index += 1;
+                                    let helper = ExprKind::View.helper();
+                                    quote! { #helper(__cx, &mut __parts, #result?); }
+                                }
+                                _ => unreachable!(),
+                            });
+                            quote! {{
+                                #wait
+                                #(#region_parts)*
+                            }}
+                            .to_tokens(&mut output);
+                            continue;
+                        }
+
+                        match &chunks[index] {
                             Chunk::Static { string } => {
                                 let helper = ExprKind::Unescaped.helper();
                                 let tokens = quote! { #string };
@@ -144,6 +208,7 @@ impl ViewWriter {
                                 let helper = kind.helper();
                                 quote! { #helper(__cx, &mut __parts, #tokens); }
                             }
+                            Chunk::Component { .. } => unreachable!(),
                             Chunk::Local { pat, expr } => {
                                 quote! { let #pat = #expr; }
                             }
@@ -191,6 +256,7 @@ impl ViewWriter {
                             }
                         }
                         .to_tokens(&mut output);
+                        index += 1;
                     }
                     output
                 }
@@ -253,6 +319,9 @@ enum Chunk {
     },
     Expr {
         kind: ExprKind,
+        tokens: TokenStream,
+    },
+    Component {
         tokens: TokenStream,
     },
     Local {
@@ -362,6 +431,19 @@ mod tests {
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"<p>\")"));
         assert!(out.contains("__node (__cx , & mut __parts , value)"));
         assert!(out.contains("__unescaped (__cx , & mut __parts , \"</p>\")"));
+    }
+
+    #[test]
+    fn static_markup_does_not_split_component_join() {
+        let mut writer = ViewWriter::new();
+        writer.write_str_unescaped("<main>");
+        writer.write_component(quote! { first() });
+        writer.write_str_unescaped("<aside>");
+        writer.write_component(quote! { second() });
+        writer.write_str_unescaped("</aside></main>");
+        let out = rendered(writer);
+
+        assert!(out.contains("__join ! (first () , second ())"));
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/view_writer.rs
+++ b/crates/topcoat-view/grammar/src/view/view_writer.rs
@@ -100,6 +100,18 @@ impl ViewWriter {
         });
     }
 
+    pub fn concurrent_for_loop(&mut self, pat: &Pat, expr: &Expr, f: impl FnOnce(&mut ViewWriter)) {
+        self.flush();
+        let mut body = ViewWriter::new();
+        f(&mut body);
+        body.flush();
+        self.chunks.push(Chunk::ConcurrentFor {
+            pat: pat.clone(),
+            expr: Box::new(expr.clone()),
+            body: Box::new(body),
+        });
+    }
+
     pub fn if_else(&mut self, expr: &Expr, f: impl FnOnce(&mut ViewWriter, &mut ViewWriter)) {
         self.flush();
         let mut then_branch = ViewWriter::new();
@@ -239,6 +251,27 @@ impl ViewWriter {
                                     }
                                 }
                             }
+                            Chunk::ConcurrentFor { pat, expr, body } => {
+                                let body = build_parts(&body.chunks);
+                                quote! {
+                                    {
+                                        let __render_iteration = async |#pat| {
+                                            let mut __parts = #topcoat_view::ViewParts::new();
+                                            #body
+                                            ::core::result::Result::<
+                                                #topcoat_view::View,
+                                                #topcoat_error::Error,
+                                            >::Ok(#topcoat_view::View::new(__parts))
+                                        };
+                                        let __iterations = (#expr)
+                                            .into_iter()
+                                            .map(__render_iteration);
+                                        for __iteration in __join_all(__iterations).await {
+                                            __view(__cx, &mut __parts, __iteration?);
+                                        }
+                                    }
+                                }
+                            }
                             Chunk::Match { expr, arms } => {
                                 let arm_tokens = arms.iter().map(|arm| {
                                     let pat = &arm.pat;
@@ -332,6 +365,11 @@ enum Chunk {
         tokens: TokenStream,
     },
     For {
+        pat: Pat,
+        expr: Box<Expr>,
+        body: Box<ViewWriter>,
+    },
+    ConcurrentFor {
         pat: Pat,
         expr: Box<Expr>,
         body: Box<ViewWriter>,
@@ -479,6 +517,18 @@ mod tests {
         });
         let out = rendered(writer);
         assert!(out.contains("for x in xs"));
+    }
+
+    #[test]
+    fn concurrent_for_loop_joins_iteration_futures() {
+        let mut writer = ViewWriter::new();
+        writer.concurrent_for_loop(&syn::parse_quote!(x), &syn::parse_quote!(xs), |body| {
+            body.write_expr(ExprKind::Node, quote! { x });
+        });
+        let out = rendered(writer);
+
+        assert!(out.contains("let __render_iteration = async | x |"));
+        assert!(out.contains("__join_all (__iterations) . await"));
     }
 
     #[test]

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -187,6 +187,26 @@ view! {
 # }
 ```
 
+Use `for concurrent` when iterations perform independent async component work:
+
+```rust
+# use topcoat::{Result, view::*};
+# struct Post { title: &'static str }
+# #[component]
+# async fn post_card(post: Post) -> Result { view! { <article>(post.title)</article> } }
+# #[component]
+# async fn example() -> Result {
+# let posts = vec![Post { title: "A" }, Post { title: "B" }];
+view! {
+    for concurrent post in posts {
+        post_card(post: post)
+    }
+}
+# }
+```
+
+The iterations render concurrently, but their completed views are inserted in iterator order. Use this form only when iterations are independent. An ordinary `for` remains sequential and can mutate or mutably borrow shared state. `for concurrent` is available in view-body position, not in an element's attribute list.
+
 ## `match`
 
 Use `match` to choose markup from patterns. Match arms can also use guards.

--- a/crates/topcoat-view/macro/docs/view.md
+++ b/crates/topcoat-view/macro/docs/view.md
@@ -345,6 +345,10 @@ view! {
 
 See how to define components in the [`component`] macro guide.
 
+Component calls in the same straight-line view body render concurrently. Static HTML between the calls does not split the group, and the completed views are inserted in source order. A Rust expression, local binding, statement, or control-flow construct ends the group because later component props may depend on it.
+
+Each control-flow body forms its own group. An ordinary `for` loop still renders its iterations in order, but peer components within one iteration can render concurrently.
+
 # Boolean And Conditional Attributes
 
 [Boolean HTML attributes](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML) such as `disabled`, `required`, and `checked` are true when the attribute is present and false when it is absent. HTML expects a present boolean attribute to have an empty value.

--- a/crates/topcoat-view/macro/tests/component.rs
+++ b/crates/topcoat-view/macro/tests/component.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use topcoat::{
     Result,
     context::Cx,
@@ -93,6 +95,68 @@ async fn component_can_call_other_components_and_forward_child_views() {
 
     assert!(html.contains("<h2>Outer</h2>"));
     assert!(html.contains("<em>inner</em>"));
+}
+
+#[component]
+async fn concurrent_peer(log: Arc<Mutex<Vec<String>>>, label: &'static str) -> Result {
+    log.lock().unwrap().push(format!("enter {label}"));
+    tokio::task::yield_now().await;
+    log.lock().unwrap().push(format!("exit {label}"));
+
+    view! { <span>(label)</span> }
+}
+
+#[tokio::test]
+async fn peer_components_render_concurrently_across_static_markup() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            <aside>concurrent_peer(log: Arc::clone(&log), label: "b")</aside>
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        ["enter a", "enter b", "exit a", "exit b"],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><aside><span>b</span></aside></main>",
+    );
+}
+
+#[tokio::test]
+async fn control_flow_and_loops_split_concurrent_component_groups() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let result: Result = view! {
+        <main>
+            concurrent_peer(log: Arc::clone(&log), label: "a")
+            if true {
+                <section>concurrent_peer(log: Arc::clone(&log), label: "b")</section>
+            }
+            for label in ["c", "d"] {
+                concurrent_peer(log: Arc::clone(&log), label: label)
+            }
+            concurrent_peer(log: Arc::clone(&log), label: "e")
+        </main>
+    };
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        [
+            "enter a", "exit a", "enter b", "exit b", "enter c", "exit c", "enter d", "exit d",
+            "enter e", "exit e",
+        ],
+    );
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<main><span>a</span><section><span>b</span></section><span>c</span><span>d</span><span>e</span></main>",
+    );
 }
 
 #[component]

--- a/crates/topcoat-view/macro/tests/control_flow.rs
+++ b/crates/topcoat-view/macro/tests/control_flow.rs
@@ -1,4 +1,17 @@
-use topcoat::{context::Cx, view::view};
+use std::{
+    future::poll_fn,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::Poll,
+};
+
+use topcoat::{
+    Result,
+    context::Cx,
+    view::{component, view},
+};
 
 fn r(v: topcoat::Result) -> String {
     v.unwrap().render(&Cx::default())
@@ -101,6 +114,50 @@ async fn for_loop_renders_body_per_item() {
         <ul>
             for title in posts {
                 <li>(title)</li>
+            }
+        </ul>
+    });
+
+    assert_eq!(html, "<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>");
+}
+
+#[component]
+async fn concurrent_loop_item(
+    started: Arc<AtomicUsize>,
+    expected: usize,
+    label: &'static str,
+) -> Result {
+    let mut first_poll = true;
+    poll_fn(|cx| {
+        if first_poll {
+            first_poll = false;
+            started.fetch_add(1, Ordering::SeqCst);
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        } else {
+            assert_eq!(started.load(Ordering::SeqCst), expected);
+            Poll::Ready(())
+        }
+    })
+    .await;
+
+    view! { <li>(label)</li> }
+}
+
+#[tokio::test]
+async fn concurrent_for_loop_polls_iterations_together_and_preserves_order() {
+    let labels = ["alpha", "beta", "gamma"];
+    let started = Arc::new(AtomicUsize::new(0));
+    let cx = &Cx::default();
+    let html = r(view! {
+        cx =>
+        <ul>
+            for concurrent label in labels {
+                concurrent_loop_item(
+                    started: Arc::clone(&started),
+                    expected: labels.len(),
+                    label: label
+                )
             }
         </ul>
     });

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,8 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    use core::future::Future;
+
     pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
@@ -44,6 +46,15 @@ pub mod internal {
     #[inline]
     pub fn __view(_cx: &Cx, parts: &mut ViewParts, view: View) {
         parts.push_view(view);
+    }
+
+    #[inline]
+    pub async fn __join_all<I>(futures: I) -> Vec<<I::Item as Future>::Output>
+    where
+        I: IntoIterator,
+        I::Item: Future,
+    {
+        futures_util::future::join_all(futures).await
     }
 
     #[inline]

--- a/crates/topcoat-view/src/lib.rs
+++ b/crates/topcoat-view/src/lib.rs
@@ -28,6 +28,7 @@ pub use view::*;
 /// Macro helpers to shorten the generated source code.
 #[doc(hidden)]
 pub mod internal {
+    pub use futures_util::join as __join;
     use topcoat_core::context::Cx;
 
     use crate::{

--- a/crates/topcoat-view/src/view.rs
+++ b/crates/topcoat-view/src/view.rs
@@ -68,6 +68,7 @@ impl View {
     /// Panics if a dynamic attribute key or element name in the view contains
     /// a character that could break out of the identifier.
     #[track_caller]
+    #[must_use]
     pub fn render(&self, cx: &Cx) -> String {
         let mut buf = String::with_capacity(self.part.size_hint());
         let mut f = Formatter::new(&mut buf);

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -49,6 +49,7 @@ full = [
 	"tailwind",
 	"tower",
 	"ui",
+	"vercel",
 	"view",
 	"websocket",
 ]
@@ -160,6 +161,11 @@ tower = [
 ui = [
 	"dep:topcoat-ui-registry",
 ]
+vercel = [
+	"router",
+	"serve",
+	"dep:topcoat-vercel",
+]
 view = [
 	"dep:topcoat-view",
 	"dep:topcoat-view-macro",
@@ -193,6 +199,7 @@ topcoat-runtime-macro = { workspace = true, optional = true }
 topcoat-session = { workspace = true, optional = true }
 topcoat-tailwind = { workspace = true, optional = true }
 topcoat-ui-registry = { workspace = true, optional = true }
+topcoat-vercel = { workspace = true, optional = true }
 topcoat-view = { workspace = true, optional = true }
 topcoat-view-macro = { workspace = true, optional = true }
 

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -40,6 +40,7 @@ full = [
 	"mail",
 	"mail-smtp",
 	"multipart",
+	"shell-view",
 	"router",
 	"runtime",
 	"serve",
@@ -115,6 +116,10 @@ multipart = [
 	"router",
 	"topcoat-router/multipart",
 ]
+shell-view = [
+	"dep:topcoat-shell-view",
+	"router",
+]
 router = [
 	"dep:topcoat-router",
 	"dep:topcoat-router-macro",
@@ -180,6 +185,7 @@ topcoat-icon = { workspace = true, optional = true }
 topcoat-icon-macro = { workspace = true, optional = true }
 topcoat-mail = { workspace = true, optional = true }
 topcoat-mail-macro = { workspace = true, optional = true }
+topcoat-shell-view = { workspace = true, optional = true }
 topcoat-router = { workspace = true, optional = true }
 topcoat-router-macro = { workspace = true, optional = true }
 topcoat-runtime = { workspace = true, optional = true }

--- a/crates/topcoat/docs/shell_view.md
+++ b/crates/topcoat/docs/shell_view.md
@@ -1,0 +1,85 @@
+`ShellView` streams a page shell first, then replaces placeholders as deferred views finish. It is useful when a page has a fast container and slower independent sections. Return it from a [`route`](crate::router::route) container; pages, layouts, and components continue to return ordinary views and can be rendered inside that container.
+
+Enable the `shell-view` feature, then build the response around ordinary [`View`](crate::view::View) values:
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    shell_view::ShellView,
+    router::route,
+    view::view,
+};
+
+# async fn load_activity() -> Result<&'static str> { Ok("Signed in") }
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading activity..."</p> }?,
+        |cx| async move {
+            let message = load_activity().await?;
+            let cx = cx.as_ref();
+            view! { cx => <p>(message)</p> }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <h1>"Dashboard"</h1>
+                (activity)
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+```
+
+[`defer`](ShellViewBuilder::defer) returns a normal `View` containing the placeholder. Insert it anywhere a view expression is accepted. The render closure receives an owned [`CxHandle`](crate::context::CxHandle), so request context stays available after the handler returns. Bind `handle.as_ref()` to an identifier when using the explicit `cx =>` form of `view!` inside the closure.
+
+The shell is the first response chunk. Deferred futures start when the response body is polled, run concurrently, and emit replacement scripts in completion order. A slow fragment does not delay a faster one.
+
+# Components
+
+A deferred closure can render components through a nested `view!` call:
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::{component, view}};
+# #[component]
+# async fn recommendations() -> Result { view! { <p>"Recommendations"</p> } }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let mut page = ShellView::builder(cx);
+let recommendations_slot = page.defer(
+    view! { <p>"Finding recommendations..."</p> }?,
+    |cx| async move {
+        let cx = cx.as_ref();
+        view! { cx => recommendations() }
+    },
+);
+
+let shell = view! { cx => <section>(recommendations_slot)</section> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Composition
+
+Shell views compose at their container boundary. Pass a child to [`include`](ShellViewBuilder::include), insert the returned shell into the parent, then finish the parent. The parent adopts the child's deferred work, so all fragments use one response stream.
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::view};
+# async fn sidebar(cx: &Cx) -> Result<ShellView> { Ok(ShellView::from_view(view! { cx => <aside></aside> }?)) }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let child = sidebar(cx).await?;
+let mut page = ShellView::builder(cx);
+let child = page.include(child);
+let shell = view! { cx => <main>(child)</main> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Response behavior
+
+Status codes and headers declared by the shell are applied before streaming begins. Declarations in deferred views cannot change headers that were already sent. Each completed fragment is delivered by a small inline script, so the page's Content Security Policy must allow those scripts.

--- a/crates/topcoat/docs/shell_view.md
+++ b/crates/topcoat/docs/shell_view.md
@@ -41,6 +41,29 @@ async fn home(cx: &Cx) -> Result<ShellView> {
 
 The shell is the first response chunk. Deferred futures start when the response body is polled, run concurrently, and emit replacement scripts in completion order. A slow fragment does not delay a faster one.
 
+# Inline Deferred Components
+
+Use [`shell_view!`] when the deferred work is a component. Write the component after `defer`; the following block is its placeholder:
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::{ShellView, shell_view}, view::{component, view}};
+# #[component]
+# async fn newsfeed() -> Result { view! { <p>"News"</p> } }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+shell_view! {
+    cx =>
+    <section>
+        <h2>"Newsfeed"</h2>
+        defer newsfeed() {
+            <p aria-busy="true">"Loading newsfeed..."</p>
+        }
+    </section>
+}
+# }
+```
+
+The macro creates a `ShellView`, registers every inline deferred component, and inserts each returned placeholder into the surrounding markup. Use the builder form when the deferred future needs logic beyond rendering one component.
+
 # Components
 
 A deferred closure can render components through a nested `view!` call:
@@ -66,7 +89,7 @@ Ok(page.finish(shell))
 
 # Composition
 
-Shell views compose at their container boundary. Pass a child to [`include`](ShellViewBuilder::include), insert the returned shell into the parent, then finish the parent. The parent adopts the child's deferred work, so all fragments use one response stream.
+Shell views compose at their container boundary. Pass a child to [`include`](ShellViewBuilder::include), insert the returned shell into the parent, then finish the parent. The parent adopts the child's deferred work, so all fragments use one response stream. A child built with `shell_view!` composes the same way as one built manually.
 
 ```rust
 # use topcoat::{Result, context::Cx, shell_view::ShellView, view::view};

--- a/crates/topcoat/docs/vercel.md
+++ b/crates/topcoat/docs/vercel.md
@@ -1,0 +1,49 @@
+Run a Topcoat application as a streaming Rust function on [Vercel](https://vercel.com/). The `topcoat-vercel` CLI builds the application using Vercel's Build Output API.
+
+# Setup
+
+Enable the `vercel` feature on the `topcoat` dependency:
+
+```toml
+[dependencies]
+topcoat = { version = "0.5", features = ["vercel"] }
+```
+
+Keep using [`topcoat::start`](crate::start) in the application's existing binary. With the `vercel` feature enabled, it uses the normal Topcoat server locally and the Vercel runtime when deployed:
+
+```rust,no_run
+use topcoat::router::{Router, RouterBuilderDiscoverExt};
+
+#[tokio::main]
+async fn main() {
+    let router = Router::builder().discover().build();
+    topcoat::start(router).await.unwrap();
+}
+```
+
+Install the deployment CLI and initialize the project:
+
+```console
+$ cargo install topcoat-vercel
+$ topcoat-vercel init
+```
+
+If the package contains several binaries, select the application binary during setup:
+
+```console
+$ topcoat-vercel init --bin my-app
+```
+
+The command creates `vercel.json`, pins the supported Rust toolchain when the project does not already select one, and ignores generated deployment output. Existing configuration files are not replaced unless `--force` is passed.
+
+# Deploy
+
+Deploy the project with the Vercel CLI or a connected Git repository. Vercel installs the matching `topcoat-vercel` release and runs `topcoat-vercel build`:
+
+```console
+$ vercel deploy
+```
+
+The build writes a Build Output API v3 deployment to `.vercel/output`. The Topcoat application becomes a streaming Rust function, while bundled assets are copied into Vercel's static file output and also packaged beside the executable so [`AssetBundle::load`](crate::asset::AssetBundle::load) works at startup.
+
+`topcoat-vercel build` currently produces a Linux x86-64 executable and must run in Vercel's Linux build environment. Native builds from other platforms fail with an explanation instead of producing an artifact that cannot run on Vercel.

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -42,6 +42,9 @@ pub mod icon;
 #[cfg(feature = "mail")]
 pub mod mail;
 
+#[cfg(feature = "shell-view")]
+pub mod shell_view;
+
 #[cfg(feature = "router")]
 pub mod router;
 

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -51,8 +51,29 @@ pub mod router;
 #[cfg(feature = "view")]
 pub mod view;
 
+#[cfg(all(feature = "serve", not(feature = "vercel")))]
+pub use serve::start;
 #[cfg(feature = "serve")]
-pub use serve::{serve, serve_until, start};
+pub use serve::{serve, serve_until};
+
+/// Starts a Topcoat router using the current runtime.
+///
+/// Applications with the `vercel` feature use the Vercel runtime when
+/// deployed and the normal Topcoat server locally.
+///
+/// # Errors
+///
+/// Returns an error if the selected runtime cannot start.
+#[cfg(feature = "vercel")]
+pub async fn start(router: router::Router) -> Result<()> {
+    if std::env::var_os("VERCEL_IPC_PATH").is_some()
+        || std::env::var_os("VERCEL_DEV_PORT").is_some()
+    {
+        topcoat_vercel::run(router).await.map_err(Into::into)
+    } else {
+        serve::start(router).await.map_err(Into::into)
+    }
+}
 
 #[cfg(feature = "runtime")]
 pub mod runtime;
@@ -62,6 +83,12 @@ pub mod session;
 
 #[cfg(feature = "tailwind")]
 pub mod tailwind;
+
+#[cfg(feature = "vercel")]
+#[doc = include_str!("../docs/vercel.md")]
+pub mod vercel {
+    pub use topcoat_vercel::{Error, run};
+}
 
 #[doc(hidden)]
 pub mod internal;

--- a/crates/topcoat/src/shell_view.rs
+++ b/crates/topcoat/src/shell_view.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../docs/shell_view.md")]
+
+pub use topcoat_shell_view::*;

--- a/examples/shell-view/Cargo.toml
+++ b/examples/shell-view/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "shell-view"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/examples/shell-view/README.md
+++ b/examples/shell-view/README.md
@@ -1,6 +1,6 @@
 # Shell view
 
-This example streams a dashboard shell with two placeholders, then replaces each placeholder when its component finishes.
+This example builds a page shell with navigation and a nested content shell. The content shell contains three deferred portlets. Activity and recommendations use `ShellViewBuilder::defer`, while the newsfeed uses inline `defer` syntax inside `shell_view!`.
 
 ## Run the example
 
@@ -10,4 +10,4 @@ From the repository root, run:
 cargo run --manifest-path examples/shell-view/Cargo.toml
 ```
 
-Open `http://127.0.0.1:3000/`. The shell appears first, recent activity appears after one second, and recommendations appear after two seconds.
+Open `http://127.0.0.1:3000/`. The page and content shells appear first. Each portlet replaces its placeholder when its component finishes.

--- a/examples/shell-view/README.md
+++ b/examples/shell-view/README.md
@@ -1,0 +1,13 @@
+# Shell view
+
+This example streams a dashboard shell with two placeholders, then replaces each placeholder when its component finishes.
+
+## Run the example
+
+From the repository root, run:
+
+```sh
+cargo run --manifest-path examples/shell-view/Cargo.toml
+```
+
+Open `http://127.0.0.1:3000/`. The shell appears first, recent activity appears after one second, and recommendations appear after two seconds.

--- a/examples/shell-view/src/main.rs
+++ b/examples/shell-view/src/main.rs
@@ -4,7 +4,7 @@ use topcoat::{
     Result,
     context::Cx,
     router::{Router, RouterBuilderDiscoverExt, route},
-    shell_view::ShellView,
+    shell_view::{ShellView, shell_view},
     view::{component, view},
 };
 
@@ -33,15 +33,11 @@ async fn home(cx: &Cx) -> Result<ShellView> {
         },
     );
 
-    let shell = view! {
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <title>"Shell view"</title>
-                topcoat::dev::script()
-            </head>
-            <body>
-                <h1>"Dashboard"</h1>
+    let content = shell_view! {
+        cx =>
+        <main>
+            <h1>"Dashboard"</h1>
+            <div class="portlets">
                 <section>
                     <h2>"Recent activity"</h2>
                     (activity)
@@ -50,6 +46,30 @@ async fn home(cx: &Cx) -> Result<ShellView> {
                     <h2>"Recommendations"</h2>
                     (recommendations_slot)
                 </section>
+                <section>
+                    <h2>"Newsfeed"</h2>
+                    defer newsfeed() {
+                        <p aria-busy="true">"Loading newsfeed..."</p>
+                    }
+                </section>
+            </div>
+        </main>
+    }?;
+    let content = page.include(content);
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>"Shell view"</title>
+                topcoat::dev::script()
+            </head>
+            <body>
+                <nav aria-label="Primary">
+                    <a href="/">"Home"</a>
+                    <a href="/account">"Account"</a>
+                </nav>
+                (content)
             </body>
         </html>
     }?;
@@ -60,6 +80,12 @@ async fn home(cx: &Cx) -> Result<ShellView> {
 async fn recent_activity() -> Result {
     tokio::time::sleep(Duration::from_secs(1)).await;
     view! { <p>"You published a new post."</p> }
+}
+
+#[component]
+async fn newsfeed() -> Result {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    view! { <p>"Here is your news feed."</p> }
 }
 
 #[component]

--- a/examples/shell-view/src/main.rs
+++ b/examples/shell-view/src/main.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{Router, RouterBuilderDiscoverExt, route},
+    shell_view::ShellView,
+    view::{component, view},
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(Router::builder().discover().build())
+        .await
+        .unwrap();
+}
+
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading recent activity..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recent_activity() }
+        },
+    );
+    let recommendations_slot = page.defer(
+        view! { <p aria-busy="true">"Loading recommendations..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recommendations() }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>"Shell view"</title>
+                topcoat::dev::script()
+            </head>
+            <body>
+                <h1>"Dashboard"</h1>
+                <section>
+                    <h2>"Recent activity"</h2>
+                    (activity)
+                </section>
+                <section>
+                    <h2>"Recommendations"</h2>
+                    (recommendations_slot)
+                </section>
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+
+#[component]
+async fn recent_activity() -> Result {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    view! { <p>"You published a new post."</p> }
+}
+
+#[component]
+async fn recommendations() -> Result {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    view! { <p>"Follow the Topcoat release feed."</p> }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -49,6 +49,7 @@ changelog_include = [
     "topcoat-mail",
     "topcoat-mail-grammar",
     "topcoat-mail-macro",
+    "topcoat-shell-view",
     "topcoat-router",
     "topcoat-router-grammar",
     "topcoat-router-macro",
@@ -151,6 +152,11 @@ version_group = "topcoat"
 
 [[package]]
 name = "topcoat-mail-macro"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-shell-view"
 release = true
 version_group = "topcoat"
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -62,6 +62,7 @@ changelog_include = [
     "topcoat-tailwind",
     "topcoat-ui",
     "topcoat-ui-registry",
+    "topcoat-vercel",
     "topcoat-view",
     "topcoat-view-grammar",
     "topcoat-view-macro",
@@ -219,6 +220,11 @@ version_group = "topcoat"
 
 [[package]]
 name = "topcoat-ui-registry"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-vercel"
 release = true
 version_group = "topcoat"
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -50,6 +50,8 @@ changelog_include = [
     "topcoat-mail-grammar",
     "topcoat-mail-macro",
     "topcoat-shell-view",
+    "topcoat-shell-view-grammar",
+    "topcoat-shell-view-macro",
     "topcoat-router",
     "topcoat-router-grammar",
     "topcoat-router-macro",
@@ -157,6 +159,16 @@ version_group = "topcoat"
 
 [[package]]
 name = "topcoat-shell-view"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-shell-view-grammar"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-shell-view-macro"
 release = true
 version_group = "topcoat"
 


### PR DESCRIPTION
## Summary

- Add `topcoat-vercel`, including a streaming Vercel runtime adapter and the `topcoat-vercel init` and `build` commands.
- Generate Vercel Build Output API v3 functions and static assets directly, including streaming function metadata and bundled Topcoat assets.
- Keep application startup runtime-neutral through `topcoat::start`, and add setup/deployment documentation plus CLI tests.

This draft follows #287. Until the preceding drafts land, GitHub also shows their prerequisite commits in this PR.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`
- Deployed and exercised the kitchen-sink demo on Vercel, including streamed shell replacements and static assets.

## AI disclosure

OpenAI Codex (GPT-5) helped implement, test, and prepare this change for review.