### PR TITLE
fix(router): rewrite through 'discover' routing

### DIFF
--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -4,7 +4,7 @@ use topcoat_core::{context::Cx, error::Result};
 use topcoat_view::View;
 
 use crate::{
-    Body, IntoPath, Methods, OwnedMethods, Path, Route, RouteFuture, RouteId,
+    Body, IntoPath, Methods, OwnedMethods, Path, Route, RouteFuture, RouteId, error::RewriteError,
     response::IntoResponse,
 };
 
@@ -225,7 +225,11 @@ impl Route for PageWithLayouts {
             for layout in self.layouts.iter().rev() {
                 slot = layout.render(cx, slot).await;
             }
-            slot.into_response(cx)
+
+            match slot {
+                Err(error) if error.downcast_ref::<RewriteError>().is_some() => Err(error),
+                slot => slot.into_response(cx),
+            }
         })
     }
 }

--- a/crates/topcoat-router/src/page.rs
+++ b/crates/topcoat-router/src/page.rs
@@ -4,7 +4,7 @@ use topcoat_core::{context::Cx, error::Result};
 use topcoat_view::View;
 
 use crate::{
-    Body, IntoPath, Methods, OwnedMethods, Path, Route, RouteFuture, RouteId, error::RewriteError,
+    Body, IntoPath, Methods, OwnedMethods, Path, Route, RouteFuture, RouteId,
     response::IntoResponse,
 };
 
@@ -225,11 +225,7 @@ impl Route for PageWithLayouts {
             for layout in self.layouts.iter().rev() {
                 slot = layout.render(cx, slot).await;
             }
-
-            match slot {
-                Err(error) if error.downcast_ref::<RewriteError>().is_some() => Err(error),
-                slot => slot.into_response(cx),
-            }
+            slot?.into_response(cx)
         })
     }
 }

--- a/crates/topcoat-router/src/router.rs
+++ b/crates/topcoat-router/src/router.rs
@@ -706,6 +706,14 @@ mod tests {
         Box::pin(async move { Err(rewrite("/x", Body::empty()).into()) })
     }
 
+    fn render_rewriting_page(_cx: &Cx, _body: Body) -> ViewFuture<'_> {
+        Box::pin(async move { Err(rewrite("/x", Body::empty()).into()) })
+    }
+
+    fn layout_rewrites(_cx: &Cx, _slot: Result<View>) -> ViewFuture<'_> {
+        Box::pin(async move { Err(rewrite("/x", Body::empty()).into()) })
+    }
+
     fn rewrite_to_missing(_cx: &Cx, _body: Body) -> RouteFuture<'_> {
         Box::pin(async move { Err(rewrite("/missing", Body::empty()).into()) })
     }
@@ -760,6 +768,52 @@ mod tests {
     fn a_rewrite_serves_the_new_path() {
         let router = RouterBuilder::new()
             .route(RouteFn::new(Method::GET, path("/old"), rewrite_to_x))
+            .route(RouteFn::new(Method::GET, path("/x"), say_route))
+            .build();
+
+        let (status, _, body) = send(&router, Method::GET, "/old");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"route");
+    }
+
+    #[test]
+    fn a_page_without_a_layout_can_rewrite() {
+        let router = RouterBuilder::new()
+            .page(PageFn::new(
+                Method::GET,
+                path("/old"),
+                render_rewriting_page,
+            ))
+            .route(RouteFn::new(Method::GET, path("/x"), say_route))
+            .build();
+
+        let (status, _, body) = send(&router, Method::GET, "/old");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"route");
+    }
+
+    #[test]
+    fn a_page_wrapped_by_a_layout_can_rewrite() {
+        let router = RouterBuilder::new()
+            .page(PageFn::new(
+                Method::GET,
+                path("/old"),
+                render_rewriting_page,
+            ))
+            .layout(LayoutFn::new(path("/"), layout_root))
+            .route(RouteFn::new(Method::GET, path("/x"), say_route))
+            .build();
+
+        let (status, _, body) = send(&router, Method::GET, "/old");
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"route");
+    }
+
+    #[test]
+    fn a_layout_can_rewrite() {
+        let router = RouterBuilder::new()
+            .page(PageFn::new(Method::GET, path("/old"), render_page))
+            .layout(LayoutFn::new(path("/"), layout_rewrites))
             .route(RouteFn::new(Method::GET, path("/x"), say_route))
             .build();
 

--- a/examples/error/src/main.rs
+++ b/examples/error/src/main.rs
@@ -2,8 +2,8 @@ use topcoat::{
     Result,
     context::Cx,
     router::{
-        Router, RouterBuilderDiscoverExt, StatusCode,
-        error::{ForbiddenError, NotFoundError, RouterErrorExt, forbidden},
+        Body, Router, RouterBuilderDiscoverExt, StatusCode,
+        error::{ForbiddenError, NotFoundError, RouterErrorExt, forbidden, rewrite},
         href, layout, not_found, page, path_param,
     },
     view::view,
@@ -24,6 +24,7 @@ async fn home() -> Result {
             <li><a href=(href!(post, PostId(1)))>"An existing post"</a></li>
             <li><a href=(href!(post, PostId(7)))>"A missing post (404)"</a></li>
             <li><a href=(href!(admin))>"The admin area (403)"</a></li>
+            <li><a href=(href!(rewrite_page))>"A page rewrite"</a></li>
             // No route serves this URL, so there is no target to point at.
             <li><a href="/no/such/page">"An unrouted URL (404)"</a></li>
         </ul>
@@ -75,6 +76,17 @@ async fn post(cx: &Cx) -> Result {
 #[page("/admin")]
 async fn admin() -> Result {
     Err(forbidden().into())
+}
+
+// A rewrite starts a new server-side dispatch without changing the browser URL.
+#[page("/rewrite")]
+async fn rewrite_page() -> Result {
+    Err(rewrite("/rewritten", Body::empty()).into())
+}
+
+#[page("/rewritten")]
+async fn rewritten() -> Result {
+    view! { <h1>"The rewrite target"</h1> }
 }
 
 // A URL matching no route is normally answered with a bare 404 that skips the


### PR DESCRIPTION
Upon testing **request rewrites** in v0.6.0 I was seeing persistent 'internal server error' instead of the desired behaviour.

The culprit was `PageWithLayouts::handle -> slot.into_response` being called on `RewriteError`. The submitted change allows the `RewriteError` back into the router.rs loop that correctly handles the rewrite.

Tests have been added to `router.rs` to confirm the fix for;
1. pages
2. layouts
3. pages through layouts.

The error example has been updated to show a RewriteError working as expected.

Tests were generated with GPT-5.6 Terra.