### PR TITLE
fix(cli): add '/ws' to exempt OriginPolicy on dev

### DIFF
--- a/crates/topcoat-cli/src/dev/broadcast_server.rs
+++ b/crates/topcoat-cli/src/dev/broadcast_server.rs
@@ -10,7 +10,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::{net::TcpListener, sync::broadcast};
 use topcoat_core::context::{Cx, app_context};
 use topcoat_router::{
-    Body, HeaderValue, Method, Path, RouteFn, RouteFuture, Router, RouterService,
+    Body, HeaderValue, Method, OriginPolicy, Path, RouteFn, RouteFuture, Router, RouterService,
     content::websocket::{Message, WebSocket, WebSocketUpgrade},
     header, internal_serve,
     request::FromRequest,
@@ -113,6 +113,7 @@ pub async fn bind() -> TcpListener {
 pub async fn run(listener: TcpListener, events: EventBus) {
     let router = Router::builder()
         .app_context(events)
+        .origin_policy(OriginPolicy::new().exempt_paths(["/ws"]))
         .route(RouteFn::new(
             Method::GET,
             Cow::Borrowed(Path::new("/dev.js")),


### PR DESCRIPTION
When you run 'topcoat dev' the websocket request is denied because it is coming from a different address. This creates an infinite loop of network errors in the dev console. 

<img width="1045" height="336" alt="image" src="https://github.com/user-attachments/assets/da1f810f-4fe3-48c7-a193-1e59abddb276" />

Reproduction on the hello-world example:
```
topcoat dev
```

This pr just allows "/ws" on dev. 