### PR TITLE
feat(shell-view): add streaming shell responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Topcoat is a Cargo workspace. The framework crates live in `crates/`, runnable e
 - `topcoat-cookie`: the cookie jar, `cookie!` macro, signed/private jars, and `CookieStore<T>`.
 - `topcoat-session`: bring-your-own-storage session authentication: the token/hash model, the session lifecycle, and origin checking.
 - `topcoat-mail`: the `Mail` type and `mail!` macro for declaring mail, and its delivery through pluggable transports (SMTP, file, in-memory).
+- `topcoat-shell-view`: streaming HTML containers that replace placeholders as deferred views finish.
 - `topcoat-htmx`, `topcoat-alpine-ajax`, and `topcoat-datastar`: request and response helpers for those client libraries.
 - `topcoat-tailwind`: the build-script wrapper around the standalone Tailwind CLI.
 - `topcoat-ui` (+ `registry/`): the component registry behind `topcoat ui`, which copies component source into a project.
@@ -50,6 +51,7 @@ Each crate's `docs/` directory holds the user-facing guides for that crate, embe
 - [`crates/topcoat-view/macro/docs/attributes.md`](crates/topcoat-view/macro/docs/attributes.md): The `attributes!` macro and the runtime `Attributes` value for building/forwarding attribute collections.
 - [`crates/topcoat-view/macro/docs/class.md`](crates/topcoat-view/macro/docs/class.md): The `class!` macro: assembling a space-separated class list from static and conditional entries.
 - [`crates/topcoat-view/macro/docs/props.md`](crates/topcoat-view/macro/docs/props.md): The `props!` macro for building a component's props value.
