### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpine-ajax"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -424,7 +424,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coffee-shop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "toasty",
@@ -477,7 +477,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "tokio",
@@ -640,7 +640,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datastar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -842,7 +842,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1082,7 +1082,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1547,7 +1547,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mail"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "tokio",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "manual-router"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2080,7 +2080,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "tokio",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "sse"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2421,7 +2421,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "toasty",
@@ -2787,7 +2787,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-alpine-ajax"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http",
  "tokio",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http",
  "memchr",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "console",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cookie 0.18.1",
  "getrandom 0.2.17",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "quote",
  "serde",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-datastar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-util",
  "http",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "heck",
  "inventory",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "quote",
  "syn",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http",
  "serde",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lettre",
  "thiserror",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "quote",
  "syn",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "http",
  "quote",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "quote",
  "syn",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "futures-core",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "quote",
  "syn",
@@ -3363,7 +3363,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "websocket"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -113,36 +113,36 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-alpine-ajax = { version = "0.6.0", path = "crates/topcoat-alpine-ajax" }
-topcoat-asset = { version = "0.6.0", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.6.0", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.6.0", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.6.0", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.6.0", path = "crates/topcoat-core/macro" }
-topcoat-datastar = { version = "0.6.0", path = "crates/topcoat-datastar" }
-topcoat-font = { version = "0.6.0", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.6.0", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.6.0", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.6.0", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.6.0", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.6.0", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.6.0", path = "crates/topcoat-icon/macro" }
-topcoat-mail = { version = "0.6.0", path = "crates/topcoat-mail" }
-topcoat-mail-grammar = { version = "0.6.0", path = "crates/topcoat-mail/grammar" }
-topcoat-mail-macro = { version = "0.6.0", path = "crates/topcoat-mail/macro" }
-topcoat-router = { version = "0.6.0", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.6.0", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.6.0", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.6.0", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.6.0", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.6.0", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.6.0", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.6.0", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.6.0", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.6.0", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.6.0", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.6.0", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.6.0", path = "crates/topcoat-view/macro" }
+topcoat-alpine-ajax = { version = "0.6.1", path = "crates/topcoat-alpine-ajax" }
+topcoat-asset = { version = "0.6.1", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.6.1", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.6.1", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.6.1", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.6.1", path = "crates/topcoat-core/macro" }
+topcoat-datastar = { version = "0.6.1", path = "crates/topcoat-datastar" }
+topcoat-font = { version = "0.6.1", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.6.1", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.6.1", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.6.1", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.6.1", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.6.1", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.6.1", path = "crates/topcoat-icon/macro" }
+topcoat-mail = { version = "0.6.1", path = "crates/topcoat-mail" }
+topcoat-mail-grammar = { version = "0.6.1", path = "crates/topcoat-mail/grammar" }
+topcoat-mail-macro = { version = "0.6.1", path = "crates/topcoat-mail/macro" }
+topcoat-router = { version = "0.6.1", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.6.1", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.6.1", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.6.1", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.6.1", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.6.1", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.6.1", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.6.1", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.6.1", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.6.1", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.6.1", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.6.1", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.6.1", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-router/CHANGELOG.md
+++ b/crates/topcoat-router/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.6.0...topcoat-router-v0.6.1) - 2026-08-18
+
+### Fixed
+
+- *(router)* rewrite through 'discover' routing ([#354](https://github.com/tokio-rs/topcoat/pull/354))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.5.0...topcoat-router-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-runtime/grammar/CHANGELOG.md
+++ b/crates/topcoat-runtime/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.6.0...topcoat-runtime-grammar-v0.6.1) - 2026-08-18
+
+### Fixed
+
+- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.5.0...topcoat-runtime-grammar-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-runtime/macro/CHANGELOG.md
+++ b/crates/topcoat-runtime/macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.6.0...topcoat-runtime-macro-v0.6.1) - 2026-08-18
+
+### Fixed
+
+- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.5.0...topcoat-runtime-macro-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/tokio-rs/topcoat/compare/v0.6.0...v0.6.1) - 2026-08-18
+
+### Fixed
+
+- *(router)* rewrite through 'discover' routing ([#354](https://github.com/tokio-rs/topcoat/pull/354))
+- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/v0.5.0...v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["alpine-ajax"] }
+topcoat = { version = "0.6.1", features = ["alpine-ajax"] }
 ```
 
 # Loading the Alpine AJAX script

--- a/crates/topcoat/docs/datastar.md
+++ b/crates/topcoat/docs/datastar.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::datastar` and gated behind the `d
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["datastar"] }
+topcoat = { version = "0.6.1", features = ["datastar"] }
 ```
 
 # Loading the Datastar script

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.6.0", features = ["font-fontsource"] }
+topcoat = { version = "0.6.1", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["htmx"] }
+topcoat = { version = "0.6.1", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["icon-iconify"] }
+topcoat = { version = "0.6.1", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.0", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.6.1", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/mail.md
+++ b/crates/topcoat/docs/mail.md
@@ -5,7 +5,7 @@ Everything below is re-exported from `topcoat::mail` and gated behind the `mail`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["mail", "mail-smtp"] }
+topcoat = { version = "0.6.1", features = ["mail", "mail-smtp"] }
 ```
 
 # Setup

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["tailwind"] }
+topcoat = { version = "0.6.1", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.6.1", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.0", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.6.1", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.0", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.6.1", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.6.0 -> 0.6.1
* `topcoat-alpine-ajax`: 0.6.0 -> 0.6.1
* `topcoat-view`: 0.6.0 -> 0.6.1
* `topcoat-router`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `topcoat-asset`: 0.6.0 -> 0.6.1
* `topcoat-cookie`: 0.6.0 -> 0.6.1
* `topcoat-core-grammar`: 0.6.0 -> 0.6.1
* `topcoat-core-macro`: 0.6.0 -> 0.6.1
* `topcoat-datastar`: 0.6.0 -> 0.6.1
* `topcoat-view-grammar`: 0.6.0 -> 0.6.1
* `topcoat-view-macro`: 0.6.0 -> 0.6.1
* `topcoat-font`: 0.6.0 -> 0.6.1
* `topcoat-font-grammar`: 0.6.0 -> 0.6.1
* `topcoat-font-macro`: 0.6.0 -> 0.6.1
* `topcoat-htmx`: 0.6.0 -> 0.6.1
* `topcoat-icon`: 0.6.0 -> 0.6.1
* `topcoat-icon-grammar`: 0.6.0 -> 0.6.1
* `topcoat-icon-macro`: 0.6.0 -> 0.6.1
* `topcoat-mail`: 0.6.0 -> 0.6.1
* `topcoat-mail-grammar`: 0.6.0 -> 0.6.1
* `topcoat-mail-macro`: 0.6.0 -> 0.6.1
* `topcoat-router-grammar`: 0.6.0 -> 0.6.1
* `topcoat-router-macro`: 0.6.0 -> 0.6.1
* `topcoat-runtime`: 0.6.0 -> 0.6.1
* `topcoat-runtime-grammar`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `topcoat-runtime-macro`: 0.6.0 -> 0.6.1
* `topcoat-session`: 0.6.0 -> 0.6.1
* `topcoat-tailwind`: 0.6.0 -> 0.6.1
* `topcoat-ui-registry`: 0.6.0 -> 0.6.1
* `topcoat`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `topcoat-ui`: 0.6.0 -> 0.6.1
* `topcoat-cli`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.5.0...topcoat-core-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* seal Cx on detach
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))
- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
</blockquote>

## `topcoat-alpine-ajax`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-alpine-ajax-v0.5.0...topcoat-alpine-ajax-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
</blockquote>

## `topcoat-view`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.5.0...topcoat-view-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- implement NodeViewParts and AttributeValueViewParts for Cow<'static, str> ([#306](https://github.com/tokio-rs/topcoat/pull/306))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
- *(view)* add docs about concurrent rendering
- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-router`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.6.0...topcoat-router-v0.6.1) - 2026-08-18

