### PR TITLE
feat(core)!: make Cx detachable, remove CxBuilder

### DIFF
--- a/crates/topcoat-cli/src/dev/broadcast_server.rs
+++ b/crates/topcoat-cli/src/dev/broadcast_server.rs
@@ -143,7 +143,7 @@ fn ws_route(cx: &Cx, body: Body) -> RouteFuture<'_> {
     Box::pin(async move {
         let upgrade = WebSocketUpgrade::from_request(cx, body).await?;
         let events = app_context::<EventBus>(cx).clone();
-        upgrade.on_upgrade(move |_cx, socket| handle_socket(socket, events))
+        upgrade.on_upgrade(move |socket| handle_socket(socket, events))
     })
 }
 

--- a/crates/topcoat-cli/src/dev/broadcast_server.rs
+++ b/crates/topcoat-cli/src/dev/broadcast_server.rs
@@ -143,7 +143,7 @@ fn ws_route(cx: &Cx, body: Body) -> RouteFuture<'_> {
     Box::pin(async move {
         let upgrade = WebSocketUpgrade::from_request(cx, body).await?;
         let events = app_context::<EventBus>(cx).clone();
-        upgrade.on_upgrade(move |socket| handle_socket(socket, events))
+        upgrade.on_upgrade(move |_cx, socket| handle_socket(socket, events))
     })
 }
 

--- a/crates/topcoat-cookie/src/router.rs
+++ b/crates/topcoat-cookie/src/router.rs
@@ -1,4 +1,4 @@
-use topcoat_core::context::CxBuilder;
+use topcoat_core::context::Cx;
 use topcoat_router::{Body, Layer, LayerFuture, Next, Path, RouterBuilder};
 
 use crate::{CookieJarCell, write_cookies};
