### PR TITLE
perf(view): consume view when rendering to improve performance

### DIFF
--- a/benchmarks/axum-maud/Cargo.lock
+++ b/benchmarks/axum-maud/Cargo.lock
@@ -750,19 +750,21 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.1.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "anymap3",
  "boxcar",
  "hashbrown",
+ "http",
  "pin-project-lite",
+ "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.1.3"
+version = "0.5.0"
 dependencies = [
  "sha2",
  "thiserror",

--- a/crates/topcoat-mail/macro/tests/mail.rs
+++ b/crates/topcoat-mail/macro/tests/mail.rs
@@ -51,7 +51,7 @@ async fn collects_every_field() -> Result<()> {
     assert_eq!(mail.reply_to(), [Mailbox::new("replies@example.com")?]);
     assert_eq!(mail.subject(), "Analytical engines");
     assert_eq!(
-        mail.html().map(|html| html.render(&Cx::default())),
+        mail.html().map(|html| html.clone().render(&Cx::default())),
         Some("<p>The engine weaves algebraic patterns.</p>".to_owned())
     );
     assert_eq!(
@@ -111,7 +111,7 @@ async fn html_renders_dynamic_parts_against_the_named_context() -> Result<()> {
     }?;
 
     assert_eq!(
-        mail.html().map(|html| html.render(cx)),
+        mail.html().map(|html| html.clone().render(cx)),
         Some("<p>Hello, Ada!</p>".to_owned())
     );
 

--- a/crates/topcoat-mail/src/mail.rs
+++ b/crates/topcoat-mail/src/mail.rs
@@ -30,7 +30,7 @@ pub struct Mail {
     bcc: Vec<Mailbox>,
     reply_to: Vec<Mailbox>,
     subject: String,
-    html: Option<View>,
+    pub(crate) html: Option<View>,
     text: TextBody,
     attachments: Vec<Attachment>,
     in_reply_to: Option<String>,

--- a/crates/topcoat-mail/src/mime.rs
+++ b/crates/topcoat-mail/src/mime.rs
@@ -33,7 +33,7 @@ impl Mail {
     /// Returns [`SendError`] if the mail is incomplete (no `From` address,
     /// no recipients, or no body) or declares an attachment content type or
     /// custom header name that is invalid.
-    pub fn formatted(&self, cx: &Cx) -> Result<Vec<u8>, SendError> {
+    pub fn formatted(self, cx: &Cx) -> Result<Vec<u8>, SendError> {
         Ok(message(cx, self, BccHeader::Dropped)?.formatted())
     }
 }
@@ -59,8 +59,8 @@ pub(crate) enum BccHeader {
 ///
 /// The message carries its envelope (all recipients, including `Bcc`) and
 /// a `Message-ID` and `Date`, generated unless the mail declared them.
-pub(crate) fn message(cx: &Cx, mail: &Mail, bcc: BccHeader) -> Result<Message, SendError> {
-    let builder = headers(mail, bcc)?;
+pub(crate) fn message(cx: &Cx, mail: Mail, bcc: BccHeader) -> Result<Message, SendError> {
+    let builder = headers(&mail, bcc)?;
     let content = body(cx, mail)?;
 
     let message = match content {
@@ -136,7 +136,9 @@ enum Content {
 }
 
 /// Builds the MIME body tree, rendering the HTML body with `cx`.
-fn body(cx: &Cx, mail: &Mail) -> Result<Content, SendError> {
+fn body(cx: &Cx, mut mail: Mail) -> Result<Content, SendError> {
+    let html = mail.html.take().map(|view| view.render(cx));
+
     let inline: Vec<&Attachment> = mail
         .attachments()
         .iter()
@@ -148,7 +150,6 @@ fn body(cx: &Cx, mail: &Mail) -> Result<Content, SendError> {
         .filter(|attachment| attachment.filename().is_some())
         .collect();
 
-    let html = mail.html().map(|view| view.render(cx));
     if html.is_none() && !inline.is_empty() {
         return Err(SendError::InlineWithoutHtml);
     }
@@ -234,14 +235,14 @@ mod tests {
             .to([Mailbox::new("bob@example.com").unwrap()])
     }
 
-    fn formatted(mail: &Mail) -> String {
+    fn formatted(mail: Mail) -> String {
         String::from_utf8(mail.formatted(&Cx::default()).unwrap()).unwrap()
     }
 
     #[test]
     fn text_only_is_a_single_plain_part() {
         let mail = base().subject("Hello").text("Hi Bob").build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("From: Ada <ada@example.com>\r\n"));
         assert!(wire.contains("To: bob@example.com\r\n"));
@@ -256,7 +257,7 @@ mod tests {
         let mail = base()
             .html(View::unescaped_unchecked("<h1>Hi</h1><p>Bye now</p>"))
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Content-Type: multipart/alternative;"));
         assert!(wire.contains("Content-Type: text/plain; charset=utf-8\r\n"));
@@ -269,7 +270,7 @@ mod tests {
             .html(View::unescaped_unchecked("<h1>Hi</h1>"))
             .text(TextBody::None)
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Content-Type: text/html; charset=utf-8\r\n"));
         assert!(wire.contains("<h1>Hi</h1>"));
@@ -281,7 +282,7 @@ mod tests {
         let mail = base()
             .html(View::unescaped_unchecked("<img src=\"x.png\">"))
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(!wire.contains("text/plain"));
         assert!(!wire.contains("multipart"));
@@ -293,7 +294,7 @@ mod tests {
             .text("Hi Bob")
             .html(View::unescaped_unchecked("<h1>Hi</h1>"))
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Content-Type: multipart/alternative;"));
         let plain = wire.find("Content-Type: text/plain").unwrap();
@@ -309,7 +310,7 @@ mod tests {
             .html(View::unescaped_unchecked("<img src=\"cid:logo\">"))
             .attachments([Attachment::inline("logo", "image/png", b"\x89PNG")])
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Content-Type: multipart/alternative;"));
         assert!(wire.contains("Content-Type: multipart/related;"));
@@ -323,7 +324,7 @@ mod tests {
             .text("Hi Bob")
             .attachments([Attachment::new("invoice.pdf", "application/pdf", b"%PDF-")])
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Content-Type: multipart/mixed;"));
         assert!(wire.contains("Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n"));
@@ -336,7 +337,7 @@ mod tests {
             .text("Hi")
             .build();
 
-        let message = message(&Cx::default(), &mail, BccHeader::Dropped).unwrap();
+        let message = message(&Cx::default(), mail.clone(), BccHeader::Dropped).unwrap();
         let recipients: Vec<String> = message
             .envelope()
             .to()
@@ -345,7 +346,7 @@ mod tests {
             .collect();
         assert!(recipients.contains(&"dan@example.com".to_owned()));
 
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
         assert!(!wire.contains("Bcc"));
         assert!(!wire.contains("dan@example.com"));
     }
@@ -357,7 +358,7 @@ mod tests {
             .text("Hi")
             .build();
 
-        let message = message(&Cx::default(), &mail, BccHeader::Kept).unwrap();
+        let message = message(&Cx::default(), mail, BccHeader::Kept).unwrap();
         let wire = String::from_utf8(message.formatted()).unwrap();
         assert!(wire.contains("Bcc: dan@example.com\r\n"));
     }
@@ -369,7 +370,7 @@ mod tests {
             .message_id("<mail@example.com>")
             .date(std::time::SystemTime::UNIX_EPOCH)
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("Message-ID: <mail@example.com>\r\n"));
         assert!(wire.contains("Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n"));
@@ -379,7 +380,7 @@ mod tests {
     fn missing_message_id_and_date_are_generated() {
         let mail = base().text("Hi").build();
 
-        let message = message(&Cx::default(), &mail, BccHeader::Dropped).unwrap();
+        let message = message(&Cx::default(), mail, BccHeader::Dropped).unwrap();
         let id = message_id(&message);
         assert!(id.contains('@'), "generated Message-ID: {id:?}");
         assert!(message.headers().get_raw("Date").is_some());
@@ -394,7 +395,7 @@ mod tests {
                 "<mailto:stop@example.com>".to_owned(),
             )])
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("List-Unsubscribe: <mailto:stop@example.com>\r\n"));
     }
@@ -406,7 +407,7 @@ mod tests {
             .in_reply_to("<earlier@example.com>")
             .references("<earlier@example.com>")
             .build();
-        let wire = formatted(&mail);
+        let wire = formatted(mail);
 
         assert!(wire.contains("In-Reply-To: <earlier@example.com>\r\n"));
         assert!(wire.contains("References: <earlier@example.com>\r\n"));

--- a/crates/topcoat-mail/src/transport/file.rs
+++ b/crates/topcoat-mail/src/transport/file.rs
@@ -53,7 +53,7 @@ impl FileTransport {
 impl Transport for FileTransport {
     fn send<'a>(&'a self, cx: &'a Cx, mail: Mail) -> TransportFuture<'a> {
         Box::pin(async move {
-            let message = mime::message(cx, &mail, BccHeader::Kept)?;
+            let message = mime::message(cx, mail, BccHeader::Kept)?;
             let message_id = mime::message_id(&message);
 
             let path = self.directory.join(format!(

--- a/crates/topcoat-mail/src/transport/memory.rs
+++ b/crates/topcoat-mail/src/transport/memory.rs
@@ -72,7 +72,7 @@ impl MemoryTransport {
 impl Transport for MemoryTransport {
     fn send<'a>(&'a self, cx: &'a Cx, mail: Mail) -> TransportFuture<'a> {
         Box::pin(async move {
-            let message = mime::message(cx, &mail, BccHeader::Dropped)?;
+            let message = mime::message(cx, mail.clone(), BccHeader::Dropped)?;
             let receipt = Receipt::new(mime::message_id(&message));
             self.sent
                 .lock()

--- a/crates/topcoat-mail/src/transport/smtp.rs
+++ b/crates/topcoat-mail/src/transport/smtp.rs
@@ -99,7 +99,7 @@ impl SmtpTransport {
 impl Transport for SmtpTransport {
     fn send<'a>(&'a self, cx: &'a Cx, mail: Mail) -> TransportFuture<'a> {
         Box::pin(async move {
-            let message = mime::message(cx, &mail, BccHeader::Dropped)?;
+            let message = mime::message(cx, mail, BccHeader::Dropped)?;
             let message_id = mime::message_id(&message);
             self.inner
                 .send(message)

--- a/crates/topcoat-view/benches/render.rs
+++ b/crates/topcoat-view/benches/render.rs
@@ -20,7 +20,8 @@ use std::{
 };
 
 use criterion::{
-    BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
+    BatchSize, BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main,
+    measurement::WallTime,
 };
 use topcoat::{
     Result,
@@ -45,10 +46,14 @@ fn block_on<F: Future>(future: F) -> F::Output {
 
 /// Times `view.render(cx)` and reports throughput as the rendered byte length,
 /// so the report shows bytes per second alongside per-render latency.
-fn measure(group: &mut BenchmarkGroup<'_, WallTime>, id: impl Into<String>, cx: &Cx, view: &View) {
-    group.throughput(Throughput::Bytes(view.render(cx).len() as u64));
+fn measure(group: &mut BenchmarkGroup<'_, WallTime>, id: impl Into<String>, cx: &Cx, view: View) {
+    group.throughput(Throughput::Bytes(view.clone().render(cx).len() as u64));
     group.bench_function(id.into(), |b| {
-        b.iter(|| black_box(black_box(view).render(black_box(cx))));
+        b.iter_batched(
+            || view.clone(),
+            |v| black_box(v.render(black_box(cx))),
+            BatchSize::SmallInput,
+        );
     });
 }
 
@@ -432,26 +437,26 @@ fn bench_render(c: &mut Criterion) {
     let mut group = c.benchmark_group("view_render");
 
     let static_view = block_on(static_page()).expect("render static_page");
-    measure(&mut group, "static_page", &cx, &static_view);
+    measure(&mut group, "static_page", &cx, static_view);
 
     let comments = make_comments(200);
     let comment_view = block_on(comment_feed(&cx, &comments)).expect("render comment_feed");
-    measure(&mut group, "text_escaping", &cx, &comment_view);
+    measure(&mut group, "text_escaping", &cx, comment_view);
 
     let number_rows = make_number_rows(120, 10);
     let number_view = block_on(numeric_table(&cx, &number_rows)).expect("render numeric_table");
-    measure(&mut group, "numeric_table", &cx, &number_view);
+    measure(&mut group, "numeric_table", &cx, number_view);
 
     let tags = make_tags(200);
     let tag_view = block_on(tag_cloud(&cx, &tags)).expect("render tag_cloud");
-    measure(&mut group, "attributes", &cx, &tag_view);
+    measure(&mut group, "attributes", &cx, tag_view);
 
     // The realistic grid grows with the number of cards, showing how render
     // time scales with document length.
     for &count in &[12usize, 96, 768] {
         let products = make_products(count);
         let grid_view = block_on(product_grid(&cx, &products)).expect("render product_grid");
-        measure(&mut group, format!("product_grid/{count}"), &cx, &grid_view);
+        measure(&mut group, format!("product_grid/{count}"), &cx, grid_view);
     }
 
     group.finish();

--- a/crates/topcoat-view/benches/render.rs
+++ b/crates/topcoat-view/benches/render.rs
@@ -55,6 +55,7 @@ fn measure(group: &mut BenchmarkGroup<'_, WallTime>, id: impl Into<String>, cx: 
             BatchSize::SmallInput,
         );
     });
+    drop(view);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/topcoat-view/src/format.rs
+++ b/crates/topcoat-view/src/format.rs
@@ -53,9 +53,9 @@ impl<'a> Formatter<'a> {
     /// recorded: the first render part that mentions a header name provides
     /// all of that name's values.
     #[cfg(feature = "http")]
-    pub(crate) fn record_headers(&mut self, headers: &HeaderMap) {
+    pub(crate) fn record_headers(&mut self, headers: HeaderMap) {
         if self.headers.is_empty() {
-            self.headers = headers.clone();
+            self.headers = headers;
             return;
         }
         for name in headers.keys() {

--- a/crates/topcoat-view/src/view.rs
+++ b/crates/topcoat-view/src/view.rs
@@ -68,7 +68,7 @@ impl View {
     /// Panics if a dynamic attribute key or element name in the view contains
     /// a character that could break out of the identifier.
     #[track_caller]
-    pub fn render(&self, cx: &Cx) -> String {
+    pub fn render(self, cx: &Cx) -> String {
         let mut buf = String::with_capacity(self.part.size_hint());
         let mut f = Formatter::new(&mut buf);
         self.part.render(cx, &mut f);
@@ -92,7 +92,7 @@ impl View {
     #[cfg(feature = "http")]
     #[must_use]
     #[track_caller]
-    pub fn render_response(&self, cx: &Cx) -> RenderedResponse {
+    pub fn render_response(self, cx: &Cx) -> RenderedResponse {
         let mut html = String::with_capacity(self.part.size_hint());
         let mut f = Formatter::new(&mut html);
         self.part.render(cx, &mut f);
@@ -246,31 +246,31 @@ impl ViewPart {
     /// Writes the part into `f`, escaped or validated for the context each
     /// piece of text was written in.
     #[track_caller]
-    pub(crate) fn render(&self, cx: &Cx, f: &mut Formatter<'_>) {
+    pub(crate) fn render(self, cx: &Cx, f: &mut Formatter<'_>) {
         let mut int_buffer = itoa::Buffer::new();
 
         match self {
             Self::Empty => {}
-            Self::Bool(inner) => f.write_str(if *inner { "true" } else { "false" }),
+            Self::Bool(inner) => f.write_str(if inner { "true" } else { "false" }),
             // The `Display` output of the numeric types consists of digits,
             // signs, and plain letters, none of which are significant in any
             // HTML context, so they write verbatim.
-            Self::I8(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::I16(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::I32(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::I64(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::I128(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::Isize(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::U8(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::U16(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::U32(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::U64(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::U128(inner) => f.write_str(int_buffer.format(*inner)),
-            Self::Usize(inner) => f.write_str(int_buffer.format(*inner)),
+            Self::I8(inner) => f.write_str(int_buffer.format(inner)),
+            Self::I16(inner) => f.write_str(int_buffer.format(inner)),
+            Self::I32(inner) => f.write_str(int_buffer.format(inner)),
+            Self::I64(inner) => f.write_str(int_buffer.format(inner)),
+            Self::I128(inner) => f.write_str(int_buffer.format(inner)),
+            Self::Isize(inner) => f.write_str(int_buffer.format(inner)),
+            Self::U8(inner) => f.write_str(int_buffer.format(inner)),
+            Self::U16(inner) => f.write_str(int_buffer.format(inner)),
+            Self::U32(inner) => f.write_str(int_buffer.format(inner)),
+            Self::U64(inner) => f.write_str(int_buffer.format(inner)),
+            Self::U128(inner) => f.write_str(int_buffer.format(inner)),
+            Self::Usize(inner) => f.write_str(int_buffer.format(inner)),
             Self::F32(inner) => write!(f, "{inner}").unwrap(),
             Self::F64(inner) => write!(f, "{inner}").unwrap(),
-            Self::Char { value, context } => context.writer(f).write_char(*value),
-            Self::Str { value, context } => context.writer(f).write_str(value),
+            Self::Char { value, context } => context.writer(f).write_char(value),
+            Self::Str { value, context } => context.writer(f).write_str(&value),
             Self::BoxDyn { inner, context, .. } => inner.render(cx, &mut context.writer(f)),
             Self::BoxSlice { inner, .. } => {
                 for part in inner {
@@ -278,9 +278,9 @@ impl ViewPart {
                 }
             }
             #[cfg(feature = "http")]
-            Self::StatusCode(status_code) => f.record_status_code(*status_code),
+            Self::StatusCode(status_code) => f.record_status_code(status_code),
             #[cfg(feature = "http")]
-            Self::Headers(headers) => f.record_headers(headers),
+            Self::Headers(headers) => f.record_headers(*headers),
         }
     }
 


### PR DESCRIPTION
gives a ~5-8% performance boost on the benchmarks, likely because the tree does not have to be walked a second time for deallocation