+- [`crates/topcoat/docs/shell_view.md`](crates/topcoat/docs/shell_view.md): `ShellView` streaming responses, deferred placeholders, components, and composition.
 
 ### UI components
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,6 +2307,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-view"
+version = "0.5.0"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2795,7 @@ dependencies = [
  "topcoat-runtime",
  "topcoat-runtime-macro",
  "topcoat-session",
+ "topcoat-shell-view",
  "topcoat-tailwind",
  "topcoat-ui-registry",
  "topcoat-view",
@@ -3157,6 +3166,23 @@ dependencies = [
  "topcoat-core",
  "topcoat-router",
  "web-time",
+]
+
+[[package]]
+name = "topcoat-shell-view"
+version = "0.5.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "serde_json",
+ "tokio",
+ "topcoat",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/topcoat-mail",
     "crates/topcoat-mail/grammar",
     "crates/topcoat-mail/macro",
+    "crates/topcoat-shell-view",
     "crates/topcoat-router",
     "crates/topcoat-router/grammar",
     "crates/topcoat-router/macro",
@@ -48,6 +49,7 @@ members = [
     "examples/manual-router",
     "examples/module-router",
     "examples/path-query-params",
+    "examples/shell-view",
     "examples/procedure",
     "examples/request-response",
     "examples/runtime",
@@ -127,6 +129,7 @@ topcoat-icon-macro = { version = "0.5.0", path = "crates/topcoat-icon/macro" }
 topcoat-mail = { version = "0.5.0", path = "crates/topcoat-mail" }
 topcoat-mail-grammar = { version = "0.5.0", path = "crates/topcoat-mail/grammar" }
 topcoat-mail-macro = { version = "0.5.0", path = "crates/topcoat-mail/macro" }
+topcoat-shell-view = { version = "0.5.0", path = "crates/topcoat-shell-view" }
 topcoat-router = { version = "0.5.0", path = "crates/topcoat-router" }
 topcoat-router-grammar = { version = "0.5.0", path = "crates/topcoat-router/grammar" }
 topcoat-router-macro = { version = "0.5.0", path = "crates/topcoat-router/macro" }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ view! { <link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())> }
 **Rendering**
 - [The `view!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.view.html): templating syntax, control flow, conditional attributes.
 - [The `#[component]` macro](https://docs.rs/topcoat/latest/topcoat/view/attr.component.html): async functions as components, with child content.
+- [`ShellView`](https://docs.rs/topcoat/latest/topcoat/shell_view/index.html): stream placeholders first and replace them as deferred views finish.
 - [The `attributes!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.attributes.html): reusable runtime attribute fragments.
 - [The `class!` macro](https://docs.rs/topcoat/latest/topcoat/view/macro.class.html): space-separated class lists from static and conditional entries.
 

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -19,9 +19,9 @@ use crate::{abort::AbortStore, memoize::MemoizeCache};
 pub struct Cx {
     id: CxId,
     app_context: Arc<ContextMap>,
-    request_context: ContextMap,
-    memoize_cache: MemoizeCache,
-    abort_store: AbortStore,
+    request_context: Arc<ContextMap>,
+    memoize_cache: Arc<MemoizeCache>,
+    abort_store: Arc<AbortStore>,
 }
 
 impl Cx {
@@ -30,16 +30,59 @@ impl Cx {
         Self {
             id: CxId::new(),
             app_context,
-            request_context,
-            memoize_cache: MemoizeCache::new(),
-            abort_store: AbortStore::new(),
+            request_context: Arc::new(request_context),
+            memoize_cache: Arc::new(MemoizeCache::new()),
+            abort_store: Arc::new(AbortStore::new()),
         }
     }
 
     /// Returns this context's unique [`CxId`].
     #[inline]
+    #[must_use]
     pub fn id(&self) -> CxId {
         self.id
+    }
+
+    /// Returns an owned handle to this request context.
+    ///
+    /// The handle keeps request and app context values alive for work that
+    /// continues while a streaming response is sent.
+    #[must_use]
+    pub fn handle(&self) -> CxHandle {
+        CxHandle(Self {
+            id: self.id,
+            app_context: Arc::clone(&self.app_context),
+            request_context: Arc::clone(&self.request_context),
+            memoize_cache: Arc::clone(&self.memoize_cache),
+            abort_store: Arc::clone(&self.abort_store),
+        })
+    }
+}
+
+/// An owned handle to a request [`Cx`].
+///
+/// This is useful for response streams and other work that must own the
+/// request context. It dereferences to `Cx`, so context helpers accept `&handle`.
+#[derive(Debug)]
+pub struct CxHandle(Cx);
+
+impl Clone for CxHandle {
+    fn clone(&self) -> Self {
+        self.0.handle()
+    }
+}
+
+impl AsRef<Cx> for CxHandle {
+    fn as_ref(&self) -> &Cx {
+        &self.0
+    }
+}
+
+impl Deref for CxHandle {
+    type Target = Cx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -71,11 +114,18 @@ impl CxBuilder {
     ///
     /// A type can hold only one value at a time, so registering a type that is
     /// already present replaces it and hands back the displaced value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     pub fn insert<T>(&mut self, value: T) -> Option<T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.insert(value)
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .insert(value)
     }
 
     /// Returns `true` if a value of type `T` has been registered on the request
@@ -100,12 +150,19 @@ impl CxBuilder {
 
     /// Returns a mutable reference to the request context value of type `T`, or
     /// `None` if no such value has been registered.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a [`CxHandle`] was created from this builder before the
+    /// request context finished building.
     #[must_use]
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.get_mut::<T>()
+        Arc::get_mut(&mut self.cx.request_context)
+            .expect("request context was shared before it was built")
+            .get_mut::<T>()
     }
 
     /// Consumes the builder, returning the finished [`Cx`].
@@ -169,12 +226,14 @@ impl CxTestBuilder {
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn memoize_cache(cx: &Cx) -> &MemoizeCache {
     &cx.memoize_cache
 }
 
 #[inline]
 #[doc(hidden)]
+#[must_use]
 pub fn abort_store(cx: &Cx) -> &AbortStore {
     &cx.abort_store
 }

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -66,6 +66,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn app_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,
@@ -131,6 +132,7 @@ where
 /// }
 /// ```
 #[track_caller]
+#[must_use]
 pub fn request_context<T>(cx: &Cx) -> &T
 where
     T: Any + Send + Sync,

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -78,6 +78,7 @@ impl PageFn {
     }
 
     /// Renders the page, returning a [`Result`].
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,
@@ -124,6 +125,7 @@ impl LayoutFn {
     }
 
     /// Renders the layout, embedding the given child content [`Result`]`<`[`View`]`>` as its slot.
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,

--- a/crates/topcoat-shell-view/Cargo.toml
+++ b/crates/topcoat-shell-view/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "topcoat-shell-view"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+topcoat-core.workspace = true
+topcoat-router.workspace = true
+topcoat-view = { workspace = true, features = ["http"] }
+
+bytes.workspace = true
+futures-util.workspace = true
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/topcoat-shell-view/src/lib.rs
+++ b/crates/topcoat-shell-view/src/lib.rs
@@ -1,0 +1,343 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use bytes::Bytes;
+use futures_util::{
+    StreamExt as _,
+    stream::{self, FuturesUnordered},
+};
+use http::{HeaderValue, header::CONTENT_TYPE};
+use http_body::Frame;
+use http_body_util::StreamBody;
+use topcoat_core::{
+    context::{Cx, CxHandle},
+    error::Result,
+};
+use topcoat_router::{
+    Body,
+    response::{IntoResponse, Response},
+};
+use topcoat_view::{HtmlContext, PartsWriter, View, ViewParts};
+
+type DeferredFuture = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'static>>;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+const HTML: HeaderValue = HeaderValue::from_static("text/html; charset=utf-8");
+
+/// Builds a streaming [`ShellView`] from a normal view shell and deferred views.
+pub struct ShellViewBuilder {
+    cx: CxHandle,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellViewBuilder {
+    /// Defers a view and returns its placeholder for insertion into the shell.
+    ///
+    /// `render` receives an owned request context handle. Its future starts
+    /// when the response body is polled, and all deferred futures are polled
+    /// concurrently. Completed views replace their placeholders immediately.
+    pub fn defer<F, Fut>(&mut self, placeholder: View, render: F) -> View
+    where
+        F: FnOnce(CxHandle) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<View>> + Send + 'static,
+    {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let cx = self.cx.clone();
+        self.deferred.push(Box::pin(async move {
+            let view = render(cx.clone()).await?;
+            Ok(Bytes::from(patch(id, &view.render(&cx))))
+        }));
+        placeholder_view(id, placeholder)
+    }
+
+    /// Inserts a child shell view and adopts its deferred work.
+    ///
+    /// Put the returned shell view into the parent shell. Deferred fragments
+    /// from both views then share the same response stream.
+    #[must_use]
+    pub fn include(&mut self, child: ShellView) -> View {
+        self.deferred.extend(child.deferred);
+        child.shell
+    }
+
+    /// Finishes the builder with the view sent as the first response chunk.
+    #[must_use]
+    pub fn finish(self, shell: View) -> ShellView {
+        ShellView {
+            shell,
+            deferred: self.deferred,
+        }
+    }
+}
+
+/// An HTML response that streams deferred views into placeholders.
+pub struct ShellView {
+    shell: View,
+    deferred: Vec<DeferredFuture>,
+}
+
+impl ShellView {
+    /// Starts a shell view builder for `cx`.
+    #[must_use]
+    pub fn builder(cx: &Cx) -> ShellViewBuilder {
+        ShellViewBuilder {
+            cx: cx.handle(),
+            deferred: Vec::new(),
+        }
+    }
+
+    /// Creates a shell view with no deferred fragments.
+    #[must_use]
+    pub fn from_view(view: View) -> Self {
+        Self {
+            shell: view,
+            deferred: Vec::new(),
+        }
+    }
+}
+
+impl IntoResponse for ShellView {
+    fn into_response(self, cx: &Cx) -> Result<Response> {
+        let rendered = self.shell.render_response(cx);
+        let initial = stream::once(async move {
+            Ok::<_, topcoat_core::error::Error>(Frame::data(Bytes::from(rendered.html)))
+        });
+        let deferred = self
+            .deferred
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .map(|result| result.map(Frame::data));
+        let body = Body::new(StreamBody::new(initial.chain(deferred)));
+        let mut response = Response::new(body);
+        *response.status_mut() = rendered.status_code.unwrap_or_default();
+        response.headers_mut().insert(CONTENT_TYPE, HTML);
+        response.headers_mut().extend(rendered.headers);
+        Ok(response)
+    }
+}
+
+fn placeholder_view(id: u64, placeholder: View) -> View {
+    let mut parts = ViewParts::new();
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped(format!(
+        r#"<topcoat-shell id="topcoat-shell-{id}" style="display: contents">"#,
+    ));
+    parts.push_view(placeholder);
+    PartsWriter::new(&mut parts, HtmlContext::Unescaped).push_str_unescaped("</topcoat-shell>");
+    View::new(parts)
+}
+
+fn patch(id: u64, html: &str) -> String {
+    let html = serde_json::to_string(html)
+        .expect("serializing a string cannot fail")
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026");
+    format!(
+        r#"<script>(()=>{{const p=document.getElementById("topcoat-shell-{id}");if(!p)return;const t=document.createElement("template");t.innerHTML={html};p.replaceWith(t.content)}})()</script>"#,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::{pending, poll_fn},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::Poll,
+        time::Duration,
+    };
+
+    use futures_util::StreamExt as _;
+    use topcoat::{
+        context::{Cx, request_context},
+        router::{response::IntoResponse as _, to_bytes},
+        shell_view::ShellView,
+        view::view,
+    };
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn streams_shell_then_fragments_in_completion_order() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let mut page = ShellView::builder(&cx);
+
+        let slow_completed = Arc::clone(&completed);
+        let slow = page.defer(
+            view! { cx_ref => <p>"slow placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                slow_completed.lock().unwrap().push("slow");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"slow result"</p> }
+            },
+        );
+        let fast_completed = Arc::clone(&completed);
+        let fast = page.defer(
+            view! { cx_ref => <p>"fast placeholder"</p> }.unwrap(),
+            move |cx| async move {
+                fast_completed.lock().unwrap().push("fast");
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>"fast result"</p> }
+            },
+        );
+        let response = page
+            .finish(
+                view! {
+                    cx_ref =>
+                    <main>
+                        (slow)
+                        (fast)
+                    </main>
+                }
+                .unwrap(),
+            )
+            .into_response(&cx)
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+
+        let shell = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(shell.contains("slow placeholder"));
+        assert!(shell.contains("fast placeholder"));
+
+        let first_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(first_patch.contains("fast result"));
+        let second_patch = String::from_utf8(body.next().await.unwrap().unwrap().to_vec()).unwrap();
+        assert!(second_patch.contains("slow result"));
+        assert_eq!(*completed.lock().unwrap(), ["fast", "slow"]);
+    }
+
+    #[tokio::test]
+    async fn deferred_view_keeps_request_context_alive() {
+        struct Name(&'static str);
+
+        let cx = topcoat::context::CxTestBuilder::new()
+            .request_context(Name("Ada"))
+            .build();
+        let cx_ref = &cx;
+        let mut page = ShellView::builder(&cx);
+        let greeting = page.defer(view! { cx_ref => "Loading" }.unwrap(), |cx| async move {
+            let name = request_context::<Name>(&cx).0;
+            let cx_ref = cx.as_ref();
+            view! {
+                cx_ref =>
+                <p>
+                    "Hello, "
+                    (name)
+                </p>
+            }
+        });
+        let response = page
+            .finish(view! { cx_ref => (greeting) }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Hello, "));
+        assert!(html.contains("Ada"));
+    }
+
+    #[tokio::test]
+    async fn dropping_response_cancels_deferred_views() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let dropped = Arc::new(AtomicBool::new(false));
+        let mut page = ShellView::builder(&cx);
+        let future_dropped = Arc::clone(&dropped);
+        let slot = page.defer(
+            view! { cx_ref => "Loading" }.unwrap(),
+            move |_cx| async move {
+                let _drop_flag = DropFlag(future_dropped);
+                pending::<()>().await;
+                unreachable!()
+            },
+        );
+        let response = page
+            .finish(view! { cx_ref => (slot) }.unwrap())
+            .into_response(&cx)
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+
+        body.next().await.unwrap().unwrap();
+        poll_fn(|cx| {
+            assert!(body.poll_next_unpin(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        assert!(!dropped.load(Ordering::SeqCst));
+
+        drop(body);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    async fn shell_section(cx: &Cx, label: &'static str) -> topcoat::Result<ShellView> {
+        let cx_ref = cx;
+        let mut child = ShellView::builder(cx);
+        let child_slot = child.defer(
+            view! { cx_ref => <p>(format!("{label} loading"))</p> }?,
+            move |cx| async move {
+                let cx_ref = cx.as_ref();
+                view! { cx_ref => <p>(format!("{label} ready"))</p> }
+            },
+        );
+        Ok(child.finish(view! { cx_ref => <section>(child_slot)</section> }?))
+    }
+
+    #[tokio::test]
+    async fn includes_multiple_shell_view_containers() {
+        let cx = Cx::default();
+        let cx_ref = &cx;
+        let activity = shell_section(&cx, "activity").await.unwrap();
+        let recommendations = shell_section(&cx, "recommendations").await.unwrap();
+
+        let mut parent = ShellView::builder(&cx);
+        let activity = parent.include(activity);
+        let recommendations = parent.include(recommendations);
+        let response = parent
+            .finish(
+                view! {
+                    cx_ref =>
+                    <main>
+                        (activity)
+                        (recommendations)
+                    </main>
+                }
+                .unwrap(),
+            )
+            .into_response(&cx)
+            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+
+        assert_eq!(html.matches("<section>").count(), 2);
+        assert!(html.contains("activity loading"));
+        assert!(html.contains("recommendations loading"));
+        assert!(html.contains("activity ready"));
+        assert!(html.contains("recommendations ready"));
+    }
+
+    #[test]
+    fn patch_html_cannot_close_its_script() {
+        let patch = super::patch(7, "</script><script>alert('xss')</script>");
+
+        assert!(!patch.contains("</script><script>"));
+        assert!(patch.contains(r"\u003c/script\u003e"));
+    }
+}

--- a/crates/topcoat-view/src/view.rs
+++ b/crates/topcoat-view/src/view.rs
@@ -68,6 +68,7 @@ impl View {
     /// Panics if a dynamic attribute key or element name in the view contains
     /// a character that could break out of the identifier.
     #[track_caller]
+    #[must_use]
     pub fn render(&self, cx: &Cx) -> String {
         let mut buf = String::with_capacity(self.part.size_hint());
         let mut f = Formatter::new(&mut buf);

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -40,6 +40,7 @@ full = [
 	"mail",
 	"mail-smtp",
 	"multipart",
+	"shell-view",
 	"router",
 	"runtime",
 	"serve",
@@ -115,6 +116,10 @@ multipart = [
 	"router",
 	"topcoat-router/multipart",
 ]
+shell-view = [
+	"dep:topcoat-shell-view",
+	"router",
+]
 router = [
 	"dep:topcoat-router",
 	"dep:topcoat-router-macro",
@@ -180,6 +185,7 @@ topcoat-icon = { workspace = true, optional = true }
 topcoat-icon-macro = { workspace = true, optional = true }
 topcoat-mail = { workspace = true, optional = true }
 topcoat-mail-macro = { workspace = true, optional = true }
+topcoat-shell-view = { workspace = true, optional = true }
 topcoat-router = { workspace = true, optional = true }
 topcoat-router-macro = { workspace = true, optional = true }
 topcoat-runtime = { workspace = true, optional = true }

--- a/crates/topcoat/docs/shell_view.md
+++ b/crates/topcoat/docs/shell_view.md
@@ -1,0 +1,85 @@
+`ShellView` streams a page shell first, then replaces placeholders as deferred views finish. It is useful when a page has a fast container and slower independent sections. Return it from a [`route`](crate::router::route) container; pages, layouts, and components continue to return ordinary views and can be rendered inside that container.
+
+Enable the `shell-view` feature, then build the response around ordinary [`View`](crate::view::View) values:
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    shell_view::ShellView,
+    router::route,
+    view::view,
+};
+
+# async fn load_activity() -> Result<&'static str> { Ok("Signed in") }
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading activity..."</p> }?,
+        |cx| async move {
+            let message = load_activity().await?;
+            let cx = cx.as_ref();
+            view! { cx => <p>(message)</p> }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <body>
+                <h1>"Dashboard"</h1>
+                (activity)
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+```
+
+[`defer`](ShellViewBuilder::defer) returns a normal `View` containing the placeholder. Insert it anywhere a view expression is accepted. The render closure receives an owned [`CxHandle`](crate::context::CxHandle), so request context stays available after the handler returns. Bind `handle.as_ref()` to an identifier when using the explicit `cx =>` form of `view!` inside the closure.
+
+The shell is the first response chunk. Deferred futures start when the response body is polled, run concurrently, and emit replacement scripts in completion order. A slow fragment does not delay a faster one.
+
+# Components
+
+A deferred closure can render components through a nested `view!` call:
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::{component, view}};
+# #[component]
+# async fn recommendations() -> Result { view! { <p>"Recommendations"</p> } }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let mut page = ShellView::builder(cx);
+let recommendations_slot = page.defer(
+    view! { <p>"Finding recommendations..."</p> }?,
+    |cx| async move {
+        let cx = cx.as_ref();
+        view! { cx => recommendations() }
+    },
+);
+
+let shell = view! { cx => <section>(recommendations_slot)</section> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Composition
+
+Shell views compose at their container boundary. Pass a child to [`include`](ShellViewBuilder::include), insert the returned shell into the parent, then finish the parent. The parent adopts the child's deferred work, so all fragments use one response stream.
+
+```rust
+# use topcoat::{Result, context::Cx, shell_view::ShellView, view::view};
+# async fn sidebar(cx: &Cx) -> Result<ShellView> { Ok(ShellView::from_view(view! { cx => <aside></aside> }?)) }
+# async fn example(cx: &Cx) -> Result<ShellView> {
+let child = sidebar(cx).await?;
+let mut page = ShellView::builder(cx);
+let child = page.include(child);
+let shell = view! { cx => <main>(child)</main> }?;
+Ok(page.finish(shell))
+# }
+```
+
+# Response behavior
+
+Status codes and headers declared by the shell are applied before streaming begins. Declarations in deferred views cannot change headers that were already sent. Each completed fragment is delivered by a small inline script, so the page's Content Security Policy must allow those scripts.

--- a/crates/topcoat/src/lib.rs
+++ b/crates/topcoat/src/lib.rs
@@ -42,6 +42,9 @@ pub mod icon;
 #[cfg(feature = "mail")]
 pub mod mail;
 
+#[cfg(feature = "shell-view")]
+pub mod shell_view;
+
 #[cfg(feature = "router")]
 pub mod router;
 

--- a/crates/topcoat/src/shell_view.rs
+++ b/crates/topcoat/src/shell_view.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../docs/shell_view.md")]
+
+pub use topcoat_shell_view::*;

--- a/examples/shell-view/Cargo.toml
+++ b/examples/shell-view/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "shell-view"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+topcoat = { workspace = true, features = ["shell-view"] }
+
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/examples/shell-view/README.md
+++ b/examples/shell-view/README.md
@@ -1,0 +1,13 @@
+# Shell view
+
+This example streams a dashboard shell with two placeholders, then replaces each placeholder when its component finishes.
+
+## Run the example
+
+From the repository root, run:
+
+```sh
+cargo run --manifest-path examples/shell-view/Cargo.toml
+```
+
+Open `http://127.0.0.1:3000/`. The shell appears first, recent activity appears after one second, and recommendations appear after two seconds.

--- a/examples/shell-view/src/main.rs
+++ b/examples/shell-view/src/main.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{Router, RouterBuilderDiscoverExt, route},
+    shell_view::ShellView,
+    view::{component, view},
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(Router::builder().discover().build())
+        .await
+        .unwrap();
+}
+
+#[route(GET "/")]
+async fn home(cx: &Cx) -> Result<ShellView> {
+    let mut page = ShellView::builder(cx);
+    let activity = page.defer(
+        view! { <p aria-busy="true">"Loading recent activity..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recent_activity() }
+        },
+    );
+    let recommendations_slot = page.defer(
+        view! { <p aria-busy="true">"Loading recommendations..."</p> }?,
+        |cx| async move {
+            let cx = cx.as_ref();
+            view! { cx => recommendations() }
+        },
+    );
+
+    let shell = view! {
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>"Shell view"</title>
+                topcoat::dev::script()
+            </head>
+            <body>
+                <h1>"Dashboard"</h1>
+                <section>
+                    <h2>"Recent activity"</h2>
+                    (activity)
+                </section>
+                <section>
+                    <h2>"Recommendations"</h2>
+                    (recommendations_slot)
+                </section>
+            </body>
+        </html>
+    }?;
+    Ok(page.finish(shell))
+}
+
+#[component]
+async fn recent_activity() -> Result {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    view! { <p>"You published a new post."</p> }
+}
+
+#[component]
+async fn recommendations() -> Result {
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    view! { <p>"Follow the Topcoat release feed."</p> }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -49,6 +49,7 @@ changelog_include = [
     "topcoat-mail",
     "topcoat-mail-grammar",
     "topcoat-mail-macro",
+    "topcoat-shell-view",
     "topcoat-router",
     "topcoat-router-grammar",
     "topcoat-router-macro",
@@ -151,6 +152,11 @@ version_group = "topcoat"
 
 [[package]]
 name = "topcoat-mail-macro"
+release = true
+version_group = "topcoat"
+
+[[package]]
+name = "topcoat-shell-view"
 release = true
 version_group = "topcoat"
 


### PR DESCRIPTION
## What this adds

`ShellView` is an opt-in streaming response for pages with a fast outer shell and slower independent sections. It sends the shell and loading placeholders immediately, then streams each completed section into its placeholder.

Try the [kitchen-sink demo](https://topcoat-kitchen-sink-demo.vercel.app/) to compare blocking rendering, concurrent rendering, and shell-first streaming.

Pages, layouts, and components still return ordinary `View` values. A route uses `ShellView::builder` only at the streaming boundary:

```rust
#[route(GET "/")]
async fn home(cx: &Cx) -> Result<ShellView> {
    let mut page = ShellView::builder(cx);
    let activity = page.defer(
        view! { <p aria-busy="true">"Loading activity..."</p> }?,
        |cx| async move {
            let cx = cx.as_ref();
            view! { cx => recent_activity() }
        },
    );

    let shell = view! {
        cx =>
        <main>
            <h1>"Dashboard"</h1>
            (activity)
        </main>
    }?;

    Ok(page.finish(shell))
}
```

`defer` registers a future and returns a normal `View` containing its placeholder. The placeholder can be inserted anywhere a view expression is accepted.

## Response lifecycle

1. The first response chunk contains the complete shell with placeholders.
2. Deferred futures start when the response body is polled.
3. The futures run concurrently.
4. Each completed view is sent as a small script that replaces its placeholder. Patches are emitted in completion order, so a fast section is not blocked by a slow one.

The response body owns the deferred futures. Dropping the body, including after a client disconnect, drops pending futures. A timeout must cover the body stream if it should limit work after response headers have been sent.

Status codes and headers come from the shell because deferred views finish after headers may already be on the wire.

## Composition and context

`ShellViewBuilder::include` nests shell views by inserting the child shell and transferring the child's deferred work to the parent response stream.

Multiple container functions can each return a `ShellView`, then a parent can combine them into one stream:

```rust
async fn dashboard(cx: &Cx) -> Result<ShellView> {
    let activity = activity_panel(cx).await?;
    let recommendations = recommendations_panel(cx).await?;

    let mut page = ShellView::builder(cx);
    let activity = page.include(activity);
    let recommendations = page.include(recommendations);

    let shell = view! {
        cx =>
        <main>
            (activity)
            (recommendations)
        </main>
    }?;

    Ok(page.finish(shell))
}
```

Each child keeps its own shell and placeholders. `include` moves both children's deferred futures into the parent, so all deferred sections run concurrently and emit patches through the same response body.

Deferred futures must outlive the route handler. `CxHandle` provides an owned handle to the same request context so context values remain available while the response is streaming.

## Future work

This PR is limited to the runtime behavior and builder API. It leaves syntax and broader component integration to follow-up work.

### Shell-aware syntax

A `shell_view!` macro could create the builder and lower inline `defer` declarations automatically:

```rust
shell_view! {
    cx =>
    <main>
        <h1>"Dashboard"</h1>
        defer recent_activity() {
            <p aria-busy="true">"Loading activity..."</p>
        }
        defer recommendations() {
            <p aria-busy="true">"Loading recommendations..."</p>
        }
    </main>
}
```

Each `defer component() { placeholder }` would register on the generated builder, removing manual `builder`, `defer`, and `finish` calls.

The macro could later become shell-aware for ordinary component calls too. Components returning `ShellView` could be adopted automatically, making `include` an implementation detail:

```rust
#[component]
async fn activity_panel() -> Result<ShellView> {
    shell_view! {
        <section>
            defer recent_activity() {
                <p aria-busy="true">"Loading activity..."</p>
            }
        </section>
    }
}

shell_view! {
    cx =>
    <main>
        activity_panel()
        recommendations_panel()
    </main>
}
```

This requires more than token rewriting. Components currently always return `View`, and procedural macros cannot inspect an expression's resolved Rust type. Automatic composition would need a generic component output plus shell-aware lowering, or a unified render type.

### Make every view stream-capable

A larger follow-up could replace the `View`/`ShellView` split with one stream-capable type. A view with no deferred work would behave like today's `View`; a view with deferred work would carry its shell and deferred futures. Components, pages, and layouts could all return that type, and nesting would merge deferred work automatically.

That model would let any component use this technology without changing the container at each composition boundary. It could also preserve the familiar `view!` name instead of requiring callers to choose between two view macros.

The tradeoff is a much broader change: the component trait and routing contracts would change, streaming concerns would move into the base view layer, the optional feature boundary would need reconsideration, and nested status/header behavior would need a precise contract. A generic `Component::Output` that supports both `View` and `ShellView` is a smaller intermediate option.

### CSP-friendly patches with htmx

The current patch format uses inline scripts to replace placeholders. A follow-up integration could instead emit htmx out-of-band fragments with `hx-swap-oob`, allowing htmx to apply completed views without inline JavaScript:

```html
<section id="activity" hx-swap-oob="outerHTML">
    <!-- completed activity view -->
</section>
```

This could support applications whose Content Security Policy blocks inline scripts. It should remain an optional htmx transport rather than making the core streaming type depend on htmx. The design would also need to verify how incremental response chunks are processed and define behavior when the htmx runtime is absent.

None of this future work is included here. Keeping it separate lets the streaming, ownership, cancellation, and composition model be reviewed before committing to syntax or a universal view type.

## Testing

- `cargo +nightly fmt --all`
- `cargo topcoat fmt`
- `cargo test -p topcoat-shell-view`

The focused tests cover shell-first delivery, completion-order patches, request context lifetime, cancellation, nested shell views, and safe script escaping.

## AI disclosure

OpenAI Codex (GPT-5) helped implement, test, and prepare this change for review.
