### PR TITLE
feat(core)!: specify as_ref manually on memoized functions

### DIFF
--- a/crates/topcoat-core/grammar/src/memoize.rs
+++ b/crates/topcoat-core/grammar/src/memoize.rs
@@ -1,19 +1,41 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote, quote_spanned};
 use syn::{
-    FnArg, ItemFn, Pat, ReturnType, Type,
+    FnArg, ItemFn, Pat, ReturnType,
     parse::{Parse, ParseStream},
     parse_quote,
     spanned::Spanned,
 };
 
-use crate::paths::{topcoat_context, topcoat_internal};
+use crate::paths::topcoat_context;
 
-pub struct MemoizeAttr {}
+mod kw {
+    use syn::custom_keyword;
+
+    custom_keyword!(as_ref);
+}
+
+pub struct MemoizeAttr {
+    as_ref: Option<kw::as_ref>,
+}
+
+impl MemoizeAttr {
+    /// Whether the return value is borrowed through `.as_ref()`, exposing the
+    /// `MemoizeAsRef` associated type instead of a plain reference.
+    fn as_ref(&self) -> bool {
+        self.as_ref.is_some()
+    }
+}
 
 impl Parse for MemoizeAttr {
-    fn parse(_input: ParseStream) -> syn::Result<Self> {
-        Ok(Self {})
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            as_ref: if input.is_empty() {
+                None
+            } else {
+                Some(input.parse()?)
+            },
+        })
     }
 }
 
