### PR TITLE
feat(cookie): protect cookie jar from being written to after response…

### DIFF
--- a/crates/topcoat-cookie/src/jar.rs
+++ b/crates/topcoat-cookie/src/jar.rs
@@ -1,4 +1,7 @@
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{
+    Mutex, MutexGuard,
+    atomic::{AtomicBool, Ordering},
+};
 
 use cookie::{Cookie, CookieJar as RawCookieJar};
 use http::{HeaderValue, header, request::Parts};
@@ -18,9 +21,13 @@ use crate::Cookies;
 /// [`Prefixed`](crate::Prefixed), [`Map`](crate::Map)) ultimately reads from and
 /// writes to this jar, so the pending changes it accumulates are what gets
 /// serialized into `Set-Cookie` response headers.
+///
+/// Once those headers are written the jar is sealed: reads keep working, but
+/// adding or removing a cookie panics instead of being silently dropped.
 #[derive(Debug)]
 pub struct CookieJar {
     jar: Mutex<RawCookieJar>,
+    sealed: AtomicBool,
 }
 
 impl CookieJar {
@@ -40,6 +47,7 @@ impl CookieJar {
         }
         Self {
             jar: Mutex::new(jar),
+            sealed: AtomicBool::new(false),
         }
     }
 
@@ -56,6 +64,24 @@ impl CookieJar {
             .filter_map(|cookie| HeaderValue::from_str(&cookie.encoded().to_string()).ok())
             .collect()
     }
+
+    /// Closes the jar for writing, after its changes have been written onto the
+    /// response.
+    pub(crate) fn seal(&self) {
+        self.sealed.store(true, Ordering::Release);
+    }
+
+    /// Panics if the response has already taken this jar's changes, because a
+    /// write made now would never reach the client.
+    fn assert_open(&self, action: &str) {
+        assert!(
+            !self.sealed.load(Ordering::Acquire),
+            "cannot {action} a cookie after the response headers have been sent. \
+             Pending cookies are written when the handler returns, so work that \
+             outlives it, such as a streaming body or a WebSocket task, can only \
+             read cookies"
+        );
+    }
 }
 
 impl Cookies for &CookieJar {
@@ -64,10 +90,12 @@ impl Cookies for &CookieJar {
     }
 
     fn add<C: Into<Cookie<'static>>>(&self, cookie: C) {
+        self.assert_open("add");
         self.lock().add(cookie.into());
     }
 
     fn remove<C: Into<Cookie<'static>>>(&self, cookie: C) {
+        self.assert_open("remove");
         self.lock().remove(cookie.into());
     }
 }

--- a/crates/topcoat-cookie/src/lib.rs
+++ b/crates/topcoat-cookie/src/lib.rs
@@ -10,7 +10,10 @@ mod router;
 mod signed;
 mod store;
 
-use std::sync::OnceLock;
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 pub use cookie::{Cookie, Expiration, Key, SameSite, time};
 pub use jar::*;