@@ -21,7 +21,7 @@ impl Layer for CookieLayer {
         Path::new("/")
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             cx.insert(CookieJarCell::new());
 

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -1,7 +1,7 @@
 mod context_map;
 mod id;
 
-use std::{any::Any, ops::Deref, sync::Arc};
+use std::{any::Any, sync::Arc};
 
 pub use context_map::*;
 pub use id::*;
@@ -16,54 +16,54 @@ use crate::{abort::AbortStore, memoize::MemoizeCache};
 /// automatically. Use it to read values registered for the request with the
 /// app and request context helpers, such as [`app_context`] and
 /// [`request_context`].
+///
+/// A `Cx` is a handle to state shared by everything serving the same request.
+/// Work that outlives the handler, such as a streaming response body or a
+/// WebSocket task, takes an owned handle with [`detach`](Self::detach).
 #[derive(Debug, Default)]
 pub struct Cx {
-    id: CxId,
-    app_context: Arc<ContextMap>,
-    request_context: ContextMap,
-    memoize_cache: MemoizeCache,
-    abort_store: AbortStore,
+    inner: Arc<CxInner>,
 }
 
 impl Cx {
+    /// Creates the context for one request over the shared app context, with an
+    /// empty request context.
+    #[must_use]
+    pub fn new(app_context: Arc<ContextMap>) -> Self {
+        Self::from_parts(app_context, ContextMap::new())
+    }
+
     /// Creates a `Cx` from the given app and request context maps.
-    fn new(app_context: Arc<ContextMap>, request_context: ContextMap) -> Self {
+    fn from_parts(app_context: Arc<ContextMap>, request_context: ContextMap) -> Self {
         Self {
-            id: CxId::new(),
-            app_context,
-            request_context,
-            memoize_cache: MemoizeCache::new(),
-            abort_store: AbortStore::new(),
+            inner: Arc::new(CxInner {
+                id: CxId::new(),
+                app_context,
+                request_context,
+                memoize_cache: MemoizeCache::new(),
+                abort_store: AbortStore::new(),
+            }),
         }
     }
 
     /// Returns this context's unique [`CxId`].
     #[inline]
     pub fn id(&self) -> CxId {
-        self.id
+        self.inner.id
     }
-}
 
-/// Assembles the request context for an in-flight request.
-///
-/// The router creates a `CxBuilder` over the shared app context, then threads
-/// `&mut CxBuilder` through the layers wrapping the matched route so each can
-/// register request-scoped values with [`insert`](Self::insert) before the
-/// route runs. Because a `CxBuilder` dereferences to the [`Cx`] it is building,
-/// app and request context can be read through it (with helpers such as
-/// [`app_context`] and [`request_context`]) while it is still being assembled.
-#[derive(Debug, Default)]
-pub struct CxBuilder {
-    cx: Cx,
-}
-
-impl CxBuilder {
-    /// Creates a builder over the shared app context, with an empty request
-    /// context.
+    /// Returns an owned handle to this request's context.
+    ///
+    /// Every handle reads the same state: the app context, the request context,
+    /// and the memoize cache. Take an owned handle for work that outlives the
+    /// handler, such as a streaming response body or a WebSocket task.
+    ///
+    /// While any detached handle is alive, the request context is frozen:
+    /// registering a value with [`insert`](Self::insert) panics.
     #[must_use]
-    pub fn new(app_context: Arc<ContextMap>) -> Self {
-        Self {
-            cx: Cx::new(app_context, ContextMap::new()),
+    pub fn detach(&self) -> Cx {
+        Cx {
+            inner: Arc::clone(&self.inner),
         }
     }
 
@@ -72,62 +72,62 @@ impl CxBuilder {
     ///
     /// A type can hold only one value at a time, so registering a type that is
     /// already present replaces it and hands back the displaced value.
+    ///
+    /// # Panics
+    ///
+    /// Panics while a handle taken with [`detach`](Self::detach) is alive.
     pub fn insert<T>(&mut self, value: T) -> Option<T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.insert(value)
-    }
-
-    /// Returns `true` if a value of type `T` has been registered on the request
-    /// context.
-    #[must_use]
-    pub fn contains<T>(&self) -> bool
-    where
-        T: Any + Send + Sync,
-    {
-        self.cx.request_context.contains::<T>()
-    }
-
-    /// Returns a reference to the request context value of type `T`, or `None`
-    /// if no such value has been registered.
-    #[must_use]
-    pub fn get<T>(&self) -> Option<&T>
-    where
-        T: Any + Send + Sync,
-    {
-        self.cx.request_context.get::<T>()
+        self.inner_mut().request_context.insert(value)
     }
 
     /// Returns a mutable reference to the request context value of type `T`, or
     /// `None` if no such value has been registered.
+    ///
+    /// # Panics
+    ///
+    /// Panics while a handle taken with [`detach`](Self::detach) is alive.
     #[must_use]
     pub fn get_mut<T>(&mut self) -> Option<&mut T>
     where
         T: Any + Send + Sync,
     {
-        self.cx.request_context.get_mut::<T>()
+        self.inner_mut().request_context.get_mut::<T>()
     }
 
-    /// Consumes the builder, returning the finished [`Cx`].
-    #[must_use]
-    pub fn build(self) -> Cx {
-        self.cx
+    /// Returns exclusive access to the context state.
+    ///
+    /// # Panics
+    ///
+    /// Panics while a detached handle is alive, because the state is shared for
+    /// as long as the handle exists.
+    #[track_caller]
+    fn inner_mut(&mut self) -> &mut CxInner {
+        Arc::get_mut(&mut self.inner).unwrap_or_else(|| {
+            panic!(
+                "cannot modify the request context while a handle taken with \
+                 `Cx::detach` is alive"
+            )
+        })
     }
 }
 
-impl Deref for CxBuilder {
-    type Target = Cx;
-
-    fn deref(&self) -> &Cx {
-        &self.cx
-    }
+/// The state behind every handle to one request's [`Cx`].
+#[derive(Debug, Default)]
+struct CxInner {
+    id: CxId,
+    app_context: Arc<ContextMap>,
+    request_context: ContextMap,
+    memoize_cache: MemoizeCache,
+    abort_store: AbortStore,
 }
 
 /// Assembles a [`Cx`] from scratch, for tests.
 ///
-/// Unlike [`CxBuilder`], which only configures request context over an existing
-/// shared app context, `CxTestBuilder` populates both app and request context.
+/// Unlike [`Cx::new`], which only takes an existing shared app context,
+/// `CxTestBuilder` populates both app and request context.
 #[derive(Debug, Default)]
 pub struct CxTestBuilder {
     app_context: ContextMap,
@@ -164,18 +164,82 @@ impl CxTestBuilder {
     /// Consumes the builder, returning the assembled [`Cx`].
     #[must_use]
     pub fn build(self) -> Cx {
-        Cx::new(Arc::new(self.app_context), self.request_context)
+        Cx::from_parts(Arc::new(self.app_context), self.request_context)
     }
 }
 
 #[inline]
 #[doc(hidden)]
 pub fn memoize_cache(cx: &Cx) -> &MemoizeCache {
-    &cx.memoize_cache
+    &cx.inner.memoize_cache
 }
 
 #[inline]
 #[doc(hidden)]
 pub fn abort_store(cx: &Cx) -> &AbortStore {
-    &cx.abort_store
+    &cx.inner.abort_store
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct Marker(u32);
+
+    #[test]
+    fn a_fresh_context_has_a_unique_id() {
+        let first = Cx::new(Arc::new(ContextMap::new()));
+        let second = Cx::new(Arc::new(ContextMap::new()));
+        assert_ne!(first.id(), second.id());
+    }
+
+    #[test]
+    fn insert_replaces_and_returns_the_displaced_value() {
+        let mut cx = Cx::new(Arc::new(ContextMap::new()));
+        assert_eq!(cx.insert(Marker(1)), None);
+        assert_eq!(cx.insert(Marker(2)), Some(Marker(1)));
+        assert_eq!(request_context::<Marker>(&cx), &Marker(2));
+    }
+
+    #[test]
+    fn get_mut_allows_mutation_in_place() {
+        let mut cx = Cx::new(Arc::new(ContextMap::new()));
+        assert_eq!(cx.get_mut::<Marker>(), None);
+        cx.insert(Marker(1));
+        cx.get_mut::<Marker>().unwrap().0 = 42;
+        assert_eq!(request_context::<Marker>(&cx), &Marker(42));
+    }
+
+    #[test]
+    fn detached_handles_outlive_the_original() {
+        let cx = CxTestBuilder::new().request_context(Marker(7)).build();
+        let id = cx.id();
+        let handle = cx.detach();
+        drop(cx);
+
+        assert_eq!(request_context::<Marker>(&handle).0, 7);
+        assert_eq!(handle.id(), id);
+    }
+
+    #[test]
+    fn handles_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Cx>();
+    }
+
+    #[test]
+    #[should_panic(expected = "`Cx::detach`")]
+    fn inserting_while_a_handle_is_alive_panics() {
+        let mut cx = Cx::new(Arc::new(ContextMap::new()));
+        let _handle = cx.detach();
+        cx.insert(Marker(0));
+    }
+
+    #[test]
+    fn dropping_every_handle_unfreezes_the_context() {
+        let mut cx = Cx::new(Arc::new(ContextMap::new()));
+        drop(cx.detach());
+        assert_eq!(cx.insert(Marker(0)), None);
+    }
 }

--- a/crates/topcoat-core/src/context.rs
+++ b/crates/topcoat-core/src/context.rs
@@ -48,6 +48,7 @@ impl Cx {
 
     /// Returns this context's unique [`CxId`].
     #[inline]
+    #[must_use]
     pub fn id(&self) -> CxId {
         self.inner.id
     }
@@ -169,12 +170,14 @@ impl CxTestBuilder {
 }
 
 #[inline]
+#[must_use]
 #[doc(hidden)]
 pub fn memoize_cache(cx: &Cx) -> &MemoizeCache {
     &cx.inner.memoize_cache
 }
 
 #[inline]
+#[must_use]
 #[doc(hidden)]
 pub fn abort_store(cx: &Cx) -> &AbortStore {
     &cx.inner.abort_store

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -36,7 +36,7 @@ pub fn try_app_context<T>(cx: &Cx) -> Option<&T>
 where
     T: Any + Send + Sync,
 {
-    cx.app_context.get::<T>()
+    cx.inner.app_context.get::<T>()
 }
 
 /// Returns a reference to the app context value of type `T` registered on the
@@ -103,7 +103,7 @@ pub fn try_request_context<T>(cx: &Cx) -> Option<&T>
 where
     T: Any + Send + Sync,
 {
-    cx.request_context.get::<T>()
+    cx.inner.request_context.get::<T>()
 }
 
 /// Returns a reference to the request context value of type `T` registered on

--- a/crates/topcoat-core/src/context/context_map.rs
+++ b/crates/topcoat-core/src/context/context_map.rs
@@ -65,6 +65,7 @@ where
 ///     db.fetch_user(id).await
 /// }
 /// ```
+#[must_use]
 #[track_caller]
 pub fn app_context<T>(cx: &Cx) -> &T
 where
@@ -130,6 +131,7 @@ where
 ///     &id.0
 /// }
 /// ```
+#[must_use]
 #[track_caller]
 pub fn request_context<T>(cx: &Cx) -> &T
 where

--- a/crates/topcoat-router/docs/content/sse.md
+++ b/crates/topcoat-router/docs/content/sse.md
@@ -25,7 +25,39 @@ async fn events() -> Result<Sse<impl Stream<Item = Result<Event>> + use<>>> {
 }
 ```
 
-The `use<>` bound keeps the stream from capturing the request context, which a route's response must not borrow. The connection stays open until the stream ends, an `Err` item occurs, or the client disconnects; a disconnect drops the stream, so tie cleanup to the stream's `Drop`.
+The `use<>` bound keeps the stream from borrowing the request context, which a route's response must not do. The connection stays open until the stream ends, an `Err` item occurs, or the client disconnects; a disconnect drops the stream, so tie cleanup to the stream's `Drop`.
+
+# Reading the request context
+
+A stream outlives the handler that returned it, so it cannot borrow the `Cx` the route was called with. Take an owned handle with [`Cx::detach`](topcoat_core::context::Cx::detach) and move it into the stream instead; it reads the same app and request context.
+
+```rust
+use futures_core::Stream;
+use topcoat::{
+    Result,
+    context::{Cx, request_context},
+    router::{
+        content::sse::{Event, Sse},
+        route,
+    },
+};
+
+struct Customer {
+    name: String,
+}
+
+#[route(GET "/greetings")]
+async fn greetings(cx: &Cx) -> Result<Sse<impl Stream<Item = Result<Event>> + use<>>> {
+    let cx = cx.detach();
+    let events = futures_util::stream::once(async move {
+        let customer: &Customer = request_context(&cx);
+        Ok(Event::new().data(customer.name.as_str()))
+    });
+    Ok(Sse::new(events))
+}
+```
+
+The request context is frozen while a detached handle is alive: registering another value on it panics.
 
 # Keeping quiet streams alive
 

--- a/crates/topcoat-router/docs/content/sse.md
+++ b/crates/topcoat-router/docs/content/sse.md
@@ -57,8 +57,6 @@ async fn greetings(cx: &Cx) -> Result<Sse<impl Stream<Item = Result<Event>> + us
 }
 ```
 
-The request context is frozen while a detached handle is alive: registering another value on it panics.
-
 # Keeping quiet streams alive
 
 Proxies and load balancers drop connections that look stale. [`keep_alive`](Sse::keep_alive) fills idle gaps with events the client ignores: [`KeepAlive::new`] sends an empty comment after 15 idle seconds, and [`interval`](KeepAlive::interval), [`text`](KeepAlive::text), and [`event`](KeepAlive::event) tune what is sent and when.

--- a/crates/topcoat-router/docs/content/websocket.md
+++ b/crates/topcoat-router/docs/content/websocket.md
@@ -4,7 +4,7 @@ A WebSocket starts as an ordinary `GET` request that asks the server to switch p
 
 # Upgrading a request
 
-A route becomes a WebSocket endpoint by taking a [`WebSocketUpgrade`] parameter and returning the response its [`on_upgrade`](WebSocketUpgrade::on_upgrade) builds. The callback passed to `on_upgrade` receives the request context and the [`WebSocket`] once the client has switched protocols, and runs on its own task; the handler itself completes immediately with the handshake response. Its `Cx` is an owned handle to the context of the request that upgraded the connection, so the socket task reads the same app and request context the handler saw.
+A route becomes a WebSocket endpoint by taking a [`WebSocketUpgrade`] parameter and returning the response its [`on_upgrade`](WebSocketUpgrade::on_upgrade) builds. The callback passed to `on_upgrade` receives the [`WebSocket`] once the client has switched protocols, and runs on its own task; the handler itself completes immediately with the handshake response.
 
 ```rust
 use topcoat::{
@@ -18,7 +18,7 @@ use topcoat::{
 
 #[route(GET "/echo")]
 async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-    upgrade.on_upgrade(|_cx, mut socket| async move {
+    upgrade.on_upgrade(|mut socket| async move {
         while let Some(Ok(message)) = socket.recv().await {
             if matches!(message, Message::Text(_) | Message::Binary(_))
                 && socket.send(message).await.is_err()
@@ -31,6 +31,35 @@ async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
 ```
 
 A request that is not a conforming WebSocket handshake is rejected before the handler's callback is involved: a non-`GET` method with `405 Method Not Allowed`, and missing or malformed handshake headers with `400 Bad Request`. Because the extractor runs inside the handler like any other, request-scoped functions (a session check, `cookies(cx)`) compose with it as usual -- reject the request by returning an error before calling `on_upgrade`.
+
+# Reading the request context
+
+The callback outlives the handler that upgraded the connection, so it cannot borrow the `Cx` the handler was called with. Take an owned handle with [`Cx::detach`](topcoat_core::context::Cx::detach) and move it into the callback instead; it reads the same app and request context.
+
+```rust
+use topcoat::{
+    Result,
+    context::{Cx, request_context},
+    router::{
+        content::websocket::{Message, WebSocketUpgrade},
+        response::Response,
+        route,
+    },
+};
+
+struct Customer {
+    name: String,
+}
+
+#[route(GET "/greet")]
+async fn greet(cx: &Cx, upgrade: WebSocketUpgrade) -> Result<Response> {
+    let cx = cx.detach();
+    upgrade.on_upgrade(move |mut socket| async move {
+        let customer: &Customer = request_context(&cx);
+        let _ = socket.send(Message::text(customer.name.as_str())).await;
+    })
+}
+```
 
 # Messages
 

--- a/crates/topcoat-router/docs/content/websocket.md
+++ b/crates/topcoat-router/docs/content/websocket.md
@@ -4,7 +4,7 @@ A WebSocket starts as an ordinary `GET` request that asks the server to switch p
 
 # Upgrading a request
 
-A route becomes a WebSocket endpoint by taking a [`WebSocketUpgrade`] parameter and returning the response its [`on_upgrade`](WebSocketUpgrade::on_upgrade) builds. The callback passed to `on_upgrade` receives the [`WebSocket`] once the client has switched protocols, and runs on its own task; the handler itself completes immediately with the handshake response.
+A route becomes a WebSocket endpoint by taking a [`WebSocketUpgrade`] parameter and returning the response its [`on_upgrade`](WebSocketUpgrade::on_upgrade) builds. The callback passed to `on_upgrade` receives the request context and the [`WebSocket`] once the client has switched protocols, and runs on its own task; the handler itself completes immediately with the handshake response. Its `Cx` is an owned handle to the context of the request that upgraded the connection, so the socket task reads the same app and request context the handler saw.
 
 ```rust
 use topcoat::{
@@ -18,7 +18,7 @@ use topcoat::{
 
 #[route(GET "/echo")]
 async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-    upgrade.on_upgrade(|mut socket| async move {
+    upgrade.on_upgrade(|_cx, mut socket| async move {
         while let Some(Ok(message)) = socket.recv().await {
             if matches!(message, Message::Text(_) | Message::Binary(_))
                 && socket.send(message).await.is_err()

--- a/crates/topcoat-router/docs/module_router.md
+++ b/crates/topcoat-router/docs/module_router.md
@@ -117,12 +117,12 @@ A layer uses its module path as a prefix:
 // src/app/api.rs: wraps handlers under /api
 use topcoat::{
     Result,
-    context::CxBuilder,
+    context::Cx,
     router::{Body, Next, layer, response::Response},
 };
 
 #[layer]
-async fn api_log(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
+async fn api_log(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> {
     let response = next.run(cx, body).await?;
     println!("API response: {}", response.status());
     Ok(response)

--- a/crates/topcoat-router/macro/docs/layer.md
+++ b/crates/topcoat-router/macro/docs/layer.md
@@ -10,7 +10,7 @@ When several layers wrap a handler, they nest from least specific (outermost) to
 
 # Handler signature
 
-The function is `async` and takes [`cx: &mut CxBuilder`](../context/struct.CxBuilder.html), the request [`body: Body`](struct.Body.html), and a [`next: Next<'_>`](struct.Next.html), returning `Result<T>` where `T` implements [`IntoResponse`](trait.IntoResponse.html). Call [`next.run(cx, body)`](struct.Next.html#method.run) to invoke the inner layers and ultimately the handler. Returning without calling `next.run` short-circuits the request: the layer's return value becomes the response.
+The function is `async` and takes [`cx: &mut Cx`](../context/struct.Cx.html), the request [`body: Body`](struct.Body.html), and a [`next: Next<'_>`](struct.Next.html), returning `Result<T>` where `T` implements [`IntoResponse`](trait.IntoResponse.html). Call [`next.run(cx, body)`](struct.Next.html#method.run) to invoke the inner layers and ultimately the handler. Returning without calling `next.run` short-circuits the request: the layer's return value becomes the response.
 
 # Examples
 
@@ -19,12 +19,12 @@ Explicit path:
 ```rust
 use topcoat::{
     Result,
-    context::CxBuilder,
+    context::Cx,
     router::{Body, Next, layer, response::Response},
 };
 
 #[layer("/")]
-async fn timing(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
+async fn timing(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> {
     let start = std::time::Instant::now();
     let response = next.run(cx, body).await?;
     println!("handled in {:?}", start.elapsed());
@@ -35,9 +35,9 @@ async fn timing(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Respon
 Module-derived path (in `src/app/api.rs` under `module_router!()`, this wraps every request under `/api`):
 
 ```rust
-# use topcoat::{Result, context::CxBuilder, router::{Body, Next, layer, response::Response}};
+# use topcoat::{Result, context::Cx, router::{Body, Next, layer, response::Response}};
 #[layer]
-async fn api_log(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
+async fn api_log(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> {
     let response = next.run(cx, body).await?;
     println!("API response: {}", response.status());
     Ok(response)

--- a/crates/topcoat-router/src/body_limit.rs
+++ b/crates/topcoat-router/src/body_limit.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use topcoat_core::context::{Cx, CxBuilder, try_request_context};
+use topcoat_core::context::{Cx, try_request_context};
 
 use crate::{Body, IntoPath, Layer, LayerFuture, Next, Path};
 
@@ -82,7 +82,7 @@ impl Layer for BodyLimit {
         &self.path
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         cx.insert(self.kind);
         next.run(cx, body)
     }

--- a/crates/topcoat-router/src/builder.rs
+++ b/crates/topcoat-router/src/builder.rs
@@ -511,10 +511,7 @@ impl Default for RouterBuilder {
 mod tests {
     use std::{future::Future, pin::Pin};
 
-    use topcoat_core::{
-        context::Cx,
-        error::Result,
-    };
+    use topcoat_core::{context::Cx, error::Result};
     use topcoat_view::View;
 
     use super::*;

--- a/crates/topcoat-router/src/builder.rs
+++ b/crates/topcoat-router/src/builder.rs
@@ -512,7 +512,7 @@ mod tests {
     use std::{future::Future, pin::Pin};
 
     use topcoat_core::{
-        context::{Cx, CxBuilder},
+        context::Cx,
         error::Result,
     };
     use topcoat_view::View;
@@ -541,7 +541,7 @@ mod tests {
     }
 
     /// A stand-in layer that continues the chain unchanged.
-    fn noop_layer<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn noop_layer<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move { next.run(cx, body).await })
     }
 

--- a/crates/topcoat-router/src/content/sse/response.rs
+++ b/crates/topcoat-router/src/content/sse/response.rs
@@ -64,7 +64,10 @@ use crate::{
 /// use topcoat::{
 ///     Result,
 ///     context::{Cx, request_context},
-///     router::{content::sse::{Event, Sse}, route},
+///     router::{
+///         content::sse::{Event, Sse},
+///         route,
+///     },
 /// };
 ///
 /// struct Customer {

--- a/crates/topcoat-router/src/content/sse/response.rs
+++ b/crates/topcoat-router/src/content/sse/response.rs
@@ -55,8 +55,32 @@ use crate::{
 /// }
 /// ```
 ///
-/// The `use<>` bound keeps the stream from capturing the request context,
-/// which a route's response must not borrow.
+/// The `use<>` bound keeps the stream from borrowing the request context,
+/// which a route's response must not do. A stream that needs the context takes
+/// an owned handle with [`Cx::detach`] and moves it in:
+///
+/// ```rust
+/// use futures_core::Stream;
+/// use topcoat::{
+///     Result,
+///     context::{Cx, request_context},
+///     router::{content::sse::{Event, Sse}, route},
+/// };
+///
+/// struct Customer {
+///     name: String,
+/// }
+///
+/// #[route(GET "/greetings")]
+/// async fn greetings(cx: &Cx) -> Result<Sse<impl Stream<Item = Result<Event>> + use<>>> {
+///     let cx = cx.detach();
+///     let events = futures_util::stream::once(async move {
+///         let customer: &Customer = request_context(&cx);
+///         Ok(Event::new().data(customer.name.as_str()))
+///     });
+///     Ok(Sse::new(events))
+/// }
+/// ```
 #[must_use]
 pub struct Sse<S> {
     stream: S,

--- a/crates/topcoat-router/src/content/websocket/upgrade.rs
+++ b/crates/topcoat-router/src/content/websocket/upgrade.rs
@@ -50,7 +50,7 @@ use crate::{
 ///
 /// #[route(GET "/echo")]
 /// async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-///     upgrade.on_upgrade(|_cx, mut socket| async move {
+///     upgrade.on_upgrade(|mut socket| async move {
 ///         while let Some(Ok(message)) = socket.recv().await {
 ///             if matches!(message, Message::Text(_) | Message::Binary(_))
 ///                 && socket.send(message).await.is_err()
@@ -61,9 +61,37 @@ use crate::{
 ///     })
 /// }
 /// ```
+///
+/// The callback outlives the handler, so it cannot borrow the request context.
+/// Take an owned handle with [`Cx::detach`] and move it in to read the context
+/// from the socket task:
+///
+/// ```rust
+/// use topcoat::{
+///     Result,
+///     context::{Cx, request_context},
+///     router::{
+///         content::websocket::{Message, WebSocketUpgrade},
+///         response::Response,
+///         route,
+///     },
+/// };
+///
+/// struct Customer {
+///     name: String,
+/// }
+///
+/// #[route(GET "/greet")]
+/// async fn greet(cx: &Cx, upgrade: WebSocketUpgrade) -> Result<Response> {
+///     let cx = cx.detach();
+///     upgrade.on_upgrade(move |mut socket| async move {
+///         let customer: &Customer = request_context(&cx);
+///         let _ = socket.send(Message::text(customer.name.as_str())).await;
+///     })
+/// }
+/// ```
 #[must_use]
 pub struct WebSocketUpgrade {
-    cx: Cx,
     config: WebSocketConfig,
     protocols: Vec<Cow<'static, str>>,
     key: HeaderValue,
@@ -138,21 +166,19 @@ impl WebSocketUpgrade {
         self
     }
 
-    /// Completes the handshake, calling `callback` with the request context and
-    /// the [`WebSocket`] once the client connection has switched protocols.
+    /// Completes the handshake, calling `callback` with the [`WebSocket`] once
+    /// the client connection has switched protocols.
     ///
     /// The returned response must be the handler's return value; sending it
     /// performs the protocol switch. The callback runs on its own task, which
-    /// owns the connection for as long as it runs. Its [`Cx`] is an owned handle
-    /// to the context of the request that upgraded the connection, so the socket
-    /// task reads the same app and request context the handler saw.
+    /// owns the connection for as long as it runs.
     ///
     /// # Errors
     ///
     /// Returns an error if the handshake response cannot be assembled.
     pub fn on_upgrade<C, F>(self, callback: C) -> Result<Response>
     where
-        C: FnOnce(Cx, WebSocket) -> F + Send + 'static,
+        C: FnOnce(WebSocket) -> F + Send + 'static,
         F: Future<Output = ()> + Send + 'static,
     {
         let protocol = negotiate_protocol(&self.protocols, self.requested_protocols.as_ref());
@@ -161,7 +187,6 @@ impl WebSocketUpgrade {
         let on_upgrade = self.on_upgrade;
         let on_failed_upgrade = self.on_failed_upgrade;
         let socket_protocol = protocol.clone();
-        let cx = self.cx;
         tokio::spawn(async move {
             let upgraded = match on_upgrade.await {
                 Ok(upgraded) => upgraded,
@@ -176,7 +201,7 @@ impl WebSocketUpgrade {
                 Some(config),
             )
             .await;
-            callback(cx, WebSocket::new(stream, socket_protocol)).await;
+            callback(WebSocket::new(stream, socket_protocol)).await;
         });
 
         let mut response = Response::new(Body::empty());
@@ -242,7 +267,6 @@ impl FromRequest for WebSocketUpgrade {
         })?;
 
         Ok(Self {
-            cx: cx.detach(),
             config: WebSocketConfig::default(),
             protocols: Vec::new(),
             key,
@@ -477,7 +501,7 @@ mod tests {
             let upgrade = WebSocketUpgrade::from_request(cx, body).await?;
             upgrade
                 .protocols(["echo.v1"])
-                .on_upgrade(|_cx, mut socket| async move {
+                .on_upgrade(|mut socket| async move {
                     while let Some(Ok(message)) = socket.recv().await {
                         if matches!(message, Message::Text(_) | Message::Binary(_))
                             && socket.send(message).await.is_err()

--- a/crates/topcoat-router/src/content/websocket/upgrade.rs
+++ b/crates/topcoat-router/src/content/websocket/upgrade.rs
@@ -50,7 +50,7 @@ use crate::{
 ///
 /// #[route(GET "/echo")]
 /// async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-///     upgrade.on_upgrade(|mut socket| async move {
+///     upgrade.on_upgrade(|_cx, mut socket| async move {
 ///         while let Some(Ok(message)) = socket.recv().await {
 ///             if matches!(message, Message::Text(_) | Message::Binary(_))
 ///                 && socket.send(message).await.is_err()
@@ -63,6 +63,7 @@ use crate::{
 /// ```
 #[must_use]
 pub struct WebSocketUpgrade {
+    cx: Cx,
     config: WebSocketConfig,
     protocols: Vec<Cow<'static, str>>,
     key: HeaderValue,
@@ -137,19 +138,21 @@ impl WebSocketUpgrade {
         self
     }
 
-    /// Completes the handshake, calling `callback` with the [`WebSocket`] once
-    /// the client connection has switched protocols.
+    /// Completes the handshake, calling `callback` with the request context and
+    /// the [`WebSocket`] once the client connection has switched protocols.
     ///
     /// The returned response must be the handler's return value; sending it
     /// performs the protocol switch. The callback runs on its own task, which
-    /// owns the connection for as long as it runs.
+    /// owns the connection for as long as it runs. Its [`Cx`] is an owned handle
+    /// to the context of the request that upgraded the connection, so the socket
+    /// task reads the same app and request context the handler saw.
     ///
     /// # Errors
     ///
     /// Returns an error if the handshake response cannot be assembled.
     pub fn on_upgrade<C, F>(self, callback: C) -> Result<Response>
     where
-        C: FnOnce(WebSocket) -> F + Send + 'static,
+        C: FnOnce(Cx, WebSocket) -> F + Send + 'static,
         F: Future<Output = ()> + Send + 'static,
     {
         let protocol = negotiate_protocol(&self.protocols, self.requested_protocols.as_ref());
@@ -158,6 +161,7 @@ impl WebSocketUpgrade {
         let on_upgrade = self.on_upgrade;
         let on_failed_upgrade = self.on_failed_upgrade;
         let socket_protocol = protocol.clone();
+        let cx = self.cx;
         tokio::spawn(async move {
             let upgraded = match on_upgrade.await {
                 Ok(upgraded) => upgraded,
@@ -172,7 +176,7 @@ impl WebSocketUpgrade {
                 Some(config),
             )
             .await;
-            callback(WebSocket::new(stream, socket_protocol)).await;
+            callback(cx, WebSocket::new(stream, socket_protocol)).await;
         });
 
         let mut response = Response::new(Body::empty());
@@ -238,6 +242,7 @@ impl FromRequest for WebSocketUpgrade {
         })?;
 
         Ok(Self {
+            cx: cx.detach(),
             config: WebSocketConfig::default(),
             protocols: Vec::new(),
             key,
@@ -472,7 +477,7 @@ mod tests {
             let upgrade = WebSocketUpgrade::from_request(cx, body).await?;
             upgrade
                 .protocols(["echo.v1"])
-                .on_upgrade(|mut socket| async move {
+                .on_upgrade(|_cx, mut socket| async move {
                     while let Some(Ok(message)) = socket.recv().await {
                         if matches!(message, Message::Text(_) | Message::Binary(_))
                             && socket.send(message).await.is_err()

--- a/crates/topcoat-router/src/layer.rs
+++ b/crates/topcoat-router/src/layer.rs
@@ -41,12 +41,7 @@ pub type LayerFuture<'a> = Pin<Box<dyn Future<Output = Result<Response>> + Send 
 ///         Path::ROOT
 ///     }
 ///
-///     fn handle<'a>(
-///         &'a self,
-///         cx: &'a mut Cx,
-///         body: Body,
-///         next: Next<'a>,
-///     ) -> LayerFuture<'a> {
+///     fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
 ///         Box::pin(async move {
 ///             let start = std::time::Instant::now();
 ///             let response = next.run(cx, body).await?;
@@ -65,8 +60,7 @@ pub trait Layer: Send + Sync + 'static {
 }
 
 /// The handler function backing a [`LayerFn`].
-pub type LayerHandlerFn =
-    for<'a> fn(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a>;
+pub type LayerHandlerFn = for<'a> fn(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a>;
 
 /// A [`Layer`] backed by a plain handler function.
 ///

--- a/crates/topcoat-router/src/layer.rs
+++ b/crates/topcoat-router/src/layer.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::Index, pin::Pin};
 
-use topcoat_core::{context::CxBuilder, error::Result};
+use topcoat_core::{context::Cx, error::Result};
 
 use crate::{Body, Endpoint, Path, Route, error::method_not_allowed, response::Response};
 
@@ -14,10 +14,10 @@ pub type LayerFuture<'a> = Pin<Box<dyn Future<Output = Result<Response>> + Send 
 /// A layer wraps every matched route whose path begins with the layer's path
 /// (the same prefix rule as layouts), so a layer at `/admin` wraps only routes
 /// under `/admin`, while a layer at `/` wraps everything. Each layer receives a
-/// mutable [`CxBuilder`] and the request [`Body`], plus a [`Next`] representing
-/// the rest of the chain. A layer typically registers request-scoped values on
-/// the context, calls [`Next::run`] to invoke the inner layers and ultimately
-/// the route, then inspects or modifies the [`Response`].
+/// mutable [`Cx`] and the request [`Body`], plus a [`Next`] representing the
+/// rest of the chain. A layer typically registers request-scoped values on the
+/// context with [`Cx::insert`], calls [`Next::run`] to invoke the inner layers
+/// and ultimately the route, then inspects or modifies the [`Response`].
 ///
 /// When several layers match a route they nest from least-specific (outermost)
 /// to most-specific (innermost), like layouts.
@@ -30,7 +30,7 @@ pub type LayerFuture<'a> = Pin<Box<dyn Future<Output = Result<Response>> + Send 
 /// use std::borrow::Cow;
 ///
 /// use topcoat::{
-///     context::CxBuilder,
+///     context::Cx,
 ///     router::{Body, Layer, LayerFuture, Next, Path},
 /// };
 ///
@@ -43,7 +43,7 @@ pub type LayerFuture<'a> = Pin<Box<dyn Future<Output = Result<Response>> + Send 
 ///
 ///     fn handle<'a>(
 ///         &'a self,
-///         cx: &'a mut CxBuilder,
+///         cx: &'a mut Cx,
 ///         body: Body,
 ///         next: Next<'a>,
 ///     ) -> LayerFuture<'a> {
@@ -61,12 +61,12 @@ pub trait Layer: Send + Sync + 'static {
     fn path(&self) -> &Path;
 
     /// Handles a request, calling `next` to continue down the chain.
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a>;
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a>;
 }
 
 /// The handler function backing a [`LayerFn`].
 pub type LayerHandlerFn =
-    for<'a> fn(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a>;
+    for<'a> fn(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a>;
 
 /// A [`Layer`] backed by a plain handler function.
 ///
@@ -94,7 +94,7 @@ impl Layer for LayerFn {
         &self.path
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         (self.handle)(cx, body, next)
     }
 }
@@ -199,7 +199,7 @@ impl<'a> Next<'a> {
 
     /// Runs the next layer in the chain, or the terminal handler once no layers
     /// remain.
-    pub fn run(self, cx: &'a mut CxBuilder, body: Body) -> LayerFuture<'a> {
+    pub fn run(self, cx: &'a mut Cx, body: Body) -> LayerFuture<'a> {
         match self.indices.split_first() {
             Some((&id, rest)) => self.layers[id].handle(
                 cx,
@@ -228,7 +228,7 @@ mod tests {
     };
 
     use http::StatusCode;
-    use topcoat_core::context::{ContextMap, Cx, CxBuilder, app_context};
+    use topcoat_core::context::{ContextMap, Cx, app_context};
 
     use super::*;
     use crate::{
@@ -255,7 +255,7 @@ mod tests {
         Box::new(LayerFn::new(path(p), noop_layer))
     }
 
-    fn noop_layer<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn noop_layer<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         next.run(cx, body)
     }
 
@@ -269,20 +269,20 @@ mod tests {
     /// test can observe the order the chain executes in.
     type Trace = Mutex<Vec<&'static str>>;
 
-    fn cx_with_trace(trace: Arc<Trace>) -> CxBuilder {
+    fn cx_with_trace(trace: Arc<Trace>) -> Cx {
         let mut app = ContextMap::new();
         app.insert(trace);
-        CxBuilder::new(Arc::new(app))
+        Cx::new(Arc::new(app))
     }
 
-    fn record_a<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn record_a<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             app_context::<Arc<Trace>>(cx).lock().unwrap().push("a");
             next.run(cx, body).await
         })
     }
 
-    fn record_b<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn record_b<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             app_context::<Arc<Trace>>(cx).lock().unwrap().push("b");
             next.run(cx, body).await
@@ -290,7 +290,7 @@ mod tests {
     }
 
     /// A layer that answers the request itself, without invoking `next`.
-    fn short_circuit<'a>(cx: &'a mut CxBuilder, _body: Body, _next: Next<'a>) -> LayerFuture<'a> {
+    fn short_circuit<'a>(cx: &'a mut Cx, _body: Body, _next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move { "short".into_response(cx) })
     }
 
@@ -396,7 +396,7 @@ mod tests {
     fn run_invokes_the_route_terminal_when_no_layers_remain() {
         let layers = Layers::default();
         let route = RouteFn::new(Method::GET, path("/x"), say_route);
-        let mut cx = CxBuilder::default();
+        let mut cx = Cx::default();
 
         let indices: &[LayerId] = &[];
         let next = Next::new(&layers, indices, Terminal::Route(&route));
@@ -416,7 +416,7 @@ mod tests {
         let mut endpoint = Endpoint::new(endpoint_path, no_params, no_layers);
         endpoint.insert(Method::GET, 0);
         endpoint.insert(Method::POST, 1);
-        let mut cx = CxBuilder::default();
+        let mut cx = Cx::default();
 
         let indices: &[LayerId] = &[];
         let next = Next::new(&layers, indices, Terminal::MethodNotAllowed(&endpoint));
@@ -460,7 +460,7 @@ mod tests {
         let indices = [stop];
         // The route would answer "route", but the layer never calls `next.run`.
         let route = RouteFn::new(Method::GET, path("/x"), say_route);
-        let mut cx = CxBuilder::default();
+        let mut cx = Cx::default();
 
         let next = Next::new(&layers, &indices, Terminal::Route(&route));
         let result = block_on(next.run(&mut cx, Body::empty()));

--- a/crates/topcoat-router/src/origin.rs
+++ b/crates/topcoat-router/src/origin.rs
@@ -1,4 +1,4 @@
-use topcoat_core::context::{Cx, CxBuilder};
+use topcoat_core::context::Cx;
 
 use crate::{
     Body, IntoPath, Layer, LayerFuture, Method, Next, Path, PathBuf,
@@ -240,7 +240,7 @@ impl Layer for OriginLayer {
         Path::ROOT
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         match self.policy.check(cx) {
             OriginVerdict::Allow => next.run(cx, body),
             OriginVerdict::Deny => Box::pin(async { Err(forbidden().into()) }),

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -78,6 +78,7 @@ impl PageFn {
     }
 
     /// Renders the page, returning a [`Result`].
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,
@@ -124,6 +125,7 @@ impl LayoutFn {
     }
 
     /// Renders the layout, embedding the given child content [`Result`]`<`[`View`]`>` as its slot.
+    #[must_use]
     pub fn render<'cx>(
         &self,
         cx: &'cx Cx,

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -810,4 +810,43 @@ mod tests {
         let (_, _, body) = send(&router, Method::GET, "/p");
         assert_eq!(&body[..], b"page");
     }
+
+    // -- Router::handle: detached contexts --
+
+    /// Registers the greeting the streaming route reads back.
+    #[cfg(feature = "sse")]
+    fn insert_greeting<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+        cx.insert(Greeting("hello"));
+        next.run(cx, body)
+    }
+
+    /// Streams the request-context greeting from a body that outlives the
+    /// handler, reading it through a detached handle.
+    #[cfg(feature = "sse")]
+    fn stream_greeting(cx: &Cx, _body: Body) -> RouteFuture<'_> {
+        use crate::content::sse::{Event, Sse};
+
+        Box::pin(async move {
+            let handle = cx.detach();
+            let events = futures_util::stream::once(async move {
+                Result::<Event>::Ok(Event::new().data(request_context::<Greeting>(&handle).0))
+            });
+            Sse::new(events).into_response(cx)
+        })
+    }
+
+    #[cfg(feature = "sse")]
+    #[test]
+    fn a_detached_handle_serves_a_stream_after_the_request_returned() {
+        let router = RouterBuilder::new()
+            .route(RouteFn::new(Method::GET, path("/events"), stream_greeting))
+            .layer(LayerFn::new(path("/"), insert_greeting))
+            .build();
+
+        let response = block_on(router.handle(request(Method::GET, "/events")));
+        // The router dropped its own context when `handle` returned; the body
+        // still reads the request context through its detached handle.
+        let body = block_on(to_bytes(response.into_body(), usize::MAX)).unwrap();
+        assert!(body.starts_with(b"data: hello"), "{body:?}");
+    }
 }

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -6,7 +6,9 @@ use std::{
     task::Poll,
 };
 
-use topcoat_core::context::{ContextMap, Cx, CxBuilder};
+#[cfg(feature = "compression")]
+use topcoat_core::context::try_request_context;
+use topcoat_core::context::{ContextMap, Cx};
 
 use crate::{
     Endpoint, EndpointPath, Layer, Layers, Next, OriginLayer, RawPathParams, Route, RouterBuilder,
@@ -108,7 +110,7 @@ impl Router {
             None => Terminal::MethodNotAllowed(endpoint),
         };
 
-        let mut cx = CxBuilder::new(self.app_context.clone());
+        let mut cx = Cx::new(Arc::clone(&self.app_context));
         cx.insert(EndpointPath(endpoint.path().clone()));
         cx.insert(path_params);
         cx.insert(parts);
@@ -123,7 +125,7 @@ impl Router {
         // bodies. The negotiation reads the request headers as the layers
         // left them.
         #[cfg(feature = "compression")]
-        let response = match cx.get::<http::request::Parts>() {
+        let response = match try_request_context::<http::request::Parts>(&cx) {
             Some(parts) => self.compression.compress(&parts.headers, response).await,
             None => response,
         };
@@ -144,7 +146,7 @@ mod tests {
     use http::{HeaderMap, StatusCode};
     use topcoat::view::{DynViewPart, HtmlWriter, NodeViewParts, PartsWriter, View, view};
     use topcoat_core::{
-        context::{Cx, CxBuilder, app_context, request_context},
+        context::{Cx, app_context, request_context},
         error::Result,
     };
 
@@ -242,21 +244,21 @@ mod tests {
     // test can observe the order layers run in.
     type Trace = Mutex<Vec<&'static str>>;
 
-    fn trace_root<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn trace_root<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             app_context::<Arc<Trace>>(cx).lock().unwrap().push("root");
             next.run(cx, body).await
         })
     }
 
-    fn trace_admin<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn trace_admin<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             app_context::<Arc<Trace>>(cx).lock().unwrap().push("admin");
             next.run(cx, body).await
         })
     }
 
-    fn trace_auth<'a>(cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn trace_auth<'a>(cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         Box::pin(async move {
             app_context::<Arc<Trace>>(cx).lock().unwrap().push("auth");
             next.run(cx, body).await

--- a/crates/topcoat-router/src/tower.rs
+++ b/crates/topcoat-router/src/tower.rs
@@ -11,7 +11,7 @@ use std::{
 use bytes::Bytes;
 use tokio::sync::{mpsc, oneshot};
 use topcoat_core::{
-    context::{Cx, CxBuilder},
+    context::Cx,
     error::{Error, Result},
 };
 use tower::ServiceExt;
@@ -212,7 +212,7 @@ where
         &self.path
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         // Clones of a tower service share its cross-request state (semaphores,
         // rate-limit windows) through the service's internal handles.
         let service = self.service.clone();
@@ -484,7 +484,7 @@ mod tests {
     };
 
     use http::{HeaderValue, StatusCode, request::Parts};
-    use topcoat_core::context::Cx;
+    use topcoat_core::context::{Cx, request_context, try_request_context};
 
     use super::*;
     use crate::{
@@ -510,19 +510,19 @@ mod tests {
     }
 
     /// Builds a request context carrying the parts of a GET request to `uri`.
-    fn cx_for(uri: &str) -> CxBuilder {
+    fn cx_for(uri: &str) -> Cx {
         let (parts, ()) = http::Request::builder()
             .uri(uri)
             .body(())
             .unwrap()
             .into_parts();
-        let mut cx = CxBuilder::default();
+        let mut cx = Cx::default();
         cx.insert(parts);
         cx
     }
 
     /// Runs a request through `layer` wrapped directly around `route`.
-    fn run(layer: &dyn Layer, cx: &mut CxBuilder, route: &RouteFn) -> Result<Response> {
+    fn run(layer: &dyn Layer, cx: &mut Cx, route: &RouteFn) -> Result<Response> {
         let layers = Layers::default();
         let next = Next::new(&layers, &[], Terminal::Route(route));
         block_on(layer.handle(cx, Body::empty(), next))
@@ -848,7 +848,11 @@ mod tests {
         // The route saw the header the middleware added, and the modified
         // request was written back to the context.
         assert_eq!(&body_bytes(response)[..], b"marked");
-        assert!(cx.get::<Parts>().unwrap().headers.contains_key("x-tower"));
+        assert!(
+            request_context::<Parts>(&cx)
+                .headers
+                .contains_key("x-tower")
+        );
     }
 
     #[test]
@@ -874,7 +878,7 @@ mod tests {
         assert_eq!(&body_bytes(response)[..], b"short");
         // The chain never ran, so the parts stay on the context for outer
         // layers and error rendering.
-        assert!(cx.get::<Parts>().is_some());
+        assert!(try_request_context::<Parts>(&cx).is_some());
     }
 
     #[test]

--- a/crates/topcoat-session/src/router.rs
+++ b/crates/topcoat-session/src/router.rs
@@ -1,4 +1,4 @@
-use topcoat_core::context::CxBuilder;
+use topcoat_core::context::Cx;
 use topcoat_router::{Body, Layer, LayerFuture, Next, Path, RouterBuilder};
 
 use crate::{SessionConfig, SessionState};
@@ -21,7 +21,7 @@ impl Layer for SessionLayer {
         Path::new("/")
     }
 
-    fn handle<'a>(&'a self, cx: &'a mut CxBuilder, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    fn handle<'a>(&'a self, cx: &'a mut Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
         cx.insert(SessionState::new());
         next.run(cx, body)
     }

--- a/crates/topcoat-view/src/view.rs
+++ b/crates/topcoat-view/src/view.rs
@@ -180,6 +180,7 @@ impl View {
     /// invocation it was built in, or if a dynamic attribute key or element
     /// name in the view contains a character that could break out of the
     /// identifier.
+    #[must_use]
     #[track_caller]
     pub fn render(self, cx: &Cx) -> String {
         match self.repr {
@@ -571,7 +572,7 @@ mod tests {
     #[should_panic(expected = "no view is building")]
     fn rendering_an_escaped_nested_view_panics() {
         let view = in_scope(async |_cx| sync(|_parts| {}));
-        view.render(&Cx::default());
+        let _ = view.render(&Cx::default());
     }
 
     #[test]

--- a/crates/topcoat/docs/context.md
+++ b/crates/topcoat/docs/context.md
@@ -122,6 +122,37 @@ fn current_customer(cx: &Cx) -> Option<&Customer> {
 }
 ```
 
+# Work that outlives the handler
+
+A [`Cx`] is a handle to state shared by everything serving one request. The router drops its own handle once the response is sent, so a streaming response body or a spawned task cannot borrow the `cx` the handler was called with. Take an owned handle with [`Cx::detach`] and move it into the work instead; it reads the same app and request context.
+
+```rust
+# async fn record(name: &str) {}
+use topcoat::{
+    Result,
+    context::{Cx, request_context},
+    router::route,
+};
+
+struct Customer {
+    name: String,
+}
+
+#[route(POST "/orders")]
+async fn place_order(cx: &Cx) -> Result<&'static str> {
+    let cx = cx.detach();
+    tokio::spawn(async move {
+        let customer: &Customer = request_context(&cx);
+        record(&customer.name).await;
+    });
+    Ok("queued")
+}
+```
+
+While a detached handle is alive the request context is frozen: registering another value on it panics. Layers register their values before calling `next.run`, so this only concerns a layer that writes to the context after the inner chain returned.
+
+A detached handle keeps reading the context after the response was sent, but it can no longer change what the client receives. Cookie changes and other response-directed writes made from work that outlives the handler are dropped.
+
 # Memoization
 
 [`#[memoize]`](macro@memoize) caches a `cx`-taking function's result for the duration of a request, keyed by its arguments. Wrap the request helpers above with it so that repeated calls (across a layout, a page, and nested components) run the work once and share the result. See its documentation for the details.

--- a/crates/topcoat/docs/router.md
+++ b/crates/topcoat/docs/router.md
@@ -72,12 +72,12 @@ A layer wraps request handling under its path prefix. It receives a mutable requ
 ```rust
 use topcoat::{
     Result,
-    context::CxBuilder,
+    context::Cx,
     router::{Body, Next, layer, response::Response},
 };
 
 #[layer("/")]
-async fn timing(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
+async fn timing(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> {
     let start = std::time::Instant::now();
     let response = next.run(cx, body).await?;
     println!("handled in {:?}", start.elapsed());
@@ -263,10 +263,10 @@ The router applies an [`OriginPolicy`] to every request before any layer or hand
 Build a router by chaining `.page()`, `.layout()`, `.layer()`, and `.route()`, then calling [`build`](RouterBuilder::build):
 
 ```rust
-# use topcoat::{Result, context::CxBuilder, router::{Body, Next, layer, layout, page, response::Response, route}, view::view};
+# use topcoat::{Result, context::Cx, router::{Body, Next, layer, layout, page, response::Response, route}, view::view};
 # #[layout("/")] async fn root_layout(slot: Result) -> Result { view! { (slot?) } }
 # #[layout("/settings")] async fn settings_layout(slot: Result) -> Result { view! { (slot?) } }
-# #[layer("/")] async fn timing(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> { next.run(cx, body).await }
+# #[layer("/")] async fn timing(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> { next.run(cx, body).await }
 # #[page("/")] async fn home() -> Result { view! { <h1>"Home"</h1> } }
 # #[page("/about")] async fn about() -> Result { view! { <h1>"About"</h1> } }
 # #[page("/settings/profile")] async fn profile() -> Result { view! { <h1>"Profile"</h1> } }
@@ -347,7 +347,7 @@ With the `tower` feature enabled, the [`tower`](mod@tower) module bridges the to
 ```rust
 use topcoat::{
     Result,
-    context::CxBuilder,
+    context::Cx,
     router::{Body, Next, Router, content::Json, layer, layout, page, response::Response, route},
     view::view,
 };
@@ -374,7 +374,7 @@ async fn root_layout(slot: Result) -> Result {
 }
 
 #[layer("/api")]
-async fn api_log(cx: &mut CxBuilder, body: Body, next: Next<'_>) -> Result<Response> {
+async fn api_log(cx: &mut Cx, body: Body, next: Next<'_>) -> Result<Response> {
     let response = next.run(cx, body).await?;
     println!("API response: {}", response.status());
     Ok(response)

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -50,7 +50,7 @@ async fn home() -> Result {
 
 #[route(GET "/echo")]
 async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-    upgrade.on_upgrade(|_cx, mut socket| async move {
+    upgrade.on_upgrade(|mut socket| async move {
         while let Some(Ok(message)) = socket.recv().await {
             // Ping, pong, and close messages are already handled for us.
             if matches!(message, Message::Text(_) | Message::Binary(_))

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -50,7 +50,7 @@ async fn home() -> Result {
 
 #[route(GET "/echo")]
 async fn echo(upgrade: WebSocketUpgrade) -> Result<Response> {
-    upgrade.on_upgrade(|mut socket| async move {
+    upgrade.on_upgrade(|_cx, mut socket| async move {
         while let Some(Ok(message)) = socket.recv().await {
             // Ping, pong, and close messages are already handled for us.
             if matches!(message, Message::Text(_) | Message::Binary(_))


### PR DESCRIPTION
## Summary

Work that outlives a handler could not reach the request context: the router dropped the `Cx` when the request finished, and response bodies must be `'static`. This makes `Cx` an `Arc`-backed handle so a streaming body or a spawned task can hold its own.

- `Cx` wraps `Arc<CxInner>`. `Cx::detach()` returns an owned handle over the same state.
- `CxBuilder` is deleted. `Layer::handle`, `LayerHandlerFn`, and `Next::run` take `&mut Cx`, and layers register values with `Cx::insert` / `Cx::get_mut`. The route terminal reborrows as `&Cx`, like the old `Deref` did.
- Mutation goes through `Arc::get_mut`, so the request context is frozen while a detached handle is alive: `insert` panics with a message naming `Cx::detach`. In-tree layers only insert before running the inner chain, so none of them can hit it.
- Reads are unchanged; they stay on the existing free helpers.

`CxBuilder::contains` and `get` had no in-tree callers and are gone rather than moved onto `Cx`.

Making `Cx` an `Arc` handle also made it `Freeze`, which turns on clippy's `must_use_candidate` for `&Cx`-taking functions. Hence the `#[must_use]` additions on `Cx::id`, `app_context`, `request_context`, `memoize_cache`, `abort_store`, `View::render`, and `PageFn`/`LayoutFn::render`.

### Breaking changes

`CxBuilder` is gone from the public API. `#[layer]` functions change `cx: &mut CxBuilder` to `cx: &mut Cx`; the macro itself never referenced `CxBuilder`, only the docs did.
