### PR TITLE
feat: implement NodeViewParts and AttributeValueViewParts for Cow<'static, str>

### DIFF
--- a/crates/topcoat-view/src/attribute/value.rs
+++ b/crates/topcoat-view/src/attribute/value.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use topcoat_core::context::Cx;
 
 use crate::{PartsWriter, Unescaped, ViewPart};
@@ -83,6 +85,7 @@ impl_primitive!(usize, push_usize, ref);
 impl_primitive!(f32, push_f32, ref);
 impl_primitive!(f64, push_f64, ref);
 impl_primitive!(String, push_str);
+impl_primitive!(Cow<'static, str>, push_str);
 
 impl AttributeValueViewParts for &str {
     #[inline]

--- a/crates/topcoat-view/src/node.rs
+++ b/crates/topcoat-view/src/node.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[cfg(feature = "http")]
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use topcoat_core::context::Cx;
@@ -71,6 +73,7 @@ impl_primitive!(usize, push_usize, ref);
 impl_primitive!(f32, push_f32, ref);
 impl_primitive!(f64, push_f64, ref);
 impl_primitive!(String, push_str);
+impl_primitive!(Cow<'static, str>, push_str);
 
 impl NodeViewParts for &str {
     #[inline]


### PR DESCRIPTION
`PartsWriter::push_str` takes `Into<Cow<'static, str>>` so this is free and allows for minimizing unnecessary heap allocations.