@@ -39,11 +42,23 @@ pub trait Cookies {
 
     /// Adds `cookie`. It is serialized into a `Set-Cookie` response header once
     /// the cookie router layer handles the response.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the response headers have already been written, which is the
+    /// case in work that outlives the handler, such as a streaming body or a
+    /// WebSocket task.
     fn add<C: Into<Cookie<'static>>>(&self, cookie: C);
 
     /// Removes `cookie`. If the request carried an original cookie with the
     /// same name, an expiring removal cookie is sent. Pass the same `Path`/
     /// `Domain` the cookie was set with.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the response headers have already been written, which is the
+    /// case in work that outlives the handler, such as a streaming body or a
+    /// WebSocket task.
     fn remove<C: Into<Cookie<'static>>>(&self, cookie: C);
 
     /// Wraps this jar so signed cookies are written and verified with `key`.
@@ -239,9 +254,14 @@ pub trait Cookies {
 /// [`cookies`] parses the incoming `Cookie` headers into a [`CookieJar`] and
 /// stores it here; response finalization reads the same cell to emit pending
 /// `Set-Cookie` headers only if the jar was actually touched.
+///
+/// Finalization also seals the cell, so a jar handed out afterwards, whether it
+/// was built during the request or on first access from a detached task, rejects
+/// writes.
 #[derive(Debug, Default)]
 pub struct CookieJarCell {
     jar: OnceLock<CookieJar>,
+    sealed: AtomicBool,
 }
 
 impl CookieJarCell {
@@ -251,11 +271,26 @@ impl CookieJarCell {
     }
 
     fn get_or_init(&self, cx: &Cx) -> &CookieJar {
-        self.jar.get_or_init(|| CookieJar::from_request(cx))
+        let jar = self.jar.get_or_init(|| CookieJar::from_request(cx));
+        // A jar built after the cell was sealed inherits the seal. Checking
+        // here rather than inside the initializer also closes the window where
+        // the seal lands while another thread is still building the jar.
+        if self.sealed.load(Ordering::Acquire) {
+            jar.seal();
+        }
+        jar
     }
 
     fn get(&self) -> Option<&CookieJar> {
         self.jar.get()
+    }
+
+    /// Closes the request's jar for writing, now and for any jar built later.
+    fn seal(&self) {
+        self.sealed.store(true, Ordering::Release);
+        if let Some(jar) = self.jar.get() {
+            jar.seal();
+        }
     }
 }
 
@@ -304,14 +339,18 @@ pub fn private_cookies(cx: &Cx) -> PrivateJar<'_, &CookieJar> {
 /// Called by the router after each handler runs. If no cookie helper was used
 /// during the request, the jar was never built, so we skip without parsing the
 /// incoming `Cookie` header at all.
+///
+/// The jar is sealed either way: from here on the response is out of the
+/// framework's hands, so a write would go nowhere and panics instead.
 #[doc(hidden)]
 pub fn write_cookies(cx: &Cx, headers: &mut http::HeaderMap) {
-    let Some(jar) = request_context::<CookieJarCell>(cx).get() else {
-        return;
-    };
-    for value in jar.delta_headers() {
-        headers.append(http::header::SET_COOKIE, value);
+    let cell = request_context::<CookieJarCell>(cx);
+    if let Some(jar) = cell.get() {
+        for value in jar.delta_headers() {
+            headers.append(http::header::SET_COOKIE, value);
+        }
     }
+    cell.seal();
 }
 
 #[cfg(test)]
@@ -460,6 +499,46 @@ mod tests {
         write_cookies(&cx, &mut headers);
 
         assert!(headers.get(header::SET_COOKIE).is_none());
+    }
+
+    #[test]
+    fn reads_still_work_after_the_response() {
+        // Work that outlives the handler, like a streaming body, may well need
+        // to look at the request's cookies.
+        let cx = cx_with(&["theme=dark"]);
+        let _ = set_cookies(&cx);
+
+        assert_eq!(cookies(&cx).get("theme").unwrap().value(), "dark");
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot add a cookie after the response")]
+    fn adding_after_the_response_panics() {
+        let cx = cx_with(&[]);
+        cookies(&cx).add(("theme", "dark"));
+        let _ = set_cookies(&cx);
+
+        cookies(&cx).add(("theme", "light"));
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot remove a cookie after the response")]
+    fn removing_after_the_response_panics() {
+        let cx = cx_with(&["session=abc123"]);
+        let _ = set_cookies(&cx);
+
+        cookies(&cx).remove(("session", ""));
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot add a cookie after the response")]
+    fn adding_through_a_jar_built_after_the_response_panics() {
+        // The handler never touched cookies, so this is the first call that
+        // builds the jar. It must still come back sealed.
+        let cx = cx_with(&["theme=dark"]);
+        let _ = set_cookies(&cx);
+
+        cookies(&cx).default_path("/").add(("theme", "light"));
     }
 
     #[test]

--- a/crates/topcoat-cookie/src/router.rs
+++ b/crates/topcoat-cookie/src/router.rs
@@ -55,6 +55,8 @@ impl RouterBuilderCookieExt for RouterBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use http::{Method, Request, header};
     use topcoat_core::{context::Cx, error::Result};
     use topcoat_router::{Body, Methods, Path, Route, RouteFuture, Router, response::Response};
@@ -98,5 +100,46 @@ mod tests {
             Some("theme=dark")
         );
         Ok(())
+    }
+
+    /// Hands an owned context handle back to the test, standing in for work
+    /// that outlives the handler, such as a streaming body or a WebSocket task.
+    struct Detach(Arc<Mutex<Option<Cx>>>);
+
+    impl Route for Detach {
+        fn methods(&self) -> Methods<'_> {
+            Methods::Only(&[Method::GET])
+        }
+
+        fn path(&self) -> &Path {
+            Path::new("/")
+        }
+
+        fn handle<'cx>(&'cx self, cx: &'cx Cx, _body: Body) -> RouteFuture<'cx> {
+            Box::pin(async move {
+                *self.0.lock().expect("lock should not be poisoned") = Some(cx.detach());
+                Ok(Response::new(Body::empty()))
+            })
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "cannot add a cookie after the response")]
+    async fn writing_once_the_layer_is_done_panics() {
+        let handle = Arc::new(Mutex::new(None));
+        let router = Router::builder()
+            .route(Detach(Arc::clone(&handle)))
+            .cookies()
+            .build();
+        let request = Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .expect("request should build");
+
+        // The layer has written its `Set-Cookie` headers by the time `handle`
+        // returns, so this cookie could never reach the client.
+        let _ = router.handle(request).await;
+        let cx = handle.lock().expect("lock should not be poisoned").take();
+        cookies(cx.as_ref().expect("route should have detached")).add(("theme", "dark"));
     }
 }


### PR DESCRIPTION
… headers have already been sent