### Fixed

- *(router)* rewrite through 'discover' routing ([#354](https://github.com/tokio-rs/topcoat/pull/354))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.5.0...topcoat-asset-v0.6.0) - 2026-08-17

### Added

- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(asset)* ignore false-positive asset scans with empty paths ([#280](https://github.com/tokio-rs/topcoat/pull/280))
- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))
- *(asset)* register one route per bundled file ([#249](https://github.com/tokio-rs/topcoat/pull/249))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.5.0...topcoat-cookie-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.5.0...topcoat-core-grammar-v0.6.0) - 2026-08-17

### Added

- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- sort imports
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.5.0...topcoat-core-macro-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* use 128-bit hash instead of Clone and Eq for memoization ([#337](https://github.com/tokio-rs/topcoat/pull/337))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))

### Fixed

- *(core)* detect recursive memoized calls ([#278](https://github.com/tokio-rs/topcoat/pull/278))

### Other

- fix memoize docs stale example
</blockquote>

## `topcoat-datastar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.5.0...topcoat-datastar-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.5.0...topcoat-view-grammar-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- *(core)* keep macro bodies intact when formatting rust snippets ([#273](https://github.com/tokio-rs/topcoat/pull/273))
- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* refactor new rendering system part 2 ([#320](https://github.com/tokio-rs/topcoat/pull/320))
- *(view)* add lowering step to high-level intermediate representation ([#316](https://github.com/tokio-rs/topcoat/pull/316))
- sort imports
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.5.0...topcoat-view-macro-v0.6.0) - 2026-08-17

### Added

- *(core)* stable component identity system ([#328](https://github.com/tokio-rs/topcoat/pull/328))
- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Fixed

- *(view)* allow keyword element names ([#274](https://github.com/tokio-rs/topcoat/pull/274))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(view)* add docs about concurrent rendering
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-font`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.5.0...topcoat-font-v0.6.0) - 2026-08-17

### Added

- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(core)* [**breaking**] turn fnv1a hash into a struct and add 128-bit variant ([#327](https://github.com/tokio-rs/topcoat/pull/327))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.5.0...topcoat-font-grammar-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.5.0...topcoat-font-macro-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.5.0...topcoat-htmx-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.5.0...topcoat-icon-grammar-v0.6.0) - 2026-08-17

### Other

- sort imports
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-mail`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.5.0...topcoat-mail-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- *(router)* [**breaking**] add unused layer sanity check ([#300](https://github.com/tokio-rs/topcoat/pull/300))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-mail-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.5.0...topcoat-mail-grammar-v0.6.0) - 2026-08-17

### Other

- sort imports
</blockquote>

## `topcoat-mail-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.5.0...topcoat-mail-macro-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))

### Other

- *(view)* consume view when rendering to improve performance ([#312](https://github.com/tokio-rs/topcoat/pull/312))
- sort imports
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.5.0...topcoat-router-grammar-v0.6.0) - 2026-08-17

### Added

- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(core)* [**breaking**] specify as_ref manually on memoized functions ([#310](https://github.com/tokio-rs/topcoat/pull/310))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))

### Fixed

- *(router)* reject invalid route signatures at parse time ([#241](https://github.com/tokio-rs/topcoat/pull/241))
- include docs and visibility in routes, procedures, layers ([#232](https://github.com/tokio-rs/topcoat/pull/232))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.5.0...topcoat-router-macro-v0.6.0) - 2026-08-17

### Added

- *(router)* `href!` macro ([#350](https://github.com/tokio-rs/topcoat/pull/350))
- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(router)* [**breaking**] add not_found macro and no longer run layers and layouts by default on unmatched requests ([#298](https://github.com/tokio-rs/topcoat/pull/298))
- *(router)* [**breaking**] replace path parameter attribute macro ([#242](https://github.com/tokio-rs/topcoat/pull/242))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(router)* remove PathBuf Arc pointer indirection ([#323](https://github.com/tokio-rs/topcoat/pull/323))
- make request and response dedicated modules
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.5.0...topcoat-runtime-v0.6.0) - 2026-08-17

### Added

- *(view)* improve new arena rendering system ([#319](https://github.com/tokio-rs/topcoat/pull/319))
- *(view)* concurrent rendering ([#317](https://github.com/tokio-rs/topcoat/pull/317))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(runtime)* support signals outside the body ([#334](https://github.com/tokio-rs/topcoat/pull/334))
- *(runtime)* let push_str accept an owned string surrogate ([#269](https://github.com/tokio-rs/topcoat/pull/269))
- *(runtime)* reject non-2xx shard responses instead of rendering them ([#247](https://github.com/tokio-rs/topcoat/pull/247))
- *(runtime)* render f64 text the way Rust's Display does ([#245](https://github.com/tokio-rs/topcoat/pull/245))
- *(runtime)* match Rust semantics for string comparison and trim ([#244](https://github.com/tokio-rs/topcoat/pull/244))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- *(router)* rename erased constant for more readable profiler and debugger traces ([#329](https://github.com/tokio-rs/topcoat/pull/329))
- sort imports
- make request and response dedicated modules
- *(runtime)* note that page guards do not cover shard endpoints ([#251](https://github.com/tokio-rs/topcoat/pull/251))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.6.0...topcoat-runtime-grammar-v0.6.1) - 2026-08-18

### Fixed

- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.6.0...topcoat-runtime-macro-v0.6.1) - 2026-08-18

### Fixed

- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.5.0...topcoat-session-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.5.0...topcoat-ui-registry-v0.6.0) - 2026-08-17

### Added

- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
</blockquote>

## `topcoat`

<blockquote>

## [0.6.1](https://github.com/tokio-rs/topcoat/compare/v0.6.0...v0.6.1) - 2026-08-18

### Fixed

- *(router)* rewrite through 'discover' routing ([#354](https://github.com/tokio-rs/topcoat/pull/354))
- *(runtime)* support await expressions in ExprBlock and ExprIf ([#352](https://github.com/tokio-rs/topcoat/pull/352))
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.5.0...topcoat-ui-v0.6.0) - 2026-08-17

### Added

- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- sort imports
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.5.0...topcoat-cli-v0.6.0) - 2026-08-17

### Added

- *(cli)* warn on version mismatch between topcoat and cli ([#305](https://github.com/tokio-rs/topcoat/pull/305))

### Fixed

- *(cli)* add '/ws' to exempt OriginPolicy on dev ([#348](https://github.com/tokio-rs/topcoat/pull/348))
- *(cli)* exclude build script outputs from final output detection ([#301](https://github.com/tokio-rs/topcoat/pull/301))
- *(asset)* [**breaking**] write the bundle next to the executable it was scanned from ([#243](https://github.com/tokio-rs/topcoat/pull/243))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).