### PR TITLE
feat(router)!: add not_found macro and no longer run layers and layouts by default on unmatched requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error"
+version = "0.5.0"
+dependencies = [
+ "tokio",
+ "topcoat",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "examples/context",
     "examples/cookie",
     "examples/datastar",
+    "examples/error",
     "examples/font",
     "examples/hello-world",
     "examples/htmx",

--- a/crates/topcoat-router/docs/error.md
+++ b/crates/topcoat-router/docs/error.md
@@ -42,21 +42,21 @@ The methods mirror the constructors: [`ok_or_not_found`](RouterErrorExt::ok_or_n
 
 # Catching an error
 
-An error keeps its type on the way out, so an outer handler can pick it up with `downcast_ref` and respond with a view instead. For example, a layout can replace a page's [`NotFoundError`] with a branded not-found page:
+An error keeps its type on the way out, so an outer handler can pick it up with `downcast_ref` and respond with a view instead. For example, a layout can replace a [`ForbiddenError`] bubbling out of any page below it with a branded access-denied page:
 
 ```rust
 use topcoat::{
     Result,
-    router::{StatusCode, error::NotFoundError, layout},
+    router::{StatusCode, error::ForbiddenError, layout},
     view::view,
 };
 
 #[layout("/")]
 async fn root_layout(slot: Result) -> Result {
     let content = match slot {
-        Err(error) if error.downcast_ref::<NotFoundError>().is_some() => view! {
-            (StatusCode::NOT_FOUND)
-            <h1>"Page not found"</h1>
+        Err(error) if error.downcast_ref::<ForbiddenError>().is_some() => view! {
+            (StatusCode::FORBIDDEN)
+            <h1>"Access denied"</h1>
         },
         content => content,
     }?;
@@ -69,7 +69,18 @@ async fn root_layout(slot: Result) -> Result {
 }
 ```
 
-The [`StatusCode`](crate::StatusCode) in the view keeps the response a 404; without it the replacement page would be served as a 200.
+The [`StatusCode`](crate::StatusCode) in the view keeps the response a 403; without it the replacement page would be served as a 200.
+
+# Not-found pages
+
+A [`NotFoundError`] returned by a handler is caught the same way. The 404 for a URL matching no route is not: the router answers it directly, and no layer or layout runs for a request nothing was registered for. To give those URLs the same branded treatment, declare a catch-all page with [`not_found!`](../macro.not_found.html):
+
+```rust
+# use topcoat::router::not_found;
+not_found!("/");
+```
+
+This registers a page resolving every otherwise unmatched URL under its path to a [`NotFoundError`], which then bubbles through the layouts like any other handler error. See the [`not_found!` reference](../macro.not_found.html) for the module-derived form and how the catch-all segment is appended.
 
 # Unexpected errors
 

--- a/crates/topcoat-router/grammar/src/lib.rs
+++ b/crates/topcoat-router/grammar/src/lib.rs
@@ -4,6 +4,7 @@ pub mod common;
 pub mod layer;
 pub mod layout;
 pub mod method;
+pub mod not_found;
 pub mod page;
 pub mod path_param;
 pub mod query_params;

--- a/crates/topcoat-router/grammar/src/not_found.rs
+++ b/crates/topcoat-router/grammar/src/not_found.rs
@@ -1,0 +1,116 @@
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+use syn::{
+    LitStr,
+    parse::{Parse, ParseStream},
+};
+use topcoat_core_grammar::paths::{
+    topcoat_error, topcoat_router, topcoat_router_macro, topcoat_view,
+};
+
+/// The `not_found!` macro input: an optional URL path prefix.
+pub struct NotFound {
+    /// The prefix the catch-all page covers; derived from the enclosing module
+    /// when absent.
+    pub path: Option<LitStr>,
+}
+
+impl NotFound {
+    /// The served path: the prefix with a `{*rest}` catch-all segment
+    /// appended. `None` when the path is module-derived.
+    #[must_use]
+    pub fn catch_all_path(&self) -> Option<LitStr> {
+        self.path.as_ref().map(|path| {
+            let prefix = path.value();
+            let full = format!("{}/{{*rest}}", prefix.trim_end_matches('/'));
+            LitStr::new(&full, path.span())
+        })
+    }
+}
+
+impl Parse for NotFound {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            path: (!input.is_empty()).then(|| input.parse()).transpose()?,
+        })
+    }
+}
+
+impl ToTokens for NotFound {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let result = quote! { #topcoat_error::Result<#topcoat_view::View> };
+        let page = |attr: TokenStream| {
+            quote! {
+                /// The catch-all page declared by `not_found!`, resolving
+                /// every request it serves to a not-found error.
+                #[#topcoat_router_macro::page(#attr)]
+                pub async fn not_found() -> #result {
+                    ::core::result::Result::Err(#topcoat_router::error::not_found().into())
+                }
+            }
+        };
+
+        match self.catch_all_path() {
+            Some(path) => page(quote! { * #path }).to_tokens(tokens),
+            None => {
+                let page = page(quote! { * });
+                quote! {
+                    /// Serves every unmatched URL under this module as a
+                    /// not-found error.
+                    pub mod not_found {
+                        #topcoat_router_macro::segment!(kind = CatchAll, rename = "rest");
+
+                        #page
+                    }
+                }
+                .to_tokens(tokens);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn catch_all_path(source: &str) -> Option<String> {
+        let not_found: NotFound = syn::parse_str(source).unwrap();
+        not_found.catch_all_path().map(|path| path.value())
+    }
+
+    #[test]
+    fn empty_input_derives_the_path_from_the_module() {
+        assert_eq!(catch_all_path(""), None);
+    }
+
+    #[test]
+    fn appends_the_catch_all_to_the_prefix() {
+        assert_eq!(
+            catch_all_path("\"/admin\"").as_deref(),
+            Some("/admin/{*rest}"),
+        );
+    }
+
+    #[test]
+    fn root_prefix_serves_a_bare_catch_all() {
+        assert_eq!(catch_all_path("\"/\"").as_deref(), Some("/{*rest}"));
+    }
+
+    #[test]
+    fn trailing_slashes_do_not_double_the_separator() {
+        assert_eq!(
+            catch_all_path("\"/admin/\"").as_deref(),
+            Some("/admin/{*rest}"),
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_string_input() {
+        assert!(syn::parse_str::<NotFound>("42").is_err());
+    }
+
+    #[test]
+    fn rejects_tokens_after_the_path() {
+        assert!(syn::parse_str::<NotFound>("\"/admin\" extra").is_err());
+    }
+}

--- a/crates/topcoat-router/grammar/src/not_found.rs
+++ b/crates/topcoat-router/grammar/src/not_found.rs
@@ -50,21 +50,20 @@ impl ToTokens for NotFound {
             }
         };
 
-        match self.catch_all_path() {
-            Some(path) => page(quote! { * #path }).to_tokens(tokens),
-            None => {
-                let page = page(quote! { * });
-                quote! {
-                    /// Serves every unmatched URL under this module as a
-                    /// not-found error.
-                    pub mod not_found {
-                        #topcoat_router_macro::segment!(kind = CatchAll, rename = "rest");
+        if let Some(path) = self.catch_all_path() {
+            page(quote! { * #path }).to_tokens(tokens);
+        } else {
+            let page = page(quote! { * });
+            quote! {
+                /// Serves every unmatched URL under this module as a
+                /// not-found error.
+                pub mod not_found {
+                    #topcoat_router_macro::segment!(kind = CatchAll, rename = "rest");
 
-                        #page
-                    }
+                    #page
                 }
-                .to_tokens(tokens);
             }
+            .to_tokens(tokens);
         }
     }
 }

--- a/crates/topcoat-router/macro/docs/layer.md
+++ b/crates/topcoat-router/macro/docs/layer.md
@@ -4,7 +4,7 @@ A layer wraps every page and API route whose path begins with the layer's path, 
 
 For a matched handler, the prefix is checked when the router is built, comparing the layer's path to the handler's registered path segment by segment; the request URL is not consulted. A handler is wrapped only when its leading segments spell out the layer's path exactly: a layer at `/docs/admin` wraps neither a page at `/docs/{something}` nor one at `/docs/{*path}`, even though both serve URLs under `/docs/admin`. A parameter segment only matches a parameter of the same name, and group segments count, so a layer at `/dashboard` does not wrap a page at `/(auth)/dashboard` although that page is served at `/dashboard`.
 
-Only when no path matches at all does the request URL come into play: a 404 response runs the layers whose path matches the request URL, checked at request time. A 405 comes from a matched path and runs that path's layers.
+Layers only wrap registered handlers. A request whose path matches no handler is answered with a 404 directly, without running any layers. A 405 comes from a matched path and runs that path's layers.
 
 When several layers wrap a handler, they nest from least specific (outermost) to most specific (innermost). Layers registered explicitly with [`RouterBuilder::layer`](struct.RouterBuilder.html#method.layer) on the same path nest by registration order, the last registered outermost. Layers collected by [`discover`](trait.RouterBuilderDiscoverExt.html) must have unique paths, because their collection order is not stable.
 

--- a/crates/topcoat-router/macro/docs/not_found.md
+++ b/crates/topcoat-router/macro/docs/not_found.md
@@ -1,0 +1,35 @@
+Declares a catch-all page that resolves every URL it serves to a not-found error.
+
+The router answers a request matching no route with a bare 404: no layers run and no layout renders around it. This macro registers a catch-all page for those URLs instead, so they dispatch like any other request and an outer layout can catch the [`NotFoundError`](error/struct.NotFoundError.html) and replace it with a custom not-found view, as described in the [error guide](error/index.html).
+
+With a path, the macro appends a `{*rest}` catch-all segment and expands to a page named `not_found` serving every method under that prefix. Register it like any other explicit-path page: pass `not_found` to [`RouterBuilder::page`](struct.RouterBuilder.html#method.page), or let [`discover`](trait.RouterBuilderDiscoverExt.html) collect it.
+
+Without a path, the macro expands to a `not_found` module holding the catch-all page, deriving the prefix from the enclosing module like any other [`module_router!`](macro.module_router.html) handler.
+
+More specific routes win over the catch-all, which only serves URLs nothing else matches. A catch-all requires at least one segment, so the prefix URL itself (`/` for a root fallback) is not covered and is served by its own page.
+
+# Examples
+
+A site-wide fallback, covering every URL no other route serves:
+
+```rust
+use topcoat::router::{Router, not_found};
+
+not_found!("/");
+
+let router = Router::builder().page(not_found).build();
+```
+
+A fallback for one subtree only, here `/admin/{*rest}`:
+
+```rust
+# use topcoat::router::{Router, not_found};
+not_found!("/admin");
+# let router = Router::builder().page(not_found).build();
+```
+
+Module-derived path (in `src/app/admin.rs` under [`module_router!`](macro.module_router.html), this covers `/admin/{*rest}`):
+
+```rust
+topcoat::router::not_found!();
+```

--- a/crates/topcoat-router/macro/src/lib.rs
+++ b/crates/topcoat-router/macro/src/lib.rs
@@ -39,6 +39,13 @@ pub fn layer(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
+#[doc = include_str!("../docs/not_found.md")]
+#[proc_macro]
+pub fn not_found(tokens: TokenStream) -> TokenStream {
+    let not_found = syn::parse_macro_input!(tokens as topcoat_router_grammar::not_found::NotFound);
+    quote! { #not_found }.into()
+}
+
 #[doc = include_str!("../docs/segment.md")]
 #[proc_macro]
 pub fn segment(tokens: TokenStream) -> TokenStream {

--- a/crates/topcoat-router/src/builder.rs
+++ b/crates/topcoat-router/src/builder.rs
@@ -1,0 +1,605 @@
+use std::{
+    any::{Any, type_name},
+    borrow::Cow,
+    collections::HashMap,
+    fmt,
+    sync::Arc,
+};
+
+use topcoat_core::{base_url::BaseUrl, context::ContextMap};
+
+use crate::{
+    Endpoint, Layer, Layers, LayoutFn, Methods, OriginLayer, OriginPolicy, PageFn, PageWithLayouts,
+    PathSegment, RawPathParamSpec, Route, Router,
+};
+
+/// Builds a [`Router`] for a Topcoat application.
+///
+/// This is the common construction surface used by manual routing,
+/// auto-discovery, `module_router!`, and builder extension traits. Register
+/// [`page`](Self::page), [`layout`](Self::layout), [`layer`](Self::layer), and
+/// [`route`](Self::route) handlers directly, or let a discovery helper add
+/// them, then call [`build`](Self::build) once at the end.
+///
+/// Builder extension traits add application-wide behavior before finalization,
+/// such as assets, cookies, or typed [`app_context`](Self::app_context) values.
+///
+/// # Examples
+///
+/// ```rust
+/// # struct AppConfig;
+/// # impl AppConfig { fn load() -> Self { Self } }
+/// use topcoat::{
+///     asset::{AssetBundle, RouterBuilderAssetExt},
+///     cookie::RouterBuilderCookieExt,
+///     router::{Router, RouterBuilderDiscoverExt},
+/// };
+///
+/// pub fn router() -> Router {
+///     Router::builder()
+///         .discover()
+///         .cookies()
+///         .assets(AssetBundle::load().unwrap())
+///         .app_context(AppConfig::load())
+///         .build()
+/// }
+/// ```
+pub struct RouterBuilder {
+    routes: Vec<Box<dyn Route>>,
+    pages: Vec<PageFn>,
+    layouts: Vec<LayoutFn>,
+    layers: Layers,
+    context: ContextMap,
+    origin_policy: OriginPolicy,
+    #[cfg(feature = "compression")]
+    compression: crate::Compression,
+}
+
+impl RouterBuilder {
+    /// Creates an empty builder with no routes registered.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut context = ContextMap::new();
+        // Register `()` so APIs generic over an app context type can default to `S = ()`.
+        context.insert(());
+        Self {
+            routes: Vec::new(),
+            pages: Vec::new(),
+            layouts: Vec::new(),
+            layers: Layers::default(),
+            context,
+            origin_policy: OriginPolicy::new(),
+            #[cfg(feature = "compression")]
+            compression: crate::Compression::new(),
+        }
+    }
+
+    /// Returns `true` if no routes, pages, or layouts have been registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty() && self.pages.is_empty() && self.layouts.is_empty()
+    }
+
+    /// Registers a [`Route`], an HTTP handler bound to a set of methods and a
+    /// path.
+    ///
+    /// A route responds to the methods its [`Route::methods`] declares: one or
+    /// more specific methods, or every method via [`Methods::Any`]. Specific-
+    /// method routes and one any-method route can share a path; the specific
+    /// method wins at dispatch.
+    #[must_use]
+    pub fn route(mut self, route: impl Route) -> Self {
+        self.routes.push(Box::new(route));
+        self
+    }
+
+    /// Registers every route annotated with `#[route]` and collected at link
+    /// time.
+    #[cfg(feature = "discover")]
+    #[must_use]
+    pub fn discover_routes(mut self) -> Self {
+        for route in inventory::iter::<crate::RouteFn>().cloned() {
+            self = self.route(route);
+        }
+        self
+    }
+
+    /// Registers a page: anything convertible into a [`PageFn`], like the
+    /// marker `#[page]` generates. Order doesn't matter: layout matching is
+    /// based on path prefixes, not registration order.
+    ///
+    /// A page serves the methods its [`PageFn`] declares (`GET` unless the
+    /// page opts into others).
+    #[must_use]
+    pub fn page(mut self, page: impl Into<PageFn>) -> Self {
+        self.pages.push(page.into());
+        self
+    }
+
+    /// Registers every [`PageFn`] annotated with `#[page]` and collected at
+    /// link time.
+    #[cfg(feature = "discover")]
+    #[must_use]
+    pub fn discover_pages(mut self) -> Self {
+        for page in inventory::iter::<PageFn>().cloned() {
+            self = self.page(page);
+        }
+        self
+    }
+
+    /// Registers a layout: anything convertible into a [`LayoutFn`], like the
+    /// marker `#[layout]` generates. A layout applies to every page whose path
+    /// starts with the layout's path prefix.
+    #[must_use]
+    pub fn layout(mut self, layout: impl Into<LayoutFn>) -> Self {
+        self.layouts.push(layout.into());
+        self
+    }
+
+    /// Registers every [`LayoutFn`] annotated with `#[layout]` and collected at
+    /// link time.
+    ///
+    /// At most one discovered layout is allowed per path: a page's layouts nest
+    /// by path prefix, so two layouts sharing a path would have an undefined
+    /// nesting order. To attach more than one layout to a page, give them
+    /// distinct paths or compose them in a single layout component.
+    ///
+    /// # Panics
+    ///
+    /// Panics if two discovered layouts share the same path.
+    #[cfg(feature = "discover")]
+    #[must_use]
+    #[track_caller]
+    pub fn discover_layouts(mut self) -> Self {
+        let mut seen = std::collections::HashSet::<crate::PathBuf>::new();
+        for layout in inventory::iter::<LayoutFn>().cloned() {
+            assert!(
+                seen.insert(layout.path().to_owned()),
+                "multiple discovered layouts registered for the same path \"{}\"",
+                layout.path()
+            );
+            self = self.layout(layout);
+        }
+        self
+    }
+
+    /// Registers a [`Layer`] that wraps every matched route whose path begins
+    /// with the layer's path, like a layout.
+    ///
+    /// When layers at *different* paths match a route they nest from
+    /// least-specific (outermost) to most-specific (innermost). Multiple layers
+    /// may share the same path; among those, the most recently registered runs
+    /// first (outermost), so `.layer(a).layer(b)` runs `b` around `a` when both
+    /// sit at the same path.
+    #[must_use]
+    pub fn layer(mut self, layer: impl Layer) -> Self {
+        self.layers.push(Box::new(layer));
+        self
+    }
+
+    /// Registers every layer annotated with `#[layer]` and collected at link
+    /// time.
+    ///
+    /// Unlike [`layer`](Self::layer), at most one discovered layer is allowed
+    /// per path. Link-time collection order is non-deterministic, so two
+    /// discovered layers sharing a path would have an undefined run order; this
+    /// rejects that rather than pick an arbitrary one. To stack several layers
+    /// on one path, register them explicitly with [`layer`](Self::layer), whose
+    /// order is well-defined.
+    ///
+    /// # Panics
+    ///
+    /// Panics if two discovered layers share the same path.
+    #[cfg(feature = "discover")]
+    #[must_use]
+    #[track_caller]
+    pub fn discover_layers(mut self) -> Self {
+        let mut seen = std::collections::HashSet::<crate::PathBuf>::new();
+        for layer in inventory::iter::<crate::LayerFn>().cloned() {
+            assert!(
+                seen.insert(layer.path().to_owned()),
+                "multiple discovered layers registered for the same path \"{}\"",
+                layer.path()
+            );
+            self = self.layer(layer);
+        }
+        self
+    }
+
+    /// Registers the [`OriginPolicy`] the router applies to every request.
+    ///
+    /// The default policy denies state-changing cross-origin browser requests
+    /// and cross-origin WebSocket handshakes; pass a policy to trust
+    /// cross-origin peers, exempt individual routes, or opt out entirely.
+    #[must_use]
+    pub fn origin_policy(mut self, origin_policy: OriginPolicy) -> Self {
+        self.origin_policy = origin_policy;
+        self
+    }
+
+    /// Configures the compression applied to responses.
+    ///
+    /// By default the router compresses each response with the algorithm
+    /// negotiated from the request's `Accept-Encoding` header. Pass
+    /// [`Compression::off`](crate::Compression::off) to disable compression
+    /// (say, behind a reverse proxy that compresses already), or a tuned
+    /// [`Compression`](crate::Compression) value to adjust it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use topcoat::router::{Compression, Router};
+    ///
+    /// let router = Router::builder().compression(Compression::off()).build();
+    /// ```
+    #[cfg(feature = "compression")]
+    #[must_use]
+    pub fn compression(mut self, compression: crate::Compression) -> Self {
+        self.compression = compression;
+        self
+    }
+
+    /// Registers the base URL the application is publicly reachable at, like
+    /// `https://example.com`.
+    ///
+    /// Relative URLs work anywhere within the site, but rendered content
+    /// that leaves it (e.g. links and images in emails, feeds, or sitemaps)
+    /// needs the absolute form. The base URL is stored on the app context;
+    /// read it back with [`base_url`](topcoat_core::base_url::base_url) (or
+    /// [`try_base_url`](topcoat_core::base_url::try_base_url)) and resolve
+    /// paths against it with
+    /// [`BaseUrl::join`](topcoat_core::base_url::BaseUrl::join).
+    ///
+    /// Accepts anything convertible into a [`BaseUrl`]. A string is parsed,
+    /// so it must be an absolute `http` or `https` URL without a query or
+    /// fragment, with an optional path prefix for applications mounted
+    /// under one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not a valid base URL, or if a base URL has
+    /// already been registered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use topcoat::router::Router;
+    ///
+    /// let router = Router::builder().base_url("https://example.com").build();
+    /// ```
+    #[must_use]
+    #[track_caller]
+    pub fn base_url(self, base_url: impl TryInto<BaseUrl, Error: fmt::Display>) -> Self {
+        match base_url.try_into() {
+            Ok(base_url) => self.app_context(base_url),
+            Err(error) => panic!("{error}"),
+        }
+    }
+
+    /// Registers a unique value that is accessible to every request sent to
+    /// this router by its type `T`. The top-level
+    /// [`app_context`](topcoat_core::context::app_context) function can be used to
+    /// retrieve a reference to this value via a request context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a value has already been registered for the same type.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use topcoat::{Result, router::route};
+    /// # struct User;
+    /// # #[route(GET "/users")]
+    /// # async fn get_user() -> Result<&'static str> { Ok("ok") }
+    /// use topcoat::{
+    ///     context::{Cx, app_context},
+    ///     router::Router,
+    /// };
+    ///
+    /// struct Database {/* ... */}
+    /// # impl Database {
+    /// #     fn connect() -> Self { Self {} }
+    /// #     async fn fetch_user(&self, _id: u64) -> User { User }
+    /// # }
+    ///
+    /// pub fn router() -> Router {
+    ///     Router::builder()
+    ///         .route(get_user)
+    ///         .app_context(Database::connect())
+    ///         .build()
+    /// }
+    ///
+    /// async fn fetch_user(cx: &Cx, id: u64) -> User {
+    ///     let db: &Database = app_context(cx);
+    ///     db.fetch_user(id).await
+    /// }
+    /// ```
+    #[must_use]
+    #[track_caller]
+    pub fn app_context<T>(mut self, value: T) -> Self
+    where
+        T: Any + Send + Sync,
+    {
+        assert!(
+            self.context.insert(value).is_none(),
+            "duplicate context entry for type `{:?}`",
+            type_name::<T>()
+        );
+        self
+    }
+
+    /// Returns a reference to the app context value of type `T` registered with
+    /// [`app_context`](Self::app_context), or `None` if none has been
+    /// registered.
+    ///
+    /// Lets code that registers a shared value lazily check for it first, rather
+    /// than tripping the duplicate-registration panic on a second call.
+    #[must_use]
+    pub fn get_app_context<T>(&self) -> Option<&T>
+    where
+        T: Any + Send + Sync,
+    {
+        self.context.get::<T>()
+    }
+
+    /// Returns a mutable reference to the app context value of type `T`
+    /// registered with [`app_context`](Self::app_context), or `None` if none
+    /// has been registered.
+    #[must_use]
+    pub fn get_app_context_mut<T>(&mut self) -> Option<&mut T>
+    where
+        T: Any + Send + Sync,
+    {
+        self.context.get_mut::<T>()
+    }
+
+    /// Finalizes the registered routes, pages, and layouts into a [`Router`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if two routes resolve to the same path and HTTP method (or both
+    /// respond to every method at the same path), since the router would have
+    /// no way to choose between them, and if a route declares an empty method
+    /// set, since it could never be dispatched to.
+    ///
+    /// Also panics if two routes resolve to the same path but different layers
+    /// wrap them (possible when their group segments differ, e.g. `/(a)/x` and
+    /// `/(b)/x` with a layer at `/(a)`): every route at a path shares one layer
+    /// stack, so the divergence is rejected rather than resolved by
+    /// registration order.
+    #[must_use]
+    #[track_caller]
+    pub fn build(self) -> Router {
+        let RouterBuilder {
+            mut routes,
+            pages,
+            layouts,
+            layers,
+            context,
+            origin_policy,
+            #[cfg(feature = "compression")]
+            compression,
+        } = self;
+
+        // Wire each page to the layouts whose path is a prefix of the page's,
+        // ordered from least- to most-specific so the page nests innermost.
+        for page in pages {
+            let mut matching: Vec<LayoutFn> = layouts
+                .iter()
+                .filter(|layout| page.path().starts_with(layout.path()))
+                .cloned()
+                .collect();
+            matching.sort_by_key(|layout| layout.path().len());
+            routes.push(Box::new(PageWithLayouts::new(page, matching)));
+        }
+
+        // Group routes that share a path into a single endpoint first, since
+        // matchit rejects inserting the same path twice. Two routes that resolve
+        // to the same path *and* method are ambiguous, so reject them here.
+        // Remember each group's first route index to name it in the layer
+        // divergence panic below.
+        let mut grouped: HashMap<Cow<'static, str>, (usize, Endpoint)> = HashMap::new();
+        let mut interned_path_params: HashMap<&str, Arc<str>> = HashMap::new();
+        for (index, route) in routes.iter().enumerate() {
+            let layer_stack = layers.for_endpoint(route.path());
+            let (first, endpoint) = grouped
+                .entry(route.path().to_matchit_path())
+                .or_insert_with(|| {
+                    let path_params = route
+                        .path()
+                        .segments()
+                        .filter_map(|segment| {
+                            let (param, is_catch_all) = match segment {
+                                PathSegment::Param(param) => (param, false),
+                                PathSegment::CatchAll(param) => (param, true),
+                                _ => return None,
+                            };
+                            let interned = interned_path_params
+                                .entry(param)
+                                .or_insert_with(|| Arc::from(param.to_owned().into_boxed_str()));
+                            Some(if is_catch_all {
+                                RawPathParamSpec::catch_all(interned.clone())
+                            } else {
+                                RawPathParamSpec::segment(interned.clone())
+                            })
+                        })
+                        .collect();
+                    let endpoint =
+                        Endpoint::new(path_params, layer_stack.clone().into_boxed_slice());
+                    (index, endpoint)
+                });
+
+            // Every route grouped at a path shares the endpoint's layer stack
+            // (the 405 fallback included), so their full paths -- group
+            // segments and all -- must select the same layers. Reject a
+            // divergence rather than let registration order pick a winner.
+            assert!(
+                layer_stack == endpoint.layers(),
+                "routes `{}` and `{}` serve the same URL path but select different layers",
+                routes[*first].path(),
+                route.path(),
+            );
+
+            // An any-method route shares its path with specific-method routes
+            // (which win at dispatch), so the two kinds are checked for
+            // duplicates independently.
+            match route.methods() {
+                Methods::Any => {
+                    assert!(
+                        endpoint.any().is_none(),
+                        "duplicate any-method route registered for `{}`",
+                        route.path().to_matchit_path()
+                    );
+                    endpoint.insert_any(index);
+                }
+                Methods::Only(methods) => {
+                    assert!(
+                        !methods.is_empty(),
+                        "route `{}` registers no methods",
+                        route.path()
+                    );
+                    for method in methods {
+                        assert!(
+                            endpoint.get(method).is_none(),
+                            "duplicate route registered for `{method} {}`",
+                            route.path().to_matchit_path()
+                        );
+                        endpoint.insert(method.clone(), index);
+                    }
+                }
+            }
+        }
+
+        // Precompute the layer stack wrapping each endpoint once, so dispatch
+        // only has to index into it rather than filter and sort per request.
+        let mut endpoints = matchit::Router::new();
+        for (path, (_, mut endpoint)) in grouped {
+            endpoint.alias_head_to_get();
+            endpoints
+                .insert(path.clone(), endpoint)
+                .unwrap_or_else(|error| panic!("failed to register route {path:?}: {error}"));
+        }
+
+        Router {
+            routes,
+            endpoints,
+            layers,
+            app_context: Arc::new(context),
+            origin: OriginLayer::new(origin_policy),
+            #[cfg(feature = "compression")]
+            compression,
+        }
+    }
+}
+
+impl Default for RouterBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topcoat_core::context::{Cx, CxBuilder};
+
+    use super::*;
+    use crate::{
+        Body, LayerFn, LayerFuture, Method, Next, Path, RouteFn, RouteFuture,
+        response::IntoResponse,
+    };
+
+    fn path(s: &'static str) -> Cow<'static, Path> {
+        Cow::Borrowed(Path::new(s))
+    }
+
+    /// A stand-in handler; builder tests register routes without running them.
+    fn handler(cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        Box::pin(async move { "handled".into_response(cx) })
+    }
+
+    /// A stand-in layer that continues the chain unchanged.
+    fn noop_layer<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+        Box::pin(async move { next.run(cx, body).await })
+    }
+
+    struct Greeting;
+
+    #[test]
+    fn new_builder_is_empty() {
+        let builder = RouterBuilder::new();
+        assert!(builder.is_empty());
+    }
+
+    #[test]
+    fn builder_is_not_empty_after_registering_a_route() {
+        let builder = RouterBuilder::new().route(RouteFn::new(Method::GET, path("/x"), handler));
+        assert!(!builder.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate route")]
+    fn duplicate_method_and_path_panics_on_build() {
+        let _ = RouterBuilder::new()
+            .route(RouteFn::new(Method::GET, path("/x"), handler))
+            .route(RouteFn::new(Method::GET, path("/x"), handler))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate any-method route")]
+    fn duplicate_any_method_routes_panic_on_build() {
+        let _ = RouterBuilder::new()
+            .route(RouteFn::new(Methods::Any, path("/x"), handler))
+            .route(RouteFn::new(Methods::Any, path("/x"), handler))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate route")]
+    fn overlapping_method_sets_panic_on_build() {
+        let _ = RouterBuilder::new()
+            .route(RouteFn::new(
+                &[Method::GET, Method::POST],
+                path("/x"),
+                handler,
+            ))
+            .route(RouteFn::new(Method::POST, path("/x"), handler))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "registers no methods")]
+    fn route_without_methods_panics_on_build() {
+        let _ = RouterBuilder::new()
+            .route(RouteFn::new(Vec::<Method>::new(), path("/x"), handler))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "select different layers")]
+    fn routes_sharing_a_url_with_different_layers_panic() {
+        // Both routes serve `/x` (groups are stripped from the URL), but only
+        // the `(a)` route is wrapped by the `/(a)` layer. The endpoint's layer
+        // stack is shared, so the build rejects the divergence.
+        let _ = RouterBuilder::new()
+            .route(RouteFn::new(Method::GET, path("/(a)/x"), handler))
+            .route(RouteFn::new(Method::POST, path("/(b)/x"), handler))
+            .layer(LayerFn::new(path("/(a)"), noop_layer))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate context entry")]
+    fn duplicate_app_context_type_panics() {
+        let _ = RouterBuilder::new()
+            .app_context(Greeting)
+            .app_context(Greeting);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid base URL")]
+    fn invalid_base_url_panics_at_registration() {
+        let _ = RouterBuilder::new().base_url("not a url");
+    }
+}

--- a/crates/topcoat-router/src/layer.rs
+++ b/crates/topcoat-router/src/layer.rs
@@ -2,11 +2,7 @@ use std::{borrow::Cow, ops::Index, pin::Pin};
 
 use topcoat_core::{context::CxBuilder, error::Result};
 
-use crate::{
-    Body, Endpoint, Path, Route,
-    error::{method_not_allowed, not_found},
-    response::Response,
-};
+use crate::{Body, Endpoint, Path, Route, error::method_not_allowed, response::Response};
 
 /// The future returned by [`Layer::handle`] and [`Next::run`]: a boxed, `Send`
 /// future borrowing the chain and the request context.
@@ -114,8 +110,9 @@ pub(crate) struct LayerId(usize);
 /// [`LayerId`].
 ///
 /// Layers are [`push`](Self::push)ed as the router is built, then only queried:
-/// [`for_path`](Self::for_path) selects the layers wrapping a request path, and
-/// indexing by [`LayerId`] resolves a selected id back to its layer.
+/// [`for_endpoint`](Self::for_endpoint) selects the layers wrapping an
+/// endpoint's path, and indexing by [`LayerId`] resolves a selected id back to
+/// its layer.
 #[derive(Default)]
 pub(crate) struct Layers {
     layers: Vec<Box<dyn Layer>>,
@@ -127,19 +124,6 @@ impl Layers {
         let id = LayerId(self.layers.len());
         self.layers.push(layer);
         id
-    }
-
-    /// Selects the layers whose path matches the URL `path`, ordered least- to
-    /// most-specific so the outermost layer runs first. Among layers that share a
-    /// path, the most recently registered runs first.
-    pub(crate) fn match_path(&self, path: &str) -> Vec<LayerId> {
-        let mut ids: Vec<LayerId> = (0..self.layers.len())
-            .map(LayerId)
-            .filter(|id| self[*id].path().matches_start(path))
-            .rev()
-            .collect();
-        ids.sort_by_key(|id| self[*id].path().len());
-        ids
     }
 
     /// Selects the layers whose path is a prefix of the endpoint `path`, ordered
@@ -166,16 +150,14 @@ impl Index<LayerId> for Layers {
 
 /// What a [`Next`] chain runs once its layers are exhausted.
 ///
-/// The layers wrapping a path are the same whether or not the request resolves
-/// to a route, so 404 and 405 responses flow through them too: a layer sees a
-/// matched route handler's result, or the not-found / method-not-allowed error,
-/// uniformly as the `Result` returned by [`Next::run`].
+/// The layers wrapping a matched path are the same whichever method the
+/// request uses, so 405 responses flow through them too: a layer sees a
+/// matched route handler's result, or the method-not-allowed error, uniformly
+/// as the `Result` returned by [`Next::run`].
 #[derive(Clone, Copy)]
 pub(crate) enum Terminal<'a> {
     /// A matched route handles the request.
     Route(&'a dyn Route),
-    /// No route matched the path; the chain resolves to a not-found error.
-    NotFound,
     /// The path matched but the method did not; the chain resolves to a
     /// method-not-allowed error listing the endpoint's supported methods.
     MethodNotAllowed(&'a Endpoint),
@@ -224,7 +206,6 @@ impl<'a> Next<'a> {
             ),
             None => match self.terminal {
                 Terminal::Route(route) => route.handle(cx, body),
-                Terminal::NotFound => Box::pin(async move { Err(not_found().into()) }),
                 Terminal::MethodNotAllowed(endpoint) => {
                     let error = method_not_allowed(endpoint.methods().cloned());
                     Box::pin(async move { Err(error.into()) })
@@ -347,77 +328,6 @@ mod tests {
     }
 
     #[test]
-    fn match_path_orders_least_to_most_specific() {
-        let mut layers = Layers::default();
-        // Registered most-specific first, to show the ordering follows path
-        // length rather than registration order.
-        let admin = layers.push(layer_at("/admin"));
-        let root = layers.push(layer_at("/"));
-        assert_eq!(layers.match_path("/admin/x"), vec![root, admin]);
-    }
-
-    #[test]
-    fn match_path_excludes_layers_that_do_not_wrap_the_url() {
-        let mut layers = Layers::default();
-        let _public = layers.push(layer_at("/public"));
-        let admin = layers.push(layer_at("/admin"));
-        assert_eq!(layers.match_path("/admin/x"), vec![admin]);
-    }
-
-    #[test]
-    fn match_path_runs_most_recent_of_a_shared_path_first() {
-        let mut layers = Layers::default();
-        let first = layers.push(layer_at("/"));
-        let second = layers.push(layer_at("/"));
-        // Among layers sharing a path, the most recently registered runs first.
-        assert_eq!(layers.match_path("/x"), vec![second, first]);
-    }
-
-    #[test]
-    fn match_path_selects_nothing_when_no_layers_match() {
-        let mut layers = Layers::default();
-        let _admin = layers.push(layer_at("/admin"));
-        assert!(layers.match_path("/public").is_empty());
-    }
-
-    #[test]
-    fn match_path_tolerates_trailing_slash() {
-        let mut layers = Layers::default();
-        let admin = layers.push(layer_at("/admin"));
-        assert_eq!(layers.match_path("/admin/"), vec![admin]);
-        assert_eq!(layers.match_path("/admin/users/"), vec![admin]);
-    }
-
-    #[test]
-    fn match_path_rejects_partial_segments() {
-        let mut layers = Layers::default();
-        let root = layers.push(layer_at("/"));
-        let _admin = layers.push(layer_at("/admin"));
-        // `/admin` is a string prefix of the URL, but not a whole segment.
-        assert_eq!(layers.match_path("/administrator"), vec![root]);
-    }
-
-    #[test]
-    fn match_path_ignores_group_segments() {
-        let mut layers = Layers::default();
-        let panel = layers.push(layer_at("/(admin)/panel"));
-        let auth = layers.push(layer_at("/(auth)"));
-        // Groups never appear in URLs, so a layer matches the stripped path...
-        assert_eq!(layers.match_path("/panel/settings"), vec![auth, panel]);
-        // ...and a group-only layer matches every URL, like the root.
-        assert_eq!(layers.match_path("/elsewhere"), vec![auth]);
-    }
-
-    #[test]
-    fn match_path_requires_param_segments_to_be_nonempty() {
-        let mut layers = Layers::default();
-        let user = layers.push(layer_at("/users/{id}"));
-        assert_eq!(layers.match_path("/users/42/posts"), vec![user]);
-        // An empty `{id}` segment never routes, so the layer does not match.
-        assert!(layers.match_path("/users//posts").is_empty());
-    }
-
-    #[test]
     fn for_endpoint_orders_prefix_layers_least_to_most_specific() {
         let mut layers = Layers::default();
         let root = layers.push(layer_at("/"));
@@ -490,19 +400,6 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(&body_bytes(response)[..], b"route");
-    }
-
-    #[test]
-    fn run_resolves_the_not_found_terminal() {
-        let layers = Layers::default();
-        let mut cx = CxBuilder::default();
-
-        let indices: &[LayerId] = &[];
-        let next = Next::new(&layers, indices, Terminal::NotFound);
-        let result = block_on(next.run(&mut cx, Body::empty()));
-        let response = respond(&cx, result);
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[test]

--- a/crates/topcoat-router/src/lib.rs
+++ b/crates/topcoat-router/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod body;
 mod body_limit;
+mod builder;
 #[cfg(feature = "compression")]
 mod compression;
 pub mod content;
@@ -28,6 +29,7 @@ pub mod tower;
 
 pub use body::*;
 pub use body_limit::*;
+pub use builder::*;
 #[cfg(feature = "compression")]
 pub use compression::*;
 pub(crate) use endpoint::Endpoint;

--- a/crates/topcoat-router/src/path.rs
+++ b/crates/topcoat-router/src/path.rs
@@ -231,41 +231,6 @@ impl Path {
     /// ```
     #[must_use]
     pub fn matches(&self, url: &str) -> bool {
-        self.match_url(url, false)
-    }
-
-    /// Returns `true` if `url`, a concrete URL path, *starts with* this route
-    /// path.
-    ///
-    /// Matches segments the same way as [`matches`](Path::matches), but allows
-    /// trailing URL segments beyond this path. This is the concrete-URL
-    /// counterpart of [`starts_with`](Path::starts_with), used to select which
-    /// layouts apply to a request URL.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use topcoat_router::Path;
-    ///
-    /// let path = Path::new("/settings");
-    /// // Extra trailing segments are allowed.
-    /// assert!(path.matches_start("/settings/profile"));
-    /// assert!(!path.matches_start("/dashboard"));
-    ///
-    /// assert!(Path::new("/users/{id}").matches_start("/users/42/posts"));
-    /// ```
-    #[must_use]
-    pub fn matches_start(&self, url: &str) -> bool {
-        self.match_url(url, true)
-    }
-
-    /// Walks this path's segments against `url`, treating `Param`/`CatchAll` as
-    /// wildcards and skipping `Group` segments.
-    ///
-    /// When `prefix` is `false` the URL must be fully consumed; when `true` any
-    /// trailing URL segments are allowed. Shared by [`matches`](Path::matches)
-    /// and [`matches_start`](Path::matches_start).
-    fn match_url(&self, url: &str, prefix: bool) -> bool {
         // Splits the `/`-separated URL body into its first segment and the
         // remainder, e.g. "users/42" into ("users", "42") and "users" into
         // ("users", ""). Returns `None` when nothing is left to consume.
@@ -299,9 +264,8 @@ impl Path {
                 PathSegment::CatchAll(_) => return !rest.is_empty(),
             }
         }
-        // Every route segment matched. A full match additionally requires the
-        // URL to be exhausted; a prefix match tolerates trailing segments.
-        prefix || rest.is_empty()
+        // Every route segment matched; the URL must also be exhausted.
+        rest.is_empty()
     }
 
     /// Returns the string backing this path.
@@ -942,80 +906,13 @@ mod tests {
     }
 
     #[test]
-    fn matches_start_allows_trailing_segments() {
-        let path = Path::new("/settings");
-        assert!(path.matches_start("/settings"));
-        assert!(path.matches_start("/settings/profile"));
-        assert!(path.matches_start("/settings/profile/security"));
-    }
-
-    #[test]
-    fn matches_start_mismatch() {
-        assert!(!Path::new("/settings").matches_start("/dashboard"));
-    }
-
-    #[test]
-    fn matches_start_tolerates_trailing_slash() {
-        assert!(Path::new("/admin").matches_start("/admin/"));
-        assert!(Path::new("/users/{id}").matches_start("/users/42/"));
-    }
-
-    #[test]
-    fn matches_start_rejects_partial_segment() {
-        assert!(!Path::new("/admin").matches_start("/administrator"));
-    }
-
-    #[test]
-    fn matches_start_rejects_empty_segments() {
-        assert!(!Path::new("/admin").matches_start("//admin"));
-        assert!(!Path::new("/users/{id}").matches_start("/users//edit"));
-    }
-
-    #[test]
-    fn matches_start_ignores_groups() {
-        // A path inside a group matches the URL with the group stripped, plus
-        // anything nested below it.
-        assert!(Path::new("/(admin)/panel").matches_start("/panel"));
-        assert!(Path::new("/(admin)/panel").matches_start("/panel/settings"));
-        assert!(!Path::new("/(admin)/panel").matches_start("/other"));
-        // A group-only path is URL-equivalent to the root and matches any URL.
-        assert!(Path::new("/(auth)").matches_start("/anything"));
-    }
-
-    #[test]
-    fn matches_start_catch_all() {
-        let path = Path::new("/files/{*rest}");
-        assert!(path.matches_start("/files/a/b"));
-        // The catch-all itself requires at least one segment.
-        assert!(!path.matches_start("/files"));
-        assert!(!path.matches_start("/files/"));
-    }
-
-    #[test]
-    fn matches_start_non_origin_form_urls() {
-        // An asterisk-form request (`OPTIONS *`) or an empty authority-form
-        // path still falls under the root, but under no other path.
-        assert!(Path::new("/").matches_start("*"));
-        assert!(Path::new("/").matches_start(""));
-        assert!(!Path::new("/admin").matches_start("*"));
-        assert!(!Path::new("/admin").matches_start(""));
-    }
-
-    #[test]
-    fn matches_start_with_params() {
-        assert!(Path::new("/users/{id}").matches_start("/users/42/posts"));
-    }
-
-    #[test]
-    fn matches_start_requires_full_prefix() {
-        assert!(!Path::new("/users/{id}/posts").matches_start("/users/42"));
-    }
-
-    #[test]
-    fn matches_start_root_matches_everything() {
-        let root = Path::new("/");
-        assert!(root.matches_start("/"));
-        assert!(root.matches_start("/anything/here"));
+    fn matches_non_origin_form_urls() {
+        // An asterisk-form request (`OPTIONS *`) matches no route path. An
+        // empty authority-form path is equivalent to the root URL.
+        assert!(!Path::new("/").matches("*"));
+        assert!(!Path::new("/admin").matches("*"));
+        assert!(Path::new("/").matches(""));
+        assert!(!Path::new("/admin").matches(""));
     }
 
     // -- Path validation --

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -1,8 +1,4 @@
 use std::{
-    any::{Any, type_name},
-    borrow::Cow,
-    collections::HashMap,
-    fmt,
     future::{Future, poll_fn},
     panic::{AssertUnwindSafe, catch_unwind},
     pin::pin,
@@ -10,14 +6,11 @@ use std::{
     task::Poll,
 };
 
-use topcoat_core::{
-    base_url::BaseUrl,
-    context::{ContextMap, CxBuilder},
-};
+use topcoat_core::context::{ContextMap, CxBuilder};
 
 use crate::{
-    Endpoint, Layer, LayerId, Layers, LayoutFn, Methods, Next, OriginLayer, OriginPolicy, PageFn,
-    PageWithLayouts, PathSegment, RawPathParamSpec, RawPathParams, Route, Terminal,
+    Endpoint, Layer, LayerId, Layers, Next, OriginLayer, RawPathParams, Route, RouterBuilder,
+    Terminal,
     error::{internal_server_response, respond},
     request::Request,
     response::Response,
@@ -44,21 +37,21 @@ use crate::{
 /// ```
 pub struct Router {
     /// The registered routes, indexed by the values stored in `endpoints`.
-    routes: Vec<Box<dyn Route>>,
+    pub(crate) routes: Vec<Box<dyn Route>>,
     /// The endpoint handling each path, matched against the request URL and
     /// indexing into `routes` by HTTP method.
-    endpoints: matchit::Router<Endpoint>,
+    pub(crate) endpoints: matchit::Router<Endpoint>,
     /// The layers registered on this router, wrapping matched routes by path
     /// prefix.
-    layers: Layers,
+    pub(crate) layers: Layers,
     /// The values shared by every request, read back via
     /// [`app_context`](topcoat_core::context::app_context).
-    app_context: Arc<ContextMap>,
+    pub(crate) app_context: Arc<ContextMap>,
     /// The origin policy wrapping every request as the outermost layer.
-    origin: OriginLayer,
+    pub(crate) origin: OriginLayer,
     /// The compression applied to responses on their way out.
     #[cfg(feature = "compression")]
-    compression: crate::Compression,
+    pub(crate) compression: crate::Compression,
 }
 
 impl Router {
@@ -148,507 +141,26 @@ impl Router {
     }
 }
 
-/// Builds a [`Router`] for a Topcoat application.
-///
-/// This is the common construction surface used by manual routing,
-/// auto-discovery, `module_router!`, and builder extension traits. Register
-/// [`page`](Self::page), [`layout`](Self::layout), [`layer`](Self::layer), and
-/// [`route`](Self::route) handlers directly, or let a discovery helper add
-/// them, then call [`build`](Self::build) once at the end.
-///
-/// Builder extension traits add application-wide behavior before finalization,
-/// such as assets, cookies, or typed [`app_context`](Self::app_context) values.
-///
-/// # Examples
-///
-/// ```rust
-/// # struct AppConfig;
-/// # impl AppConfig { fn load() -> Self { Self } }
-/// use topcoat::{
-///     asset::{AssetBundle, RouterBuilderAssetExt},
-///     cookie::RouterBuilderCookieExt,
-///     router::{Router, RouterBuilderDiscoverExt},
-/// };
-///
-/// pub fn router() -> Router {
-///     Router::builder()
-///         .discover()
-///         .cookies()
-///         .assets(AssetBundle::load().unwrap())
-///         .app_context(AppConfig::load())
-///         .build()
-/// }
-/// ```
-pub struct RouterBuilder {
-    routes: Vec<Box<dyn Route>>,
-    pages: Vec<PageFn>,
-    layouts: Vec<LayoutFn>,
-    layers: Layers,
-    context: ContextMap,
-    origin_policy: OriginPolicy,
-    #[cfg(feature = "compression")]
-    compression: crate::Compression,
-}
-
-impl RouterBuilder {
-    /// Creates an empty builder with no routes registered.
-    #[must_use]
-    pub fn new() -> Self {
-        let mut context = ContextMap::new();
-        // Register `()` so APIs generic over an app context type can default to `S = ()`.
-        context.insert(());
-        Self {
-            routes: Vec::new(),
-            pages: Vec::new(),
-            layouts: Vec::new(),
-            layers: Layers::default(),
-            context,
-            origin_policy: OriginPolicy::new(),
-            #[cfg(feature = "compression")]
-            compression: crate::Compression::new(),
-        }
-    }
-
-    /// Returns `true` if no routes, pages, or layouts have been registered.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.routes.is_empty() && self.pages.is_empty() && self.layouts.is_empty()
-    }
-
-    /// Registers a [`Route`], an HTTP handler bound to a set of methods and a
-    /// path.
-    ///
-    /// A route responds to the methods its [`Route::methods`] declares: one or
-    /// more specific methods, or every method via [`Methods::Any`]. Specific-
-    /// method routes and one any-method route can share a path; the specific
-    /// method wins at dispatch.
-    #[must_use]
-    pub fn route(mut self, route: impl Route) -> Self {
-        self.routes.push(Box::new(route));
-        self
-    }
-
-    /// Registers every route annotated with `#[route]` and collected at link
-    /// time.
-    #[cfg(feature = "discover")]
-    #[must_use]
-    pub fn discover_routes(mut self) -> Self {
-        for route in inventory::iter::<crate::RouteFn>().cloned() {
-            self = self.route(route);
-        }
-        self
-    }
-
-    /// Registers a page: anything convertible into a [`PageFn`], like the
-    /// marker `#[page]` generates. Order doesn't matter: layout matching is
-    /// based on path prefixes, not registration order.
-    ///
-    /// A page serves the methods its [`PageFn`] declares (`GET` unless the
-    /// page opts into others).
-    #[must_use]
-    pub fn page(mut self, page: impl Into<PageFn>) -> Self {
-        self.pages.push(page.into());
-        self
-    }
-
-    /// Registers every [`PageFn`] annotated with `#[page]` and collected at
-    /// link time.
-    #[cfg(feature = "discover")]
-    #[must_use]
-    pub fn discover_pages(mut self) -> Self {
-        for page in inventory::iter::<PageFn>().cloned() {
-            self = self.page(page);
-        }
-        self
-    }
-
-    /// Registers a layout: anything convertible into a [`LayoutFn`], like the
-    /// marker `#[layout]` generates. A layout applies to every page whose path
-    /// starts with the layout's path prefix.
-    #[must_use]
-    pub fn layout(mut self, layout: impl Into<LayoutFn>) -> Self {
-        self.layouts.push(layout.into());
-        self
-    }
-
-    /// Registers every [`LayoutFn`] annotated with `#[layout]` and collected at
-    /// link time.
-    ///
-    /// At most one discovered layout is allowed per path: a page's layouts nest
-    /// by path prefix, so two layouts sharing a path would have an undefined
-    /// nesting order. To attach more than one layout to a page, give them
-    /// distinct paths or compose them in a single layout component.
-    ///
-    /// # Panics
-    ///
-    /// Panics if two discovered layouts share the same path.
-    #[cfg(feature = "discover")]
-    #[must_use]
-    #[track_caller]
-    pub fn discover_layouts(mut self) -> Self {
-        let mut seen = std::collections::HashSet::<crate::PathBuf>::new();
-        for layout in inventory::iter::<LayoutFn>().cloned() {
-            assert!(
-                seen.insert(layout.path().to_owned()),
-                "multiple discovered layouts registered for the same path \"{}\"",
-                layout.path()
-            );
-            self = self.layout(layout);
-        }
-        self
-    }
-
-    /// Registers a [`Layer`] that wraps every matched route whose path begins
-    /// with the layer's path, like a layout.
-    ///
-    /// When layers at *different* paths match a route they nest from
-    /// least-specific (outermost) to most-specific (innermost). Multiple layers
-    /// may share the same path; among those, the most recently registered runs
-    /// first (outermost), so `.layer(a).layer(b)` runs `b` around `a` when both
-    /// sit at the same path.
-    #[must_use]
-    pub fn layer(mut self, layer: impl Layer) -> Self {
-        self.layers.push(Box::new(layer));
-        self
-    }
-
-    /// Registers every layer annotated with `#[layer]` and collected at link
-    /// time.
-    ///
-    /// Unlike [`layer`](Self::layer), at most one discovered layer is allowed
-    /// per path. Link-time collection order is non-deterministic, so two
-    /// discovered layers sharing a path would have an undefined run order; this
-    /// rejects that rather than pick an arbitrary one. To stack several layers
-    /// on one path, register them explicitly with [`layer`](Self::layer), whose
-    /// order is well-defined.
-    ///
-    /// # Panics
-    ///
-    /// Panics if two discovered layers share the same path.
-    #[cfg(feature = "discover")]
-    #[must_use]
-    #[track_caller]
-    pub fn discover_layers(mut self) -> Self {
-        let mut seen = std::collections::HashSet::<crate::PathBuf>::new();
-        for layer in inventory::iter::<crate::LayerFn>().cloned() {
-            assert!(
-                seen.insert(layer.path().to_owned()),
-                "multiple discovered layers registered for the same path \"{}\"",
-                layer.path()
-            );
-            self = self.layer(layer);
-        }
-        self
-    }
-
-    /// Registers the [`OriginPolicy`] the router applies to every request.
-    ///
-    /// The default policy denies state-changing cross-origin browser requests
-    /// and cross-origin WebSocket handshakes; pass a policy to trust
-    /// cross-origin peers, exempt individual routes, or opt out entirely.
-    #[must_use]
-    pub fn origin_policy(mut self, origin_policy: OriginPolicy) -> Self {
-        self.origin_policy = origin_policy;
-        self
-    }
-
-    /// Configures the compression applied to responses.
-    ///
-    /// By default the router compresses each response with the algorithm
-    /// negotiated from the request's `Accept-Encoding` header. Pass
-    /// [`Compression::off`](crate::Compression::off) to disable compression
-    /// (say, behind a reverse proxy that compresses already), or a tuned
-    /// [`Compression`](crate::Compression) value to adjust it.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use topcoat::router::{Compression, Router};
-    ///
-    /// let router = Router::builder().compression(Compression::off()).build();
-    /// ```
-    #[cfg(feature = "compression")]
-    #[must_use]
-    pub fn compression(mut self, compression: crate::Compression) -> Self {
-        self.compression = compression;
-        self
-    }
-
-    /// Registers the base URL the application is publicly reachable at, like
-    /// `https://example.com`.
-    ///
-    /// Relative URLs work anywhere within the site, but rendered content
-    /// that leaves it (e.g. links and images in emails, feeds, or sitemaps)
-    /// needs the absolute form. The base URL is stored on the app context;
-    /// read it back with [`base_url`](topcoat_core::base_url::base_url) (or
-    /// [`try_base_url`](topcoat_core::base_url::try_base_url)) and resolve
-    /// paths against it with
-    /// [`BaseUrl::join`](topcoat_core::base_url::BaseUrl::join).
-    ///
-    /// Accepts anything convertible into a [`BaseUrl`]. A string is parsed,
-    /// so it must be an absolute `http` or `https` URL without a query or
-    /// fragment, with an optional path prefix for applications mounted
-    /// under one.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is not a valid base URL, or if a base URL has
-    /// already been registered.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use topcoat::router::Router;
-    ///
-    /// let router = Router::builder().base_url("https://example.com").build();
-    /// ```
-    #[must_use]
-    #[track_caller]
-    pub fn base_url(self, base_url: impl TryInto<BaseUrl, Error: fmt::Display>) -> Self {
-        match base_url.try_into() {
-            Ok(base_url) => self.app_context(base_url),
-            Err(error) => panic!("{error}"),
-        }
-    }
-
-    /// Registers a unique value that is accessible to every request sent to
-    /// this router by its type `T`. The top-level
-    /// [`app_context`](topcoat_core::context::app_context) function can be used to
-    /// retrieve a reference to this value via a request context.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a value has already been registered for the same type.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use topcoat::{Result, router::route};
-    /// # struct User;
-    /// # #[route(GET "/users")]
-    /// # async fn get_user() -> Result<&'static str> { Ok("ok") }
-    /// use topcoat::{
-    ///     context::{Cx, app_context},
-    ///     router::Router,
-    /// };
-    ///
-    /// struct Database {/* ... */}
-    /// # impl Database {
-    /// #     fn connect() -> Self { Self {} }
-    /// #     async fn fetch_user(&self, _id: u64) -> User { User }
-    /// # }
-    ///
-    /// pub fn router() -> Router {
-    ///     Router::builder()
-    ///         .route(get_user)
-    ///         .app_context(Database::connect())
-    ///         .build()
-    /// }
-    ///
-    /// async fn fetch_user(cx: &Cx, id: u64) -> User {
-    ///     let db: &Database = app_context(cx);
-    ///     db.fetch_user(id).await
-    /// }
-    /// ```
-    #[must_use]
-    #[track_caller]
-    pub fn app_context<T>(mut self, value: T) -> Self
-    where
-        T: Any + Send + Sync,
-    {
-        assert!(
-            self.context.insert(value).is_none(),
-            "duplicate context entry for type `{:?}`",
-            type_name::<T>()
-        );
-        self
-    }
-
-    /// Returns a reference to the app context value of type `T` registered with
-    /// [`app_context`](Self::app_context), or `None` if none has been
-    /// registered.
-    ///
-    /// Lets code that registers a shared value lazily check for it first, rather
-    /// than tripping the duplicate-registration panic on a second call.
-    #[must_use]
-    pub fn get_app_context<T>(&self) -> Option<&T>
-    where
-        T: Any + Send + Sync,
-    {
-        self.context.get::<T>()
-    }
-
-    /// Returns a mutable reference to the app context value of type `T`
-    /// registered with [`app_context`](Self::app_context), or `None` if none
-    /// has been registered.
-    #[must_use]
-    pub fn get_app_context_mut<T>(&mut self) -> Option<&mut T>
-    where
-        T: Any + Send + Sync,
-    {
-        self.context.get_mut::<T>()
-    }
-
-    /// Finalizes the registered routes, pages, and layouts into a [`Router`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if two routes resolve to the same path and HTTP method (or both
-    /// respond to every method at the same path), since the router would have
-    /// no way to choose between them, and if a route declares an empty method
-    /// set, since it could never be dispatched to.
-    ///
-    /// Also panics if two routes resolve to the same path but different layers
-    /// wrap them (possible when their group segments differ, e.g. `/(a)/x` and
-    /// `/(b)/x` with a layer at `/(a)`): every route at a path shares one layer
-    /// stack, so the divergence is rejected rather than resolved by
-    /// registration order.
-    #[must_use]
-    #[track_caller]
-    pub fn build(self) -> Router {
-        let RouterBuilder {
-            mut routes,
-            pages,
-            layouts,
-            layers,
-            context,
-            origin_policy,
-            #[cfg(feature = "compression")]
-            compression,
-        } = self;
-
-        // Wire each page to the layouts whose path is a prefix of the page's,
-        // ordered from least- to most-specific so the page nests innermost.
-        for page in pages {
-            let mut matching: Vec<LayoutFn> = layouts
-                .iter()
-                .filter(|layout| page.path().starts_with(layout.path()))
-                .cloned()
-                .collect();
-            matching.sort_by_key(|layout| layout.path().len());
-            routes.push(Box::new(PageWithLayouts::new(page, matching)));
-        }
-
-        // Group routes that share a path into a single endpoint first, since
-        // matchit rejects inserting the same path twice. Two routes that resolve
-        // to the same path *and* method are ambiguous, so reject them here.
-        // Remember each group's first route index to name it in the layer
-        // divergence panic below.
-        let mut grouped: HashMap<Cow<'static, str>, (usize, Endpoint)> = HashMap::new();
-        let mut interned_path_params: HashMap<&str, Arc<str>> = HashMap::new();
-        for (index, route) in routes.iter().enumerate() {
-            let layer_stack = layers.for_endpoint(route.path());
-            let (first, endpoint) = grouped
-                .entry(route.path().to_matchit_path())
-                .or_insert_with(|| {
-                    let path_params = route
-                        .path()
-                        .segments()
-                        .filter_map(|segment| {
-                            let (param, is_catch_all) = match segment {
-                                PathSegment::Param(param) => (param, false),
-                                PathSegment::CatchAll(param) => (param, true),
-                                _ => return None,
-                            };
-                            let interned = interned_path_params
-                                .entry(param)
-                                .or_insert_with(|| Arc::from(param.to_owned().into_boxed_str()));
-                            Some(if is_catch_all {
-                                RawPathParamSpec::catch_all(interned.clone())
-                            } else {
-                                RawPathParamSpec::segment(interned.clone())
-                            })
-                        })
-                        .collect();
-                    let endpoint =
-                        Endpoint::new(path_params, layer_stack.clone().into_boxed_slice());
-                    (index, endpoint)
-                });
-
-            // Every route grouped at a path shares the endpoint's layer stack
-            // (the 405 fallback included), so their full paths -- group
-            // segments and all -- must select the same layers. Reject a
-            // divergence rather than let registration order pick a winner.
-            assert!(
-                layer_stack == endpoint.layers(),
-                "routes `{}` and `{}` serve the same URL path but select different layers",
-                routes[*first].path(),
-                route.path(),
-            );
-
-            // An any-method route shares its path with specific-method routes
-            // (which win at dispatch), so the two kinds are checked for
-            // duplicates independently.
-            match route.methods() {
-                Methods::Any => {
-                    assert!(
-                        endpoint.any().is_none(),
-                        "duplicate any-method route registered for `{}`",
-                        route.path().to_matchit_path()
-                    );
-                    endpoint.insert_any(index);
-                }
-                Methods::Only(methods) => {
-                    assert!(
-                        !methods.is_empty(),
-                        "route `{}` registers no methods",
-                        route.path()
-                    );
-                    for method in methods {
-                        assert!(
-                            endpoint.get(method).is_none(),
-                            "duplicate route registered for `{method} {}`",
-                            route.path().to_matchit_path()
-                        );
-                        endpoint.insert(method.clone(), index);
-                    }
-                }
-            }
-        }
-
-        // Precompute the layer stack wrapping each endpoint once, so dispatch
-        // only has to index into it rather than filter and sort per request.
-        let mut endpoints = matchit::Router::new();
-        for (path, (_, mut endpoint)) in grouped {
-            endpoint.alias_head_to_get();
-            endpoints
-                .insert(path.clone(), endpoint)
-                .unwrap_or_else(|error| panic!("failed to register route {path:?}: {error}"));
-        }
-
-        Router {
-            routes,
-            endpoints,
-            layers,
-            app_context: Arc::new(context),
-            origin: OriginLayer::new(origin_policy),
-            #[cfg(feature = "compression")]
-            compression,
-        }
-    }
-}
-
-impl Default for RouterBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{future::Future, pin::Pin, sync::Mutex};
+    use std::{
+        borrow::Cow,
+        future::Future,
+        pin::Pin,
+        sync::{Arc, Mutex},
+    };
 
     use http::{HeaderMap, StatusCode};
     use topcoat_core::{
-        context::{Cx, app_context, request_context},
+        context::{Cx, CxBuilder, app_context, request_context},
         error::Result,
     };
     use topcoat_view::{DynViewPart, HtmlContext, HtmlWriter, PartsWriter, View, ViewParts};
 
     use super::*;
     use crate::{
-        Body, LayerFn, LayerFuture, Method, Path, RouteFn, RouteFuture, request::Bytes,
-        response::IntoResponse, to_bytes,
+        Body, LayerFn, LayerFuture, LayoutFn, Method, Methods, OriginPolicy, PageFn, Path, RouteFn,
+        RouteFuture, request::Bytes, response::IntoResponse, to_bytes,
     };
 
     // -- Test helpers --
@@ -811,37 +323,6 @@ mod tests {
             PartsWriter::new(&mut parts, HtmlContext::Text).push_str("]");
             Ok(View::new(parts))
         })
-    }
-
-    // -- RouterBuilder --
-
-    #[test]
-    fn new_builder_is_empty() {
-        let builder = RouterBuilder::new();
-        assert!(builder.is_empty());
-    }
-
-    #[test]
-    fn builder_is_not_empty_after_registering_a_route() {
-        let builder = RouterBuilder::new().route(RouteFn::new(Method::GET, path("/x"), say_route));
-        assert!(!builder.is_empty());
-    }
-
-    #[test]
-    #[should_panic(expected = "duplicate route")]
-    fn duplicate_method_and_path_panics_on_build() {
-        let _ = RouterBuilder::new()
-            .route(RouteFn::new(Method::GET, path("/x"), say_route))
-            .route(RouteFn::new(Method::GET, path("/x"), say_route))
-            .build();
-    }
-
-    #[test]
-    #[should_panic(expected = "duplicate context entry")]
-    fn duplicate_app_context_type_panics() {
-        let _ = RouterBuilder::new()
-            .app_context(Greeting("a"))
-            .app_context(Greeting("b"));
     }
 
     // -- Router::handle: dispatch --
@@ -1049,36 +530,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "duplicate any-method route")]
-    fn duplicate_any_method_routes_panic_on_build() {
-        let _ = RouterBuilder::new()
-            .route(RouteFn::new(Methods::Any, path("/x"), say_any))
-            .route(RouteFn::new(Methods::Any, path("/x"), say_any))
-            .build();
-    }
-
-    #[test]
-    #[should_panic(expected = "duplicate route")]
-    fn overlapping_method_sets_panic_on_build() {
-        let _ = RouterBuilder::new()
-            .route(RouteFn::new(
-                &[Method::GET, Method::POST],
-                path("/x"),
-                say_route,
-            ))
-            .route(RouteFn::new(Method::POST, path("/x"), say_posted))
-            .build();
-    }
-
-    #[test]
-    #[should_panic(expected = "registers no methods")]
-    fn route_without_methods_panics_on_build() {
-        let _ = RouterBuilder::new()
-            .route(RouteFn::new(Vec::<Method>::new(), path("/x"), say_route))
-            .build();
-    }
-
-    #[test]
     fn app_context_is_available_to_handlers() {
         let router = RouterBuilder::new()
             .route(RouteFn::new(Method::GET, path("/hi"), say_greeting))
@@ -1098,12 +549,6 @@ mod tests {
         let (status, _, body) = send(&router, Method::GET, "/x");
         assert_eq!(status, StatusCode::OK);
         assert_eq!(&body[..], b"https://example.com");
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid base URL")]
-    fn invalid_base_url_panics_at_registration() {
-        let _ = RouterBuilder::new().base_url("not a url");
     }
 
     // -- Router::handle: layers --
@@ -1272,19 +717,6 @@ mod tests {
         let (status, _, _) = send(&router, Method::GET, "/missing");
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(*trace.lock().unwrap(), vec!["auth"]);
-    }
-
-    #[test]
-    #[should_panic(expected = "select different layers")]
-    fn routes_sharing_a_url_with_different_layers_panic() {
-        // Both routes serve `/x` (groups are stripped from the URL), but only
-        // the `(a)` route is wrapped by the `/(a)` layer. The endpoint's layer
-        // stack is shared, so the build rejects the divergence.
-        let _ = RouterBuilder::new()
-            .route(RouteFn::new(Method::GET, path("/(a)/x"), say_route))
-            .route(RouteFn::new(Method::POST, path("/(b)/x"), say_posted))
-            .layer(LayerFn::new(path("/(a)"), trace_auth))
-            .build();
     }
 
     #[test]

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -6,12 +6,11 @@ use std::{
     task::Poll,
 };
 
-use topcoat_core::context::{ContextMap, CxBuilder};
+use topcoat_core::context::{ContextMap, Cx, CxBuilder};
 
 use crate::{
-    Endpoint, Layer, LayerId, Layers, Next, OriginLayer, RawPathParams, Route, RouterBuilder,
-    Terminal,
-    error::{internal_server_response, respond},
+    Endpoint, Layer, Layers, Next, OriginLayer, RawPathParams, Route, RouterBuilder, Terminal,
+    error::{internal_server_response, not_found, respond},
     request::Request,
     response::Response,
 };
@@ -89,34 +88,24 @@ impl Router {
     async fn handle_inner(&self, request: Request) -> Response {
         let (parts, body) = request.into_parts();
 
-        // Resolve the layer stack and the chain's terminal. A matched path
-        // reuses its endpoint's precomputed layer stack, whether the method
-        // matches (a route) or not (405), so both flow through the same layers.
-        // An unmatched path (404) has no precomputed stack, so its layers are
-        // selected from the request path on this cold path.
-        let not_found_layers: Vec<LayerId>;
-        let (layers, terminal, path_params) =
-            if let Ok(matched) = self.endpoints.at(parts.uri.path()) {
-                let endpoint = matched.value;
-                let path_params = {
-                    debug_assert_eq!(endpoint.path_params().len(), matched.params.len());
-                    let keys = endpoint.path_params().iter().cloned();
-                    let values = matched.params.iter().map(|(_, value)| value);
-                    RawPathParams::from_pairs(keys.zip(values))
-                };
-                let terminal = match endpoint.get(&parts.method).or_else(|| endpoint.any()) {
-                    Some(index) => Terminal::Route(&*self.routes[index]),
-                    None => Terminal::MethodNotAllowed(matched.value),
-                };
-                (matched.value.layers(), terminal, path_params)
-            } else {
-                not_found_layers = self.layers.match_path(parts.uri.path());
-                (
-                    &*not_found_layers,
-                    Terminal::NotFound,
-                    RawPathParams::default(),
-                )
-            };
+        let Ok(matched) = self.endpoints.at(parts.uri.path()) else {
+            return respond(&Cx::default(), not_found());
+        };
+
+        // The chain's terminal, reached through the endpoint's precomputed
+        // layer stack whether the method matches (a route) or not (405), so
+        // both flow through the same layers.
+        let endpoint = matched.value;
+        let path_params = {
+            debug_assert_eq!(endpoint.path_params().len(), matched.params.len());
+            let keys = endpoint.path_params().iter().cloned();
+            let values = matched.params.iter().map(|(_, value)| value);
+            RawPathParams::from_pairs(keys.zip(values))
+        };
+        let terminal = match endpoint.get(&parts.method).or_else(|| endpoint.any()) {
+            Some(index) => Terminal::Route(&*self.routes[index]),
+            None => Terminal::MethodNotAllowed(endpoint),
+        };
 
         let mut cx = CxBuilder::new(self.app_context.clone());
         cx.insert(path_params);
@@ -124,7 +113,7 @@ impl Router {
 
         // The origin layer wraps the whole chain, denying untrusted
         // cross-origin requests before anything else runs.
-        let next = Next::new(&self.layers, layers, terminal);
+        let next = Next::new(&self.layers, endpoint.layers(), terminal);
         let response = self.origin.handle(&mut cx, body, next).await;
         let response = respond(&cx, response);
 
@@ -592,12 +581,22 @@ mod tests {
     }
 
     #[test]
-    fn layers_wrap_not_found_responses() {
-        let (router, trace) =
-            trace_router(RouterBuilder::new().layer(LayerFn::new(path("/"), trace_root)));
+    fn layers_do_not_wrap_not_found_responses() {
+        let (router, trace) = trace_router(
+            RouterBuilder::new()
+                .route(RouteFn::new(Method::GET, path("/admin/x"), say_route))
+                .layer(LayerFn::new(path("/"), trace_root)),
+        );
+
         let (status, _, _) = send(&router, Method::GET, "/missing");
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(*trace.lock().unwrap(), vec!["root"]);
+        assert!(trace.lock().unwrap().is_empty());
+
+        // A trailing slash is a different URL: the route does not match, and
+        // the unmatched path is answered without running any layers.
+        let (status, _, _) = send(&router, Method::GET, "/admin/x/");
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(trace.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -613,39 +612,7 @@ mod tests {
     }
 
     #[test]
-    fn layers_run_for_trailing_slash_urls() {
-        let (router, trace) = trace_router(
-            RouterBuilder::new()
-                .route(RouteFn::new(Method::GET, path("/admin/x"), say_route))
-                .layer(LayerFn::new(path("/admin"), trace_admin))
-                .layer(LayerFn::new(path("/"), trace_root)),
-        );
-
-        // A trailing slash is a different URL: the route does not match, but
-        // the layers wrapping the path still run around the 404.
-        let (status, _, _) = send(&router, Method::GET, "/admin/x/");
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(*trace.lock().unwrap(), vec!["root", "admin"]);
-    }
-
-    #[test]
-    fn layers_do_not_run_for_lookalike_prefixes() {
-        let (router, trace) = trace_router(
-            RouterBuilder::new()
-                .route(RouteFn::new(Method::GET, path("/admin/x"), say_route))
-                .layer(LayerFn::new(path("/admin"), trace_admin))
-                .layer(LayerFn::new(path("/"), trace_root)),
-        );
-
-        // `/admin` prefixes the string `/administrator` but not its segments,
-        // so only the root layer wraps the 404.
-        let (status, _, _) = send(&router, Method::GET, "/administrator");
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(*trace.lock().unwrap(), vec!["root"]);
-    }
-
-    #[test]
-    fn layer_selection_ignores_query_strings() {
+    fn dispatch_ignores_query_strings() {
         let (router, trace) = trace_router(
             RouterBuilder::new()
                 .route(RouteFn::new(Method::GET, path("/admin/x"), say_route))
@@ -654,12 +621,6 @@ mod tests {
 
         let (status, _, _) = send(&router, Method::GET, "/admin/x?tab=users");
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(*trace.lock().unwrap(), vec!["admin"]);
-
-        // The same holds on the 404 path, which selects layers by URL.
-        trace.lock().unwrap().clear();
-        let (status, _, _) = send(&router, Method::GET, "/admin/missing?tab=users");
-        assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(*trace.lock().unwrap(), vec!["admin"]);
     }
 
@@ -704,18 +665,6 @@ mod tests {
         let (status, _, body) = send(&router, Method::GET, "/dashboard");
         assert_eq!(status, StatusCode::OK);
         assert_eq!(&body[..], b"route");
-        assert_eq!(*trace.lock().unwrap(), vec!["auth"]);
-    }
-
-    #[test]
-    fn group_layers_wrap_not_found_urls_anywhere() {
-        let (router, trace) =
-            trace_router(RouterBuilder::new().layer(LayerFn::new(path("/(auth)"), trace_auth)));
-
-        // A 404 URL cannot be attributed to a group, and a group-only path is
-        // URL-equivalent to the root, so the layer wraps every unmatched URL.
-        let (status, _, _) = send(&router, Method::GET, "/missing");
-        assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(*trace.lock().unwrap(), vec!["auth"]);
     }
 

--- a/crates/topcoat-router/src/tower.rs
+++ b/crates/topcoat-router/src/tower.rs
@@ -488,8 +488,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        Layers, Method, RouteFn, RouteFuture, Router, Terminal, error::NotFoundError,
-        request::Bytes, response::IntoResponse, to_bytes,
+        Layers, Method, RouteFn, RouteFuture, Router, Terminal,
+        error::{NotFoundError, not_found},
+        request::Bytes,
+        response::IntoResponse,
+        to_bytes,
     };
 
     // -- Test helpers --
@@ -551,6 +554,12 @@ mod tests {
     /// A route that never resolves, for racing against a timeout middleware.
     fn hang(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
         Box::pin(std::future::pending())
+    }
+
+    /// A route resolving to a typed 404 error, to observe how errors cross
+    /// tower middleware.
+    fn not_found_route(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        Box::pin(async move { Err(not_found().into()) })
     }
 
     /// A route whose body is long enough to clear tower-http's compression
@@ -872,9 +881,10 @@ mod tests {
     fn chain_errors_tunnel_through_unchanged() {
         let layer = TowerLayer::new(tower::layer::util::Identity::new());
         let layers = Layers::default();
+        let route = RouteFn::new(Method::GET, path("/missing"), not_found_route);
         let mut cx = cx_for("/missing");
 
-        let next = Next::new(&layers, &[], Terminal::NotFound);
+        let next = Next::new(&layers, &[], Terminal::Route(&route));
         let result = block_on(layer.handle(&mut cx, Body::empty(), next));
 
         // The 404 comes back out as the original typed error, not a response.
@@ -892,9 +902,10 @@ mod tests {
         // still be recovered on the way out.
         let layer = TowerLayer::new(tower::timeout::TimeoutLayer::new(Duration::from_mins(1)));
         let layers = Layers::default();
+        let route = RouteFn::new(Method::GET, path("/missing"), not_found_route);
         let mut cx = cx_for("/missing");
 
-        let next = Next::new(&layers, &[], Terminal::NotFound);
+        let next = Next::new(&layers, &[], Terminal::Route(&route));
         let result = block_on(layer.handle(&mut cx, Body::empty(), next));
 
         assert!(

--- a/examples/error/Cargo.toml
+++ b/examples/error/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "error"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+topcoat.workspace = true
+
+[lints]
+workspace = true

--- a/examples/error/README.md
+++ b/examples/error/README.md
@@ -1,0 +1,76 @@
+# Error
+
+This example demonstrates how handler errors become HTTP responses and how a layout replaces them with branded error pages.
+
+It serves a small post catalog: a missing post responds 404, an unparsable id 400, the admin area 403, and a catch-all page gives unrouted URLs the same branded 404 as the rest of the application.
+
+## Run the example
+
+From the repository root, run:
+
+```sh
+cargo run --manifest-path examples/error/Cargo.toml
+```
+
+From inside the `examples` directory, run:
+
+```sh
+cargo run --manifest-path error/Cargo.toml
+```
+
+The application is served by default at:
+
+```text
+http://127.0.0.1:3000
+```
+
+## Test in the browser
+
+Open:
+
+```text
+http://127.0.0.1:3000
+```
+
+The home page links every case: an existing post, a missing post, the admin area, and an unrouted URL. The missing post and the unrouted URL both render the branded "Page not found" view, and the admin area renders "Access denied", each inside the shared layout.
+
+## Test with curl
+
+Check the status code of each route:
+
+```sh
+for path in / /posts/1 /posts/7 /posts/oops /admin /no/such/page; do
+    curl --silent --output /dev/null --write-out "%{http_code} $path\n" \
+        "http://127.0.0.1:3000$path"
+done
+```
+
+Expected output:
+
+```text
+200 /
+200 /posts/1
+404 /posts/7
+400 /posts/oops
+403 /admin
+404 /no/such/page
+```
+
+Fetch an unrouted URL to see the branded body:
+
+```sh
+curl --silent http://127.0.0.1:3000/no/such/page
+```
+
+The response is the "Page not found" view wrapped in the layout, served with a 404 status.
+
+## How it works
+
+- Every handler returns a `Result`; an `Err` becomes the response, mapped onto its HTTP status code.
+- `path_param!(post_id: u64, error = bad_request)` answers an unparsable id with a 400.
+- `ok_or_not_found()` replaces the `None` of a missing post with a `NotFoundError`.
+- The admin page returns the `forbidden()` constructor directly.
+- The root layout downcasts `NotFoundError` and `ForbiddenError` and replaces them with branded views; the `StatusCode` in each view keeps the error's status.
+- `not_found!("/")` registers a catch-all page, so a URL matching no route resolves to a `NotFoundError` that flows through the layout instead of the router's bare 404.
+
+Stop the server by pressing `Ctrl+C`.

--- a/examples/error/src/main.rs
+++ b/examples/error/src/main.rs
@@ -1,0 +1,82 @@
+use topcoat::{
+    Result,
+    context::Cx,
+    router::{
+        Router, RouterBuilderDiscoverExt, StatusCode,
+        error::{ForbiddenError, NotFoundError, RouterErrorExt, forbidden},
+        layout, not_found, page, path_param,
+    },
+    view::view,
+};
+
+#[tokio::main]
+async fn main() {
+    topcoat::start(Router::builder().discover().build())
+        .await
+        .unwrap();
+}
+
+#[page("/")]
+async fn home() -> Result {
+    view! {
+        <h1>"Error handling"</h1>
+        <ul>
+            <li><a href="/posts/1">"An existing post"</a></li>
+            <li><a href="/posts/7">"A missing post (404)"</a></li>
+            <li><a href="/admin">"The admin area (403)"</a></li>
+            <li><a href="/no/such/page">"An unrouted URL (404)"</a></li>
+        </ul>
+    }
+}
+
+// An error keeps its type on the way out, so the layout can downcast it and
+// replace it with a branded error page.
+#[layout("/")]
+async fn root_layout(slot: Result) -> Result {
+    let content = match slot {
+        Err(error) if error.downcast_ref::<NotFoundError>().is_some() => view! {
+            (StatusCode::NOT_FOUND)
+            <h1>"Page not found"</h1>
+        },
+        Err(error) if error.downcast_ref::<ForbiddenError>().is_some() => view! {
+            (StatusCode::FORBIDDEN)
+            <h1>"Access denied"</h1>
+        },
+        content => content,
+    }?;
+
+    view! {
+        <html>
+            <body>
+                (content)
+                <p><a href="/">"Home"</a></p>
+            </body>
+        </html>
+    }
+}
+
+path_param!(post_id: u64, error = bad_request);
+
+// ok_or_not_found turns the None into a 404, which the layout catches above.
+#[page("/posts/{post_id}")]
+async fn post(cx: &Cx) -> Result {
+    let title = match *path_param::<PostId>(cx)? {
+        1 => Some("Hello Topcoat"),
+        2 => Some("Error handling"),
+        _ => None,
+    }
+    .ok_or_not_found()?;
+
+    view! { <h1>(title)</h1> }
+}
+
+// An error constructor converts into the handler's error type.
+#[page("/admin")]
+async fn admin() -> Result {
+    Err(forbidden().into())
+}
+
+// A URL matching no route is normally answered with a bare 404 that skips the
+// layouts. This catch-all page resolves such URLs to a NotFoundError instead,
+// so the layout brands them like any other handler error.
+not_found!("/");


### PR DESCRIPTION
A request whose path matches no route is now answered with a bare 404 immediately. Layers no longer run for unmatched paths, which removes the request-time URL matching that existed only for that case: `Layers::match_path`, `Terminal::NotFound`, and `Path::matches_start` are gone, and the 404 cold path in `Router::handle_inner` collapses to an early return. A 405 still comes from a matched endpoint and flows through that endpoint's precomputed layer stack.

Since router-raised 404s no longer pass through layouts, this adds a `not_found!` macro to bring back branded not-found pages as regular routes:

- `not_found!("/admin")` expands to an any-method `#[page]` named `not_found` at `/admin/{*rest}` that resolves to `Err(not_found())`, so layers and layouts wrap it and a layout can catch the `NotFoundError`.
- `not_found!()` expands to a `not_found` module with a `segment!(kind = CatchAll)` override for use under `module_router!`.

The error guide now introduces layout error catching with `ForbiddenError` and covers the unmatched-URL case in a new "Not-found pages" section; the `layer` reference drops the 404 URL-matching paragraph.

BREAKING CHANGE: layers and layouts no longer run for requests whose path matches no route; register a `not_found!` catch-all page to handle those URLs. `Path::matches_start` is removed.
