### PR TITLE
fix(router): treat empty optional URL-encoded values as none

### DIFF
--- a/crates/topcoat-router/macro/docs/query_params.md
+++ b/crates/topcoat-router/macro/docs/query_params.md
@@ -12,7 +12,9 @@ struct PageQuery {
 
 # Reading the value
 
-[`query_params::<T>(cx)`](fn.query_params.html) parses the current request's query string with [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) and returns `Result<&T, &QueryParamsError>`: a reference to the parsed struct, or to the [`QueryParamsError`](type.QueryParamsError.html) naming the key that failed. Unlike a path parameter, the struct is not tied to a route: any handler can read it. Parsing runs at most once per request; the result is then memoized.
+[`query_params::<T>(cx)`](fn.query_params.html) parses the current request's URL-encoded query string and returns `Result<&T, &QueryParamsError>`: a reference to the parsed struct, or to the [`QueryParamsError`](type.QueryParamsError.html) naming the key that failed. Unlike a path parameter, the struct is not tied to a route: any handler can read it. Parsing runs at most once per request; the result is then memoized.
+
+An empty value such as `?page=` becomes `None` when its target field is an `Option`. A required `String` field still receives an empty string.
 
 # Failing with an error response
 

--- a/crates/topcoat-router/src/content/form.rs
+++ b/crates/topcoat-router/src/content/form.rs
@@ -23,6 +23,9 @@ use crate::{
 /// [`IntoResponse`] wrapper, it serializes `T` back to a URL-encoded body and
 /// sets the response `Content-Type`.
 ///
+/// An empty encoded value such as `due=` becomes [`None`] when its target field
+/// is an [`Option`]. A required [`String`] field still receives an empty string.
+///
 /// Wrap it in [`Option`] to make the body optional. For `GET` and `HEAD`
 /// requests the extractor yields [`None`] only when there is no query string;
 /// for other methods it yields [`None`] when there is no `Content-Type` header.
@@ -118,8 +121,7 @@ where
     /// Returns a bad-request error when `bytes` are not valid URL-encoded form
     /// data matching `T`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let deserializer = serde_urlencoded::Deserializer::new(form_urlencoded::parse(bytes));
-        let value = serde_path_to_error::deserialize(deserializer).map_err(|error| {
+        let value = crate::urlencoded::from_bytes(bytes).map_err(|error| {
             bad_request_at(
                 error.path(),
                 format!("invalid form value: {}", error.inner()),
@@ -194,6 +196,7 @@ fn form_content_type(content_type: Option<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use http::{Method, Request, header::CONTENT_TYPE};
+    use serde::Deserialize;
     use topcoat_core::context::{Cx, CxTestBuilder};
 
     use super::*;
@@ -325,6 +328,18 @@ mod tests {
         let Form(pairs) =
             Form::<Vec<(String, u32)>>::from_bytes(b"a=1&b=2").expect("valid form data");
         assert_eq!(pairs, vec![("a".to_owned(), 1), ("b".to_owned(), 2)]);
+    }
+
+    #[test]
+    fn from_bytes_treats_empty_optional_value_as_none() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Input {
+            due: Option<u32>,
+        }
+
+        let Form(input) = Form::<Input>::from_bytes(b"due=").expect("an empty optional value");
+
+        assert_eq!(input, Input { due: None });
     }
 
     #[test]

--- a/crates/topcoat-router/src/lib.rs
+++ b/crates/topcoat-router/src/lib.rs
@@ -24,6 +24,7 @@ mod router;
 mod service;
 #[cfg(feature = "tower")]
 pub mod tower;
+mod urlencoded;
 
 pub use body::*;
 pub use body_limit::*;

--- a/crates/topcoat-router/src/query_param.rs
+++ b/crates/topcoat-router/src/query_param.rs
@@ -48,9 +48,7 @@ pub type QueryParamsError = serde_path_to_error::Error<serde_urlencoded::de::Err
 /// into `T`.
 pub fn parse_query_params<T: DeserializeOwned>(cx: &Cx) -> Result<T, QueryParamsError> {
     let query = uri(cx).query().unwrap_or("");
-    let deserializer =
-        serde_urlencoded::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
-    serde_path_to_error::deserialize(deserializer)
+    crate::urlencoded::from_bytes(query.as_bytes())
 }
 
 /// A guard that limits [`QueryParams::query_params`] to being called through the
@@ -65,5 +63,34 @@ pub struct QueryParamsSealed(());
 impl QueryParamsSealed {
     pub(crate) fn new() -> Self {
         Self(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Request;
+    use serde::Deserialize;
+    use topcoat_core::context::CxTestBuilder;
+
+    use super::*;
+
+    #[test]
+    fn parse_query_params_treats_empty_optional_value_as_none() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Query {
+            page: Option<u32>,
+        }
+
+        let (parts, ()) = Request::builder()
+            .uri("/posts?page=")
+            .body(())
+            .expect("request should build")
+            .into_parts();
+        let cx = CxTestBuilder::new().request_context(parts).build();
+
+        assert_eq!(
+            parse_query_params::<Query>(&cx).expect("an empty optional value"),
+            Query { page: None }
+        );
     }
 }

--- a/crates/topcoat-router/src/urlencoded.rs
+++ b/crates/topcoat-router/src/urlencoded.rs
@@ -1,0 +1,352 @@
+use std::borrow::Cow;
+
+use form_urlencoded::Parse;
+use serde::{
+    Deserialize,
+    de::{self, IntoDeserializer, value::MapDeserializer},
+    forward_to_deserialize_any,
+};
+
+type Error = serde_urlencoded::de::Error;
+
+macro_rules! forward_parsed_value {
+    ($($ty:ident => $method:ident),* $(,)?) => {
+        $(
+            fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: de::Visitor<'de>,
+            {
+                self.value
+                    .parse::<$ty>()
+                    .map_err(de::Error::custom)?
+                    .into_deserializer()
+                    .$method(visitor)
+            }
+        )*
+    };
+}
+
+pub(crate) fn from_bytes<'de, T>(bytes: &'de [u8]) -> Result<T, serde_path_to_error::Error<Error>>
+where
+    T: Deserialize<'de>,
+{
+    serde_path_to_error::deserialize(Deserializer::new(form_urlencoded::parse(bytes)))
+}
+
+struct Deserializer<'de> {
+    inner: MapDeserializer<'de, PartIterator<'de>, Error>,
+}
+
+impl<'de> Deserializer<'de> {
+    fn new(parser: Parse<'de>) -> Self {
+        Self {
+            inner: MapDeserializer::new(PartIterator(parser)),
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_map(self.inner)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_seq(self.inner)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.inner.end()?;
+        visitor.visit_unit()
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string option bytes byte_buf
+        unit_struct newtype_struct tuple_struct struct identifier tuple enum ignored_any
+    }
+}
+
+struct PartIterator<'de>(Parse<'de>);
+
+impl<'de> Iterator for PartIterator<'de> {
+    type Item = (Part<'de>, Part<'de>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(key, value)| {
+            (
+                Part {
+                    value: key,
+                    empty_as_none: false,
+                },
+                Part {
+                    value,
+                    empty_as_none: true,
+                },
+            )
+        })
+    }
+}
+
+struct Part<'de> {
+    value: Cow<'de, str>,
+    empty_as_none: bool,
+}
+
+impl<'de> IntoDeserializer<'de> for Part<'de> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Part<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Cow::Borrowed(value) => visitor.visit_borrowed_str(value),
+            Cow::Owned(value) => visitor.visit_string(value),
+        }
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if self.empty_as_none && self.value.is_empty() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(EnumAccess(self.value))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    forward_to_deserialize_any! {
+        char str string unit bytes byte_buf unit_struct tuple_struct struct identifier tuple
+        ignored_any seq map
+    }
+
+    forward_parsed_value! {
+        bool => deserialize_bool,
+        u8 => deserialize_u8,
+        u16 => deserialize_u16,
+        u32 => deserialize_u32,
+        u64 => deserialize_u64,
+        i8 => deserialize_i8,
+        i16 => deserialize_i16,
+        i32 => deserialize_i32,
+        i64 => deserialize_i64,
+        f32 => deserialize_f32,
+        f64 => deserialize_f64,
+    }
+}
+
+struct EnumAccess<'de>(Cow<'de, str>);
+
+impl<'de> de::EnumAccess<'de> for EnumAccess<'de> {
+    type Error = Error;
+    type Variant = UnitVariantAccess;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(self.0.into_deserializer())?;
+        Ok((variant, UnitVariantAccess))
+    }
+}
+
+struct UnitVariantAccess;
+
+impl<'de> de::VariantAccess<'de> for UnitVariantAccess {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        Err(de::Error::custom("expected unit variant"))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(de::Error::custom("expected unit variant"))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(de::Error::custom("expected unit variant"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Values {
+        optional_number: Option<u32>,
+        optional_string: Option<String>,
+        required_string: String,
+    }
+
+    #[test]
+    fn empty_values_are_none_only_for_options() {
+        let values = from_bytes::<Values>(b"optional_number=&optional_string=&required_string=")
+            .expect("valid values");
+
+        assert_eq!(
+            values,
+            Values {
+                optional_number: None,
+                optional_string: None,
+                required_string: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn non_empty_values_keep_existing_behavior() {
+        let values =
+            from_bytes::<Values>(b"optional_number=42&optional_string=hello&required_string=world")
+                .expect("valid values");
+
+        assert_eq!(
+            values,
+            Values {
+                optional_number: Some(42),
+                optional_string: Some("hello".to_owned()),
+                required_string: "world".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn missing_values_keep_existing_behavior() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct OptionalValue {
+            value: Option<u32>,
+        }
+
+        assert_eq!(
+            from_bytes::<OptionalValue>(b"").expect("valid values"),
+            OptionalValue { value: None }
+        );
+    }
+
+    #[test]
+    fn invalid_non_empty_values_are_rejected() {
+        let error = from_bytes::<Values>(
+            b"optional_number=nope&optional_string=hello&required_string=world",
+        )
+        .expect_err("an invalid number is rejected");
+
+        assert_eq!(error.path().to_string(), "optional_number");
+    }
+
+    #[test]
+    fn sequences_of_pairs_keep_existing_behavior() {
+        let pairs = from_bytes::<Vec<(String, u32)>>(b"a=1&b=2").expect("valid values");
+
+        assert_eq!(pairs, vec![("a".to_owned(), 1), ("b".to_owned(), 2)]);
+    }
+
+    #[test]
+    fn empty_map_keys_keep_existing_behavior() {
+        let values =
+            from_bytes::<BTreeMap<Option<String>, String>>(b"=value").expect("valid values");
+
+        assert_eq!(
+            values.get(&Some(String::new())).map(String::as_str),
+            Some("value")
+        );
+        assert!(!values.contains_key(&None));
+    }
+
+    #[test]
+    fn scalar_types_match_serde_urlencoded() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        enum Choice {
+            First,
+            Second,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Scalars {
+            boolean: bool,
+            unsigned: u64,
+            signed: i64,
+            float: f64,
+            character: char,
+            string: String,
+            choice: Choice,
+        }
+
+        let bytes = b"boolean=true&unsigned=42&signed=-7&float=1.5&character=x&string=hello+world&choice=Second";
+        let expected = serde_urlencoded::from_bytes::<Scalars>(bytes).expect("valid values");
+
+        assert_eq!(
+            from_bytes::<Scalars>(bytes).expect("valid values"),
+            expected
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Treat empty URL-encoded form and query values as `None` when the target field is an `Option`, including `Option<String>`.
- Preserve existing behavior for required empty strings, map keys, non-empty scalar values, and path-aware parse errors.
- Share the deserializer between `Form<T>` and `#[query_params]`, with regression tests and public documentation for both entry points.

## Design note

This chooses the deserializer-level approach discussed in #187. It intentionally changes an empty value from `Some("")` to `None` for `Option<String>`, for both forms and query parameters.

The issue does not yet record a maintainer preference between this global behavior and an opt-in field helper. This PR remains a draft pending confirmation of that API decision.

## Testing

- `cargo test -p topcoat-router --lib --all-features`
- `cargo clippy -p topcoat-router --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --exclude ui --exclude tailwind --exclude storefront-topcoat`
- `cargo clippy --workspace --all-targets --all-features --locked --exclude ui --exclude tailwind --exclude storefront-topcoat -- -D warnings`
- `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked --exclude ui --exclude tailwind --exclude storefront-topcoat`
- The three excluded packages execute a downloaded Tailwind binary that cannot run on this NixOS host without `nix-ld`.
- `cargo +nightly fmt --package topcoat-router`
- `cargo topcoat fmt` on the changed Rust files
- Manual HTTP reproduction against `f267417` and the fixed worktree

Closes #187

AI disclosure: OpenAI Codex (`gpt-5.6-sol`) was used to reproduce the issue, implement the deserializer, add tests and documentation, and run local verification.
