### PR TITLE
docs: add Topcoat application skills

### DIFF
--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: check
 description: Always use this skill to verify a change locally before committing or opening a pull request in the Topcoat repository
+metadata:
+  internal: true
 ---
 
 # Verifying a Change

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit
 description: Always use this skill before authoring a commit message in the Topcoat repository
+metadata:
+  internal: true
 ---
 
 # Authoring Commit Messages

--- a/.agents/skills/macro/SKILL.md
+++ b/.agents/skills/macro/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: macro
 description: Always use this skill before writing procedural macros for Topcoat
+metadata:
+  internal: true
 ---
 
 ## AST nodes

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr
 description: Always use this skill before opening a pull request in the Topcoat repository
+metadata:
+  internal: true
 ---
 
 # Opening Pull Requests

--- a/.agents/skills/prose/SKILL.md
+++ b/.agents/skills/prose/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: prose
 description: Always use this skill before writing long form markdown documentation for Topcoat.
+metadata:
+  internal: true
 ---
 
 # Prose

--- a/.agents/skills/style/SKILL.md
+++ b/.agents/skills/style/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: style
 description: Always use this skill before writing or editing Rust code or documentation in the Topcoat repository
+metadata:
+  internal: true
 ---
 
 # Code Style

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,25 @@
+# Topcoat skills
+
+This directory contains agent skills for building applications with [Topcoat](https://github.com/tokio-rs/topcoat). A skill is a reusable set of instructions in a `SKILL.md` file that gives a coding agent framework-specific context and working conventions.
+
+The skills are intended for application development. The repository's `AGENTS.md` and `.agents/skills/` still contain contributor instructions for changing Topcoat itself.
+
+## Available skills
+
+- `topcoat`: The framework's core mental model, setup, and common application workflow.
+- `topcoat-routing`: Route trees, pages, layouts, layers, HTTP inputs and responses, errors, and advanced transports.
+- `topcoat-ui`: Views, components, CSS, Tailwind, Topcoat UI, assets, fonts, icons, and accessibility.
+- `topcoat-runtime`: Signals, expressions, event handlers, binds, procedures, shards, and client/server boundaries.
+- `topcoat-auth`: Cookies, sessions, request helpers, origin checks, and authorization.
+- `topcoat-testing`: Tests for views, routes, context, sessions, runtime behavior, and assets.
+- `topcoat-data`: Database clients, data helpers, mutations, transactions, and request-local caching.
+
+## Install
+
+Use the [skills CLI](https://github.com/vercel-labs/skills) to choose and install the application skills in this directory:
+
+```sh
+npx skills add tokio-rs/topcoat
+```
+
+Topcoat's contributor-only skills under `.agents/skills/` are marked internal, so this command only lists the application skills above.

--- a/skills/topcoat-auth/SKILL.md
+++ b/skills/topcoat-auth/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: topcoat-auth
+description: Implement, review, test, and debug authentication and authorization in Topcoat Rust applications. Use for cookies, signed or private jars, typed cookie stores, sessions, login and logout, session storage, current-user helpers, access guards, token rotation, sliding expiration, CSRF and origin checks, and protecting procedures or shards.
+---
+
+# Topcoat Auth
+
+Keep authorization close to the data it protects. Prefer composable `cx: &Cx` functions over hidden middleware, and check the current cookie and session guides before relying on detailed APIs.
+
+## Configure cookies and sessions
+
+```rust
+use topcoat::{
+    cookie::RouterBuilderCookieExt,
+    router::Router,
+    session::{RouterBuilderSessionExt, SessionConfig},
+};
+
+let router = Router::builder()
+    .cookies()
+    .sessions(SessionConfig::default())
+    .app_context(Database::connect().await?)
+    .build();
+```
+
+Topcoat owns token generation, client transport, and lifecycle; the application owns session records. Store only `Session.token_hash`, the authenticated subject, and `expires_at`. Never store or log the raw token.
+
+## Implement the lifecycle
+
+- Login: Verify credentials, call `session::start(cx)`, and persist the returned session.
+- Current user: Read `session::token_hash(cx)`, load an unexpired record, and return the subject.
+- Logout: Call `session::stop(cx)` and delete the returned hash.
+- Sliding expiry: Call `session::refresh(cx)` and update the stored expiry.
+- Privilege change: Call `session::rotate(cx)` and atomically replace the revoked hash with the new session.
+- Sign out everywhere: Delete all relevant records in application storage.
+
+Memoize the current-user lookup so layouts, pages, and nested components share one database query:
+
+```rust
+use topcoat::{Result, context::{Cx, memoize}, router::error::RouterErrorExt};
+
+#[memoize]
+async fn current_user(cx: &Cx) -> Result<Option<User>> {
+    let Some(hash) = topcoat::session::token_hash(cx).await? else {
+        return Ok(None);
+    };
+    Ok(db(cx).find_unexpired_session(&hash).await?)
+}
+
+async fn require_auth(cx: &Cx) -> Result<&User> {
+    Ok(current_user(cx).await?.ok_or_unauthorized()?)
+}
+```
+
+Build `require_admin`, tenant membership, ownership, and similar checks from focused helpers. Call the appropriate guard inside every page, component, API route, procedure, and shard that exposes protected data. Procedures and shards have separate endpoints and do not inherit page or layout checks.
+
+## Choose cookie protection correctly
+
+- Plain cookie: Client-readable and forgeable; use only for non-sensitive preferences.
+- Signed jar: Client-readable but tamper-evident.
+- Private jar: Encrypted and authenticated for sensitive values.
+- `CookieStore<T>`: Structured JSON state over any jar; changes are not written until `commit()`.
+
+Generate signing keys once, store them durably outside source control, and register them as app context. Regenerating a key on boot invalidates existing signed and private cookies. Reuse the same cookie name, path, domain, and prefix when removing it.
+
+Prefer the default hardened session cookie. Keep state-changing operations on non-safe methods such as `POST`; never mutate state through `GET`.
+
+## Preserve origin protection
+
+`.sessions()` installs origin verification for state-changing browser requests. Trust a specific external origin only for a legitimate flow such as an OAuth form-post callback. Disable verification only when another complete CSRF defense is in place.
+
+Test missing, malformed, expired, revoked, and rotated sessions; cookie tampering; login fixation resistance; authorization at direct procedure and shard URLs; origin rejection; and failure paths around session storage updates.

--- a/skills/topcoat-data/SKILL.md
+++ b/skills/topcoat-data/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: topcoat-data
+description: Connect Topcoat applications to databases and other data services. Use when registering data clients, writing request helpers, loading data in views, implementing mutations or transactions, adding per-request caching, or testing persistence code.
+---
+
+# Work with application data
+
+Topcoat does not prescribe a database or ORM. Keep persistence behind ordinary Rust types and functions, then make long-lived clients available through application context.
+
+## Register clients
+
+Create pools and clients at startup and register them on the router:
+
+```rust
+let database = Database::connect(&settings.database_url).await?;
+
+let app = Router::new()
+    .app_context(database)
+    .discover();
+```
+
+Retrieve the exact registered type. Newtypes make multiple clients unambiguous.
+
+```rust
+use topcoat::context::{Cx, app_context};
+
+fn database(cx: &Cx) -> &Database {
+    app_context::<Database>(cx)
+}
+```
+
+Do not open a pool per request or store request-specific state in application context.
+
+## Put data access in functions
+
+Use ordinary `cx: &Cx` functions for domain queries. Let pages and components load the data they own.
+
+```rust
+async fn find_project(cx: &Cx, id: ProjectId) -> Result<Project> {
+    use topcoat::router::error::RouterErrorExt;
+
+    Ok(database(cx).find_project(id).await?.ok_or_not_found()?)
+}
+```
+
+Return domain types rather than exposing database rows throughout the UI. Decide explicitly whether absence is optional or a not-found error.
+
+## Cache within a request
+
+Use `#[memoize]` for repeated, idempotent reads during one request:
+
+```rust
+use topcoat::context::{Cx, memoize};
+
+#[memoize]
+async fn current_team(cx: &Cx, id: TeamId) -> Result<Team> {
+    database(cx).find_team(id).await
+}
+```
+
+All arguments form the cache key. Concurrent identical calls share the work, and cached values live only for the request. Do not memoize mutations, time-sensitive reads, or functions with relevant inputs outside their arguments.
+
+## Implement writes
+
+Keep mutations in route handlers or procedures:
+
+1. Parse and validate untrusted input.
+2. Load the authenticated actor and authorize the operation.
+3. Start a transaction when multiple writes must be atomic.
+4. Apply domain changes.
+5. Commit before rendering or redirecting.
+
+Use redirect-after-post for conventional forms. Procedures and shards must repeat authorization on the server; client visibility is not access control.
+
+Avoid holding transactions across view rendering, remote calls, or other slow work. Watch for N+1 queries when components render in loops; batch or preload where the data layer supports it.
+
+## Choose integrations deliberately
+
+Use the data library already present in the application. Toasty is one option demonstrated by Topcoat examples, not a framework requirement. Follow that library's transaction, migration, and error conventions rather than inventing a Topcoat-specific repository layer.
+
+## Test persistence code
+
+- Substitute fake or in-memory clients through `CxTestBuilder::app_context`.
+- Test query helpers separately from rendered HTML.
+- Give integration tests isolated database state and deterministic fixtures.
+- Cover rollback, conflicts, missing records, and authorization failures.
+- Keep migrations and schema compatibility in the data library's own test workflow.

--- a/skills/topcoat-routing/SKILL.md
+++ b/skills/topcoat-routing/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: topcoat-routing
+description: Design, implement, review, and debug routing and HTTP behavior in Topcoat Rust applications. Use for module-based or explicit routes, pages, layouts, layers, parameters, request bodies, API responses, router errors, Tower middleware, multipart, server-sent events, and WebSockets.
+---
+
+# Topcoat Routing
+
+Use `topcoat::router` and check the installed version before relying on detailed APIs. In a source checkout, read `crates/topcoat/docs/router.md`, `crates/topcoat-router/docs/module_router.md`, and the relevant content or macro guide.
+
+## Choose registration deliberately
+
+Prefer `module_router!()` for an application route tree:
+
+```rust
+// src/app.rs
+mod api;
+mod posts;
+
+use topcoat::router::{Router, RouterBuilderDiscoverExt};
+
+pub fn router() -> Router {
+    topcoat::router::module_router!().discover().build()
+}
+```
+
+- `module_router!()` registers module-derived pages, layouts, layers, and routes below its module.
+- `.discover()` registers linked explicit-path handlers plus discovered procedures, shards, fonts, and similar items.
+- Register values such as app context and asset bundles explicitly.
+- `module_router!` follows compiled `mod` declarations; it does not scan files.
+
+Each child module adds a kebab-cased segment. An `_`-prefixed module is a group with no served segment, but its layouts and layers still scope descendants. Use `path_param!` to make the enclosing segment dynamic, `path_param!(*path)` for a catch-all, and `segment!` for renames or groups. Do not combine `segment!` and `path_param!` in one module.
+
+Adding a path string to an attribute makes that handler explicit. Register it by value or with `.discover()`. Register same-path layers manually when order matters; module discovery rejects ambiguous layer or layout ordering.
+
+## Use the right handler
+
+- `#[page]`: Render a view; defaults to `GET`.
+- `#[layout]`: Wrap matching pages by path prefix; accept `slot: Result` and render `slot?`.
+- `#[route]`: Return an `IntoResponse` value for one method, a method list, or `*`.
+- `#[layer]`: Wrap request execution under a prefix. Prefer `cx` functions for application data and authorization.
+
+```rust
+use topcoat::{Result, router::{content::Json, route}};
+
+#[route(POST "/api/widgets")]
+async fn create(Json(input): Json<CreateWidget>) -> Result<Json<Widget>> {
+    Ok(Json(save(input).await?))
+}
+```
+
+A handler may take `cx: &Cx` and at most one body extractor, in either order. Buffered extractors such as `Json`, `Form`, `Bytes`, and `String` enforce the body limit; `Body` streams directly. Scope a `BodyLimit` layer when the default 2 MiB limit is unsuitable.
+
+## Read parameters through `Cx`
+
+```rust
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{page, path_param, query_params},
+    view::view,
+};
+
+path_param!(post_id: u64, error = not_found);
+
+#[query_params(error = bad_request)]
+struct PostQuery {
+    preview: Option<bool>,
+}
+
+#[page("/posts/{post_id}")]
+async fn post(cx: &Cx) -> Result {
+    let id = path_param::<PostId>(cx)?;
+    let query = query_params::<PostQuery>(cx)?;
+    view! { <p>(id) " " (query.preview.unwrap_or(false))</p> }
+}
+```
+
+Parsing is request-memoized. Let helpers read the values from `Cx` instead of threading copies through the component tree.
+
+## Preserve HTTP semantics
+
+Return response wrappers or tuples with a leading `StatusCode`, optional headers, and a final body. Use router errors and `RouterErrorExt` for expected failures. Unexpected errors become status 500 without exposing their messages.
+
+When a layout catches an inner error and renders a replacement, include the intended `StatusCode`; otherwise the replacement is status 200.
+
+For optional features:
+
+- `multipart`: Consume fields sequentially and bound uploads.
+- `sse`: Configure keep-alives and resume from `Last-Event-ID` when needed.
+- `websocket`: Authenticate before `on_upgrade` and configure message and buffer limits.
+- `tower`: Use `TowerRoute` for services and `TowerLayer` for middleware. A catch-all does not match its bare prefix.
+
+Test methods, paths, layout/layer scope, parameter failures, body limits, status codes, redirects, and authorization at every independently exposed endpoint.

--- a/skills/topcoat-runtime/SKILL.md
+++ b/skills/topcoat-runtime/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: topcoat-runtime
+description: Build, review, test, and debug client-side reactivity in Topcoat Rust applications. Use for signals, $(...) runtime expressions, event handlers, bind attributes, raw JavaScript escapes, procedures, shards, reactive server rendering, and client/server trust boundaries.
+---
+
+# Topcoat Runtime
+
+Use Topcoat's runtime for targeted browser behavior without WebAssembly or a separate client build. Check the installed version and read `crates/topcoat/docs/runtime.md` plus the macro guides under `crates/topcoat-runtime/macro/docs/`.
+
+## Choose the smallest mechanism
+
+- Use a signal and `$(...)` when behavior can run locally in the browser.
+- Use `#[procedure]` for an imperative async server call.
+- Use `#[shard]` when changing client state should re-render a server component.
+- Use ordinary forms or links when native navigation already fits.
+
+```rust
+view! {
+    signal open = false;
+
+    <button @click=$(|_event| open.toggle())>"Toggle"</button>
+    <p :hidden=$(!open.get())>"Details"</p>
+}
+```
+
+`@event=$(closure)` attaches a handler. `:attribute=$(expr)` updates an attribute when a signal it reads changes. Runtime expressions are evaluated as Rust for initial rendering and translated to JavaScript for browser updates.
+
+## Respect the shared expression language
+
+Use only the supported cross-language types, methods, operators, and syntax. Important constraints:
+
+- Numbers are `f64`; write `1.0`, not `1`.
+- Captured server values are serialized snapshots, not live server state.
+- Unsupported Rust constructs fail at compile time.
+- `raw!` embeds JavaScript; provide equivalent Rust when the expression also runs during server rendering.
+
+Keep expressions small. Move server-only logic to a procedure or shard rather than expanding `raw!` usage.
+
+## Call procedures safely
+
+```rust
+use topcoat::{Result, runtime::procedure};
+
+#[procedure]
+async fn save_name(cx: &Cx, name: String) -> Result<String> {
+    let user = require_auth(cx).await?;
+    Ok(update_name(cx, user, name).await?)
+}
+```
+
+Call a procedure with `.await` inside browser-only async code such as an event closure. Its arguments and `Ok` value must use the shared expression vocabulary. A procedure call cannot run during server rendering.
+
+Procedure arguments come from the client. Validate them and authenticate and authorize inside the procedure. If the browser must react to a domain failure, return that outcome as data; a procedure `Err` becomes an HTTP failure and is not observable as a value in the expression.
+
+## Use shards for reactive server views
+
+```rust
+#[shard]
+async fn results(cx: &Cx, query: String) -> Result {
+    let user = require_auth(cx).await?;
+    let rows = search(cx, user, &query).await?;
+    view! { for row in rows { <p>(row.name)</p> } }
+}
+```
+
+Call it with runtime arguments such as `results(query: $(query.get()))`. Initial rendering happens inline; later signal changes request new HTML and replace only the shard. Same-tick changes coalesce and a newer request aborts an older in-flight request.
+
+State declared inside a shard resets when it is replaced. Keep persistent signals outside and pass their values in. Treat shard arguments as untrusted and authorize inside the shard because its endpoint does not run the page or layout guard.
+
+Register procedures and shards with `.discover()` or their explicit router builder methods. Test initial HTML, generated behavior, endpoint authorization, invalid arguments, rapid updates, and state reset boundaries.

--- a/skills/topcoat-testing/SKILL.md
+++ b/skills/topcoat-testing/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: topcoat-testing
+description: Test Topcoat applications, including views, components, routes, request context, sessions, runtime features, and assets. Use when adding tests, choosing a test boundary, building requests, or debugging application behavior.
+---
+
+# Test Topcoat applications
+
+Test public behavior at the smallest stable boundary. Prefer ordinary Rust tests and the framework's public APIs over generated internals.
+
+## Choose the boundary
+
+- Test pure domain functions without Topcoat.
+- Render a `View` to test components and server HTML.
+- Call `Router::handle` to test routing, layers, cookies, and responses.
+- Call procedures or shard routes directly for server behavior.
+- Use browser tests only for JavaScript behavior, navigation, or timing-sensitive interactions.
+
+## Build request context
+
+Use `CxTestBuilder` for functions that read application or request context. Register the same concrete types the application registers.
+
+```rust
+use topcoat::context::CxTestBuilder;
+
+let cx = CxTestBuilder::new()
+    .app_context(FakeDatabase::default())
+    .build();
+
+let user = current_user(&cx).await?;
+```
+
+Add request parts or request-scoped values only when the code under test needs them. Keep each test's context independent.
+
+## Render views
+
+Render the returned `View` and assert meaningful HTML or text:
+
+```rust
+let cx = &CxTestBuilder::new().build();
+let html = profile(cx, &user)?.render(cx);
+
+assert!(html.contains("Ada Lovelace"));
+```
+
+Prefer focused assertions over whole-document snapshots. Use snapshots when the complete markup is the intentional contract.
+
+## Exercise the router
+
+Build an HTTP request and pass it to the router:
+
+```rust
+use topcoat::router::{Body, Router, to_bytes};
+
+let request = http::Request::builder()
+    .method("GET")
+    .uri("/users/42")
+    .body(Body::empty())?;
+let response = router.handle(request).await;
+
+assert_eq!(response.status(), http::StatusCode::OK);
+let body = to_bytes(response.into_body(), usize::MAX).await?;
+assert!(body.starts_with(b"<!doctype html>"));
+```
+
+Register routes explicitly when discovery or global registries would make tests interfere. Test status, headers, and body separately.
+
+## Test auth and state
+
+- Use fake or in-memory stores through `.app_context(...)`.
+- Carry `Set-Cookie` values into later requests when testing a session lifecycle.
+- Cover missing, invalid, expired, rotated, and revoked sessions.
+- Test authorization on every procedure and shard that exposes protected data.
+- Control clocks, identifiers, and randomness where practical.
+
+## Test runtime behavior
+
+Server tests can verify initial HTML, procedure results, and shard responses. Use a real browser for event handlers, binds, signal updates, cancellation, and stale-response races. Do not infer browser correctness from generated markup alone.
+
+## Keep tests reliable
+
+- Avoid network services and shared mutable state.
+- Give each test a fresh router, context, and database state.
+- Assert content-hashed asset behavior without hard-coding a hash unless it is the subject of the test.
+- Run focused tests while iterating, then the workspace's normal format, lint, test, and documentation checks.

--- a/skills/topcoat-ui/SKILL.md
+++ b/skills/topcoat-ui/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: topcoat-ui
+description: Build, style, review, and debug user interfaces in Topcoat Rust applications. Use for view! templates, components, attributes, classes, CSS, Tailwind, Topcoat UI, assets, fonts, Fontsource, icons, Iconify, accessibility, responsive design, and production asset builds.
+---
+
+# Topcoat UI
+
+Build accessible server-rendered interfaces through the `topcoat` facade. Inspect `Cargo.toml`, `build.rs`, router asset registration, the root layout, stylesheets, and `components.toml` before changing the UI stack.
+
+## Write views and components
+
+Use real HTML syntax in `view!`. Quote literal text, interpolate Rust with `(expr)`, and use `if`, `for`, `match`, and `let` directly in the body.
+
+Define reusable async `#[component]` functions. A `child: View` prop receives trailing nodes; `#[default]` makes props optional; `#[into]` converts at the call site; `cx: &Cx` is supplied implicitly.
+
+Forward caller attributes with an `Attributes` prop and `<element (attrs)>`. Use `attributes!` to build fragments and `class!` for conditional class lists. Spreading consumes `Attributes`, and each key is unique.
+
+Prefer semantic elements, labels, native controls, keyboard support, and visible focus. Run `topcoat fmt` after editing views.
+
+## Bundle assets
+
+Declare local or remote files with `asset!` and load the matching bundle on the router:
+
+```rust
+use topcoat::{
+    asset::{AssetBundle, RouterBuilderAssetExt},
+    router::{Router, RouterBuilderDiscoverExt},
+};
+
+let router = Router::builder()
+    .discover()
+    .assets(AssetBundle::load().unwrap())
+    .build();
+```
+
+Use `topcoat dev` during development and `topcoat asset bundle` for manual builds. Bundle with the same binary, profile, target directory, and checkout used for deployment. Add checksums to remote assets when reproducibility matters.
+
+## Configure Tailwind
+
+Enable `tailwind` on both the runtime dependency and a build dependency with default features disabled. In `build.rs`:
+
+```rust
+fn main() {
+    topcoat::tailwind::BuildConfig::new()
+        .input("styles.css")
+        .render()
+        .unwrap();
+}
+```
+
+Load `<link rel="stylesheet" href=(topcoat::tailwind::stylesheet!())>` in the root layout and register the asset bundle.
+
+Topcoat uses the standalone Tailwind CLI. Keep complete utility names as literals; runtime-built names such as `format!("text-{color}-600")` are invisible to scanning. Use Tailwind source directives for precise scanning, keep `target/` ignored, and take care with Cargo `rerun-if-*` directives because the first one replaces default package-wide tracking.
+
+## Use Topcoat UI as owned source
+
+```sh
+topcoat ui init
+topcoat ui list
+topcoat ui add button
+```
+
+Commit `components.toml` and `styles.css`. Installed components are ordinary application source: inspect and edit them. They commonly use enum variants, forwarded `attrs`, child content, merged classes, and `*_variants` helpers.
+
+Theme semantic CSS variables in `styles.css`; apply `dark` to an ancestor for dark values. Re-adding with `--overwrite` replaces local component source, so diff first.
+
+## Add fonts and icons
+
+Use `font!` for custom faces or enable `font-fontsource` and use `fontsource_font!`. Register fonts with `.discover()` or `.font(...)`, then render `topcoat::font::link(...)` in `<head>`. Include only used weights, styles, and subsets. `host: Asset` self-hosts files and requires the asset bundle.
+
+Use the `icon` component for inline SVG. Decorative icons omit `label`; meaningful icon-only controls need an accessible label. For Iconify, enable `icon-iconify` on runtime and build dependencies, stage sets in `build.rs`, then use `iconify::include!` or `iconify_icon!`. Pin or vendor sets for reproducible offline builds.
+
+Verify responsive layouts, content extremes, keyboard behavior, focus, contrast, light/dark themes, and production-style font and asset URLs.

--- a/skills/topcoat/SKILL.md
+++ b/skills/topcoat/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: topcoat
+description: Build, change, review, and debug full-stack Rust web applications using Topcoat. Use for project setup, framework architecture, choosing Topcoat features, or application work spanning routing, server-rendered views, client reactivity, data, authentication, testing, assets, and integrations.
+---
+
+# Topcoat
+
+Build through the public `topcoat` facade crate. Topcoat is early-stage, so inspect the installed version and prefer version-matched API docs over memory.
+
+## Understand the model
+
+- Render async pages and components on the server; let them call application services directly.
+- Write HTML-like templates with `view!` and reusable functions with `#[component]`.
+- Route with explicit handler paths or derive paths from the Rust module tree.
+- Pass `cx: &Cx` to ordinary functions for request data, authentication, and request-scoped loading.
+- Use signals and `$(...)` expressions for local browser behavior without WebAssembly.
+- Use `#[shard]` for reactive server re-rendering and `#[procedure]` for imperative server calls.
+- Declare content-hashed files with `asset!`; Tailwind, fonts, and icons build on the asset pipeline.
+
+## Start a project
+
+```sh
+cargo new hello-world
+cd hello-world
+cargo add topcoat
+cargo add tokio --features rt-multi-thread,macros
+cargo install topcoat-cli
+```
+
+```rust
+use topcoat::{
+    Result,
+    router::{Router, RouterBuilderDiscoverExt, page},
+    view::view,
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(Router::builder().discover().build())
+        .await
+        .unwrap();
+}
+
+#[page("/")]
+async fn home() -> Result {
+    view! {
+        <!DOCTYPE html>
+        <html>
+            <head>topcoat::dev::script()</head>
+            <body><h1>"Hello"</h1></body>
+        </html>
+    }
+}
+```
+
+Use `topcoat dev` for rebuilding, asset bundling, restart, and browser reload. Use `topcoat fmt` to format Topcoat macro bodies.
+
+## Work in an existing application
+
+1. Inspect `Cargo.toml`, router construction, `build.rs`, and nearby handlers and components.
+2. Determine the routing, styling, data, session, and client-runtime patterns already in use.
+3. Read the focused skill and current guide for the subsystem being changed.
+4. Keep application imports on `topcoat`; its lower-level crates are implementation details.
+5. Make the smallest coherent change, format it, and run focused tests followed by project checks.
+
+In a Topcoat checkout, canonical guides live under `crates/topcoat/docs/` and each implementation crate's `docs/` directory. Runnable examples live under `examples/`.
+
+## Keep boundaries explicit
+
+- Prefer composable `cx` functions over hidden middleware for application concerns.
+- Treat route, procedure, and shard arguments as untrusted HTTP input.
+- Authorize inside every shard and procedure; page and layout checks do not guard their separate endpoints.
+- Register discovered handlers with `.discover()`, module-derived handlers with `module_router!()`, and runtime values such as app context and asset bundles explicitly.
+- Keep production binaries and asset bundles from the same build.


### PR DESCRIPTION
## Summary

- add seven concise application-development skills covering Topcoat fundamentals, routing, UI, runtime, authentication, testing, and data
- document installation through `npx skills add tokio-rs/topcoat`
- mark contributor-only skills as internal so normal CLI discovery lists only the public application skills

## Testing

- validated all public and internal skill packages with `quick_validate.py`
- confirmed `npx --yes skills@latest add . --list` discovers exactly the seven public skills
- ran `cargo +nightly fmt --all`
- ran `cargo topcoat fmt` (zero files modified; only the expected Leptos benchmark parse errors)
- ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- ran `cargo test --workspace --all-features`
- ran `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`

## AI use

Created with OpenAI Codex (GPT-5). AI was used to explore Topcoat's source and documentation, draft the skills, validate CLI discovery, and run the repository checks.