@@ -134,9 +156,9 @@ impl ToTokens for Memoize {
             ReturnType::Type(_, ty) => (**ty).clone(),
         };
         let return_type = quote! { #return_ty };
-        let return_type_as_ref = is_option_or_result(&return_ty);
-        let output_type = if return_type_as_ref {
-            quote! { <&'__cx #return_type as #topcoat_internal::MemoizeAsRef>::AsRef }
+        let as_ref = self.0.as_ref();
+        let output_type = if as_ref {
+            quote! { <#return_type as #topcoat_context::MemoizeAsRef>::AsRef<'__cx> }
         } else {
             quote! { &'__cx #return_type }
         };
@@ -167,8 +189,8 @@ impl ToTokens for Memoize {
             }
         };
 
-        let output = if return_type_as_ref {
-            quote! { (#call).as_ref() }
+        let output = if as_ref {
+            quote! { #topcoat_context::MemoizeAsRef::as_ref(#call) }
         } else {
             call
         };
@@ -185,12 +207,24 @@ impl ToTokens for Memoize {
     }
 }
 
-fn is_option_or_result(ty: &Type) -> bool {
-    let Type::Path(path) = ty else {
-        return false;
-    };
-    path.path
-        .segments
-        .last()
-        .is_some_and(|segment| segment.ident == "Option" || segment.ident == "Result")
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_arguments() {
+        let attr: MemoizeAttr = syn::parse_str("").unwrap();
+        assert!(!attr.as_ref());
+    }
+
+    #[test]
+    fn parses_as_ref() {
+        let attr: MemoizeAttr = syn::parse_str("as_ref").unwrap();
+        assert!(attr.as_ref());
+    }
+
+    #[test]
+    fn rejects_unknown_argument() {
+        assert!(syn::parse_str::<MemoizeAttr>("cloned").is_err());
+    }
 }

--- a/crates/topcoat-core/macro/docs/memoize.md
+++ b/crates/topcoat-core/macro/docs/memoize.md
@@ -20,9 +20,7 @@ async fn get_user(cx: &Cx, id: i64) -> User {
 }
 ```
 
-That's it. Calling `get_user(cx, 42).await` from anywhere in the request (a page, a layout, a component) runs the body the first time and returns the cached `User` for every subsequent call with `id == 42`. The function's return type `T` is rewritten to `&T` that has the same lifetime as `&cx`.
-
-Top-level `Option<T>` and `Result<T, E>` return types are borrowed ergonomically: the macro calls `.as_ref()` on the cached value and returns `Option<&T>` or `Result<&T, &E>` instead of `&Option<T>` or `&Result<T, E>`.
+That's it. Calling `get_user(cx, 42).await` from anywhere in the request (a page, a layout, a component) runs the body the first time and returns the cached `User` for every subsequent call with `id == 42`. The function's return type `T` is rewritten to `&T` that has the same lifetime as `&cx`. To borrow the contents of an `Option<T>` or `Result<T, E>` return value instead, see [`as_ref`](#borrowing-option-and-result-contents) below.
 
 # Sync and async
 
@@ -119,7 +117,7 @@ Arguments can be passed by value or by reference. Borrowed arguments avoid cloni
 # mod db {
 #     pub async fn find(_name: &str) -> Result<super::Record, super::Error> { Ok(super::Record) }
 # }
-#[memoize]
+#[memoize(as_ref)]
 async fn lookup(cx: &Cx, name: &str) -> Result<Record, Error> {
     db::find(name).await
 }
@@ -131,6 +129,31 @@ let record = lookup(cx, "alice").await?; // cache hit, no allocation
 # Ok(())
 # }
 ```
+
+# Borrowing Option and Result contents
+
+By default the macro returns a reference to the cached value itself: a function returning `Option<User>` hands out `&Option<User>`. Pass `as_ref` to the attribute to borrow the cached value's contents instead:
+
+```rust
+# fn main() {}
+# struct User;
+# mod db {
+#     pub async fn load_user(_id: i64) -> Option<super::User> { None }
+# }
+use topcoat::context::{Cx, memoize};
+
+#[memoize(as_ref)]
+async fn find_user(cx: &Cx, id: i64) -> Option<User> {
+    db::load_user(id).await
+}
+
+# async fn example(cx: &Cx) {
+let user: Option<&User> = find_user(cx, 42).await;
+# let _ = user;
+# }
+```
+
+With `as_ref`, the macro rewrites the return type through the `MemoizeAsRef` trait: `Option<T>` comes back as `Option<&T>` and `Result<T, E>` as `Result<&T, &E>`. Implement the trait for your own return types to use them with `as_ref`.
 
 # Requirements
 
@@ -168,7 +191,7 @@ use topcoat::{
     view::view,
 };
 
-#[memoize]
+#[memoize(as_ref)]
 async fn current_user(cx: &Cx) -> Option<User> {
     auth::resolve(cx).await
 }

--- a/crates/topcoat-core/macro/docs/memoize.md
+++ b/crates/topcoat-core/macro/docs/memoize.md
@@ -105,31 +105,6 @@ add(cx, 1, 3); // prints "computing", returns 4 (different args)
 
 Each `#[memoize]` function has its own independent cache slot, so two functions with the same argument types don't collide.
 
-# Borrowed and owned arguments
-
-Arguments can be passed by value or by reference. Borrowed arguments avoid cloning on cache hits; on a miss the value is cloned once into the cache.
-
-```rust
-# fn main() {}
-# use topcoat::context::{Cx, memoize};
-# struct Record;
-# struct Error;
-# mod db {
-#     pub async fn find(_name: &str) -> Result<super::Record, super::Error> { Ok(super::Record) }
-# }
-#[memoize(as_ref)]
-async fn lookup(cx: &Cx, name: &str) -> Result<Record, Error> {
-    db::find(name).await
-}
-
-# async fn example(cx: &Cx) -> Result<(), &Error> {
-let record = lookup(cx, "alice").await?; // computes; stores "alice".to_owned() as the key
-let record = lookup(cx, "alice").await?; // cache hit, no allocation
-# let _ = record;
-# Ok(())
-# }
-```
-
 # Borrowing Option and Result contents
 
 By default the macro returns a reference to the cached value itself: a function returning `Option<User>` hands out `&Option<User>`. Pass `as_ref` to the attribute to borrow the cached value's contents instead:
@@ -154,6 +129,31 @@ let user: Option<&User> = find_user(cx, 42).await;
 ```
 
 With `as_ref`, the macro rewrites the return type through the `MemoizeAsRef` trait: `Option<T>` comes back as `Option<&T>` and `Result<T, E>` as `Result<&T, &E>`. Implement the trait for your own return types to use them with `as_ref`.
+
+# Borrowed and owned arguments
+
+Arguments can be passed by value or by reference. Borrowed arguments avoid cloning on cache hits; on a miss the value is cloned once into the cache.
+
+```rust
+# fn main() {}
+# use topcoat::context::{Cx, memoize};
+# struct Record;
+# struct Error;
+# mod db {
+#     pub async fn find(_name: &str) -> Result<super::Record, super::Error> { Ok(super::Record) }
+# }
+#[memoize(as_ref)]
+async fn lookup(cx: &Cx, name: &str) -> Result<Record, Error> {
+    db::find(name).await
+}
+
+# async fn example(cx: &Cx) -> Result<(), &Error> {
+let record = lookup(cx, "alice").await?; // computes; stores "alice".to_owned() as the key
+let record = lookup(cx, "alice").await?; // cache hit, no allocation
+# let _ = record;
+# Ok(())
+# }
+```
 
 # Requirements
 

--- a/crates/topcoat-core/macro/tests/memoize.rs
+++ b/crates/topcoat-core/macro/tests/memoize.rs
@@ -85,10 +85,10 @@ async fn async_memoized_function_returns_stable_reference() {
 }
 
 #[tokio::test]
-async fn memoized_option_return_is_borrowed_ergonomically() {
+async fn memoized_option_return_is_borrowed_ergonomically_with_as_ref() {
     static CALLS: AtomicUsize = AtomicUsize::new(0);
 
-    #[memoize]
+    #[memoize(as_ref)]
     fn maybe(cx: &Cx, is_some: bool) -> Option<i32> {
         let _ = cx;
         CALLS.fetch_add(1, Ordering::SeqCst);
@@ -105,6 +105,38 @@ async fn memoized_option_return_is_borrowed_ergonomically() {
 
     maybe(&cx, true);
     assert_eq!(CALLS.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn memoized_result_return_is_borrowed_ergonomically_with_as_ref() {
+    #[memoize(as_ref)]
+    fn fallible(cx: &Cx, fail: bool) -> Result<i32, String> {
+        let _ = cx;
+        if fail { Err("nope".to_owned()) } else { Ok(42) }
+    }
+
+    let cx = Cx::default();
+
+    let ok_value: Result<&i32, &String> = fallible(&cx, false);
+    let err_value: Result<&i32, &String> = fallible(&cx, true);
+
+    assert_eq!(ok_value, Ok(&42));
+    assert_eq!(err_value, Err(&"nope".to_owned()));
+}
+
+#[tokio::test]
+async fn memoized_option_return_is_a_plain_reference_by_default() {
+    #[memoize]
+    fn maybe(cx: &Cx, is_some: bool) -> Option<i32> {
+        let _ = cx;
+        if is_some { Some(42) } else { None }
+    }
+
+    let cx = Cx::default();
+
+    let value: &Option<i32> = maybe(&cx, true);
+
+    assert_eq!(value, &Some(42));
 }
 
 #[tokio::test]

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -6,6 +6,7 @@ use std::{any::Any, ops::Deref, sync::Arc};
 pub use context_map::*;
 pub use id::*;
 
+pub use crate::memoize::MemoizeAsRef;
 use crate::{abort::AbortStore, memoize::MemoizeCache};
 
 /// The request context.

--- a/crates/topcoat-core/src/internal.rs
+++ b/crates/topcoat-core/src/internal.rs
@@ -1,24 +1,3 @@
-/// Converts a borrowed memoized `Option` or `Result` into the ergonomic
-/// borrowed shape exposed by `#[memoize]`.
-///
-/// `#[memoize]` stores the function's original return value in the request
-/// cache and normally returns `&T`. For top-level `Option<T>` and
-/// `Result<T, E>` return values, the macro applies `.as_ref()` and publishes
-/// this associated type instead, yielding `Option<&T>` and `Result<&T, &E>`.
-#[doc(hidden)]
-pub trait MemoizeAsRef {
-    /// The return type produced after borrowing the cached value's contents.
-    type AsRef;
-}
-
-impl<'a, T> MemoizeAsRef for &'a Option<T> {
-    type AsRef = Option<&'a T>;
-}
-
-impl<'a, T, E> MemoizeAsRef for &'a Result<T, E> {
-    type AsRef = Result<&'a T, &'a E>;
-}
-
 pub trait ResultExt {
     type T;
     type E;

--- a/crates/topcoat-core/src/memoize.rs
+++ b/crates/topcoat-core/src/memoize.rs
@@ -22,3 +22,68 @@ impl MemoizeCache {
         &self.eq_cache
     }
 }
+
+/// The borrowed return type of a `#[memoize(as_ref)]` function.
+///
+/// `#[memoize]` stores the function's return value in the request cache and
+/// hands out `&T`. With `as_ref`, the macro instead borrows the cached
+/// value's contents through this trait, so an `Option<T>` or `Result<T, E>`
+/// return value comes back as `Option<&T>` or `Result<&T, &E>`.
+///
+/// Implement this trait for your own return type to use it with
+/// `#[memoize(as_ref)]`:
+///
+/// ```rust
+/// use topcoat::context::MemoizeAsRef;
+///
+/// /// A custom optional value.
+/// enum Maybe<T> {
+///     Some(T),
+///     None,
+/// }
+///
+/// impl<T> MemoizeAsRef for Maybe<T> {
+///     type AsRef<'a>
+///         = Maybe<&'a T>
+///     where
+///         Self: 'a;
+///
+///     fn as_ref(&self) -> Self::AsRef<'_> {
+///         match self {
+///             Maybe::Some(value) => Maybe::Some(value),
+///             Maybe::None => Maybe::None,
+///         }
+///     }
+/// }
+/// ```
+pub trait MemoizeAsRef {
+    /// The return type produced by borrowing the cached value's contents.
+    type AsRef<'a>
+    where
+        Self: 'a;
+
+    /// Borrows the cached value's contents.
+    fn as_ref(&self) -> Self::AsRef<'_>;
+}
+
+impl<T> MemoizeAsRef for Option<T> {
+    type AsRef<'a>
+        = Option<&'a T>
+    where
+        Self: 'a;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        Option::as_ref(self)
+    }
+}
+
+impl<T, E> MemoizeAsRef for Result<T, E> {
+    type AsRef<'a>
+        = Result<&'a T, &'a E>
+    where
+        Self: 'a;
+
+    fn as_ref(&self) -> Self::AsRef<'_> {
+        Result::as_ref(self)
+    }
+}

--- a/crates/topcoat-router/grammar/src/path_param.rs
+++ b/crates/topcoat-router/grammar/src/path_param.rs
@@ -145,7 +145,7 @@ impl PathParam {
         let map_err = self.map_err();
 
         quote! {
-            #[#topcoat_context_macro::memoize]
+            #[#topcoat_context_macro::memoize(as_ref)]
             fn parse(
                 cx: &#topcoat_context::Cx,
             ) -> ::core::result::Result<
@@ -165,7 +165,7 @@ impl PathParam {
         let map_err = self.map_err();
 
         quote! {
-            #[#topcoat_context_macro::memoize]
+            #[#topcoat_context_macro::memoize(as_ref)]
             fn parse(
                 cx: &#topcoat_context::Cx,
             ) -> ::core::result::Result<

--- a/crates/topcoat-router/grammar/src/query_params.rs
+++ b/crates/topcoat-router/grammar/src/query_params.rs
@@ -95,7 +95,7 @@ impl ToTokens for QueryParams {
                     cx: &#topcoat_context::Cx,
                     _: #topcoat_router::QueryParamsSealed,
                 ) -> Self::Output<'_> {
-                    #[#topcoat_context_macro::memoize]
+                    #[#topcoat_context_macro::memoize(as_ref)]
                     fn parse(cx: &#topcoat_context::Cx) -> ::core::result::Result<#ident, #topcoat_router::QueryParamsError> {
                         #topcoat_router::parse_query_params(cx)
                     }

--- a/crates/topcoat/docs/functions_not_middlewares.md
+++ b/crates/topcoat/docs/functions_not_middlewares.md
@@ -123,7 +123,7 @@ async fn require_auth(cx: &Cx) -> Result<&User, UnauthorizedError> {
 }
 ```
 
-With `as_ref`, `#[memoize]` stores the owned `Option<User>` for the request, but exposes it to callers as `Option<&User>`. That lets downstream helpers borrow the current user without cloning it or threading ownership through the component tree.
+`#[memoize]` stores the owned `Option<User>` for the request, but exposes it to callers as `Option<&User>`. That lets downstream helpers borrow the current user without cloning it or threading ownership through the component tree.
 
 Now the component that needs authentication declares it by calling `require_auth(cx)`:
 

--- a/crates/topcoat/docs/functions_not_middlewares.md
+++ b/crates/topcoat/docs/functions_not_middlewares.md
@@ -99,7 +99,7 @@ fn db(cx: &Cx) -> Db {
 }
 
 /// Fetches a user by ID, deduplicated for the duration of the request.
-#[memoize]
+#[memoize(as_ref)]
 async fn fetch_user(cx: &Cx, user_id: &str) -> Option<User> {
     User::fetch_by_id(user_id).exec(db(cx)).await
 }
@@ -123,7 +123,7 @@ async fn require_auth(cx: &Cx) -> Result<&User, UnauthorizedError> {
 }
 ```
 
-`#[memoize]` stores the owned `Option<User>` for the request, but exposes it to callers as `Option<&User>`. That lets downstream helpers borrow the current user without cloning it or threading ownership through the component tree.
+With `as_ref`, `#[memoize]` stores the owned `Option<User>` for the request, but exposes it to callers as `Option<&User>`. That lets downstream helpers borrow the current user without cloning it or threading ownership through the component tree.
 
 Now the component that needs authentication declares it by calling `require_auth(cx)`:
 


### PR DESCRIPTION
Topcoat no longer auto-detects `Result` and `Option` return types in memoized functions. Instead, the user must write `#[memoize(as_ref)]` explicitely to have Topcoat turn `&Option<T>` into `Option<&T>`.