### PR TITLE
fix(view): keep if-let bindings alive in concurrent renders

### DIFF
--- a/crates/topcoat-view/grammar/src/view/hir/emit.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/emit.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{TokenStreamExt, format_ident, quote, quote_spanned};
-use syn::Ident;
+use syn::{Expr, Ident, Pat, Token};
 use topcoat_core_grammar::paths::topcoat_view;
 
 /// HIR nodes that emit themselves into the two phases of an [`Emitter`].
@@ -104,5 +104,171 @@ impl Emitter {
                 #burst
             })
         }}
+    }
+
+    /// Hoists `Option` cells for `bindings` so a joined `if`/`match` arm can
+    /// move them into its future.
+    ///
+    /// Pattern bindings die when the arm returns the future that captures
+    /// them. The cells live in the enclosing hoist, the arm stashes each
+    /// binding into one, and the future's prelude takes them back out, so the
+    /// coroutine owns them for as long as it runs.
+    ///
+    /// Returns the arm-body stash assignments and the prelude that rebinds
+    /// them inside the future.
+    pub(super) fn stash_bindings(&mut self, bindings: &[Binding]) -> (TokenStream, TokenStream) {
+        let mut stash = TokenStream::new();
+        let mut prelude = TokenStream::new();
+        for binding in bindings {
+            let temp = self.fresh_ident();
+            self.hoist(quote! {
+                let mut #temp = ::core::option::Option::None;
+            });
+            let ident = &binding.ident;
+            let mutability = &binding.mutability;
+            stash.append_all(quote! {
+                #temp = ::core::option::Option::Some(#ident);
+            });
+            prelude.append_all(quote! {
+                let #mutability #ident = #temp.take().unwrap();
+            });
+        }
+        (stash, prelude)
+    }
+}
+
+/// A named binding introduced by an `if let` condition or `match` arm pattern.
+pub(crate) struct Binding {
+    ident: Ident,
+    mutability: Option<Token![mut]>,
+}
+
+/// Bindings introduced by `if let` / let-chain conditions.
+pub(crate) fn condition_bindings(expr: &Expr) -> Vec<Binding> {
+    let mut bindings = Vec::new();
+    collect_condition_bindings(expr, &mut bindings);
+    bindings
+}
+
+/// Bindings introduced by a `match` arm pattern.
+pub(crate) fn pattern_bindings(pat: &Pat) -> Vec<Binding> {
+    let mut bindings = Vec::new();
+    collect_pat_bindings(pat, &mut bindings);
+    bindings
+}
+
+fn collect_condition_bindings(expr: &Expr, bindings: &mut Vec<Binding>) {
+    match expr {
+        Expr::Let(expr) => collect_pat_bindings(&expr.pat, bindings),
+        Expr::Binary(expr) => {
+            collect_condition_bindings(&expr.left, bindings);
+            collect_condition_bindings(&expr.right, bindings);
+        }
+        Expr::Paren(expr) => collect_condition_bindings(&expr.expr, bindings),
+        Expr::Group(expr) => collect_condition_bindings(&expr.expr, bindings),
+        _ => {}
+    }
+}
+
+fn collect_pat_bindings(pat: &Pat, bindings: &mut Vec<Binding>) {
+    match pat {
+        Pat::Ident(pat) => {
+            if is_binding_ident(pat) && bindings.iter().all(|binding| binding.ident != pat.ident) {
+                bindings.push(Binding {
+                    ident: pat.ident.clone(),
+                    mutability: pat.mutability,
+                });
+            }
+            if let Some((_, subpat)) = &pat.subpat {
+                collect_pat_bindings(subpat, bindings);
+            }
+        }
+        Pat::Or(pat) => {
+            for case in &pat.cases {
+                collect_pat_bindings(case, bindings);
+            }
+        }
+        Pat::Tuple(pat) => {
+            for elem in &pat.elems {
+                collect_pat_bindings(elem, bindings);
+            }
+        }
+        Pat::TupleStruct(pat) => {
+            for elem in &pat.elems {
+                collect_pat_bindings(elem, bindings);
+            }
+        }
+        Pat::Struct(pat) => {
+            for field in &pat.fields {
+                collect_pat_bindings(&field.pat, bindings);
+            }
+        }
+        Pat::Slice(pat) => {
+            for elem in &pat.elems {
+                collect_pat_bindings(elem, bindings);
+            }
+        }
+        Pat::Reference(pat) => collect_pat_bindings(&pat.pat, bindings),
+        Pat::Paren(pat) => collect_pat_bindings(&pat.pat, bindings),
+        Pat::Type(pat) => collect_pat_bindings(&pat.pat, bindings),
+        _ => {}
+    }
+}
+
+/// Whether this ident introduces a variable rather than naming a unit
+/// variant or constant.
+///
+/// A single uppercase ident in pattern position is almost always a path
+/// like `None` or `Status::First`'s `First`, not a binding. `ref`, `mut`,
+/// and `@` make the ident a binding regardless of case.
+fn is_binding_ident(pat: &syn::PatIdent) -> bool {
+    if pat.ident == "_" {
+        return false;
+    }
+    if pat.by_ref.is_some() || pat.mutability.is_some() || pat.subpat.is_some() {
+        return true;
+    }
+    !pat.ident.to_string().starts_with(char::is_uppercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(pat: &str) -> Vec<String> {
+        pattern_bindings(&syn::parse::Parser::parse_str(Pat::parse_single, pat).unwrap())
+            .into_iter()
+            .map(|binding| binding.ident.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn pattern_bindings_collect_lowercase_idents() {
+        assert_eq!(names("Some(status)"), vec!["status"]);
+        assert_eq!(names("(a, mut b)"), vec!["a", "b"]);
+        assert_eq!(names("s @ Some(inner)"), vec!["s", "inner"]);
+    }
+
+    #[test]
+    fn pattern_bindings_skip_unit_variants() {
+        assert!(names("None").is_empty());
+        assert!(names("Status::First").is_empty());
+    }
+
+    #[test]
+    fn condition_bindings_collect_if_let_and_let_chains() {
+        let expr: Expr = syn::parse_quote!(let Some(status) = opt);
+        let names: Vec<_> = condition_bindings(&expr)
+            .into_iter()
+            .map(|binding| binding.ident.to_string())
+            .collect();
+        assert_eq!(names, vec!["status"]);
+
+        let expr: Expr = syn::parse_quote!(let Some(a) = x && let Some(b) = y);
+        let names: Vec<_> = condition_bindings(&expr)
+            .into_iter()
+            .map(|binding| binding.ident.to_string())
+            .collect();
+        assert_eq!(names, vec!["a", "b"]);
     }
 }

--- a/crates/topcoat-view/grammar/src/view/hir/node/if_else.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/if_else.rs
@@ -1,11 +1,11 @@
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::Expr;
 use topcoat_core_grammar::paths::topcoat_view;
 
 use crate::view::hir::{
     Scope,
-    emit::{Emit, Emitter},
+    emit::{Emit, Emitter, condition_bindings},
 };
 
 /// An `if`/`else` whose branches are lowered into nested scopes.
@@ -38,7 +38,15 @@ impl Emit for IfElse {
             // In a joined position the branches yield futures instead of
             // views, so the taken branch joins with the scope's other
             // components. `Either` unifies the two future types.
-            let then_branch = then_branch.emit_future();
+            //
+            // `if let` pattern bindings die when the arm returns; stash them
+            // into the enclosing hoist and rebind them inside the future.
+            let (stash, prelude) = if then_branch.is_async() {
+                emitter.stash_bindings(&condition_bindings(expr))
+            } else {
+                (TokenStream::new(), TokenStream::new())
+            };
+            let then_branch = then_branch.emit_future_with_prelude(&prelude);
             let else_branch = else_branch.emit_future();
 
             emitter.hoist_future(
@@ -46,6 +54,7 @@ impl Emit for IfElse {
                 &ident,
                 &quote! {
                     if #expr {
+                        #stash
                         #topcoat_view::internal::Either::Left(#then_branch)
                     } else {
                         #topcoat_view::internal::Either::Right(#else_branch)

--- a/crates/topcoat-view/grammar/src/view/hir/node/match_expr.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/match_expr.rs
@@ -5,7 +5,7 @@ use topcoat_core_grammar::paths::topcoat_view;
 
 use crate::view::hir::{
     Scope,
-    emit::{Emit, Emitter},
+    emit::{Emit, Emitter, pattern_bindings},
 };
 
 /// A `match` whose arm bodies are lowered into nested scopes.
@@ -38,12 +38,29 @@ impl Emit for MatchExpr {
             // views, so the taken arm joins with the scope's other
             // components. Nested `Either`s unify the arms' future types.
             let arm_count = self.arms.len();
-            let arms = self.arms.iter().enumerate().map(|(index, arm)| {
-                let pat = &arm.pat;
-                let guard = arm.guard.as_ref().map(|guard| quote! { if #guard });
-                let body = nest_either(arm.body.emit_future(), index, arm_count);
-                quote! { #pat #guard => #body }
-            });
+            let arms: Vec<_> = self
+                .arms
+                .iter()
+                .enumerate()
+                .map(|(index, arm)| {
+                    let pat = &arm.pat;
+                    let guard = arm.guard.as_ref().map(|guard| quote! { if #guard });
+                    // Arm pattern bindings die when the arm returns; stash
+                    // them into the enclosing hoist and rebind them inside
+                    // the future.
+                    let (stash, prelude) = if arm.body.is_async() {
+                        emitter.stash_bindings(&pattern_bindings(pat))
+                    } else {
+                        (TokenStream::new(), TokenStream::new())
+                    };
+                    let body = nest_either(
+                        arm.body.emit_future_with_prelude(&prelude),
+                        index,
+                        arm_count,
+                    );
+                    quote! { #pat #guard => { #stash #body } }
+                })
+                .collect();
 
             emitter.hoist_future(
                 Span::call_site(),

--- a/crates/topcoat-view/grammar/src/view/hir/scope.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/scope.rs
@@ -83,9 +83,19 @@ impl Scope {
     ///
     /// The future borrows from its environment, so it must not outlive the
     /// enclosing block; for one that does, use
-    /// [`emit_owned_future`](Self::emit_owned_future).
+    /// [`emit_owned_future`](Self::emit_owned_future). Pattern bindings from
+    /// a joined `if let` or `match` arm are rebound through
+    /// [`emit_future_with_prelude`](Self::emit_future_with_prelude) so the
+    /// future owns them instead of borrowing values that die with the arm.
     pub(crate) fn emit_future(&self) -> TokenStream {
-        self.future(&quote! { async })
+        self.emit_future_with_prelude(&TokenStream::new())
+    }
+
+    /// Like [`emit_future`](Self::emit_future), with `prelude` statements run
+    /// inside the future before the view, so an arm can rebind stashed
+    /// pattern bindings as owned locals.
+    pub(crate) fn emit_future_with_prelude(&self, prelude: &TokenStream) -> TokenStream {
+        self.future(&quote! { async }, prelude)
     }
 
     /// Emits this scope as an expression yielding a future of the view that
@@ -93,14 +103,15 @@ impl Scope {
     /// expression is evaluated in, like one iteration's future outliving the
     /// iteration in a joined `for` loop.
     pub(crate) fn emit_owned_future(&self) -> TokenStream {
-        self.future(&quote! { async move })
+        self.future(&quote! { async move }, &TokenStream::new())
     }
 
-    fn future(&self, header: &TokenStream) -> TokenStream {
+    fn future(&self, header: &TokenStream, prelude: &TokenStream) -> TokenStream {
         let view = self.emit_view();
         if self.is_async() {
             quote! {
                 #header {
+                    #prelude
                     ::core::result::Result::<_, #topcoat_error::Error>::Ok(#view)
                 }
             }
@@ -426,6 +437,41 @@ mod tests {
         assert!(out.contains("Either :: Left"));
         assert!(out.contains("Either :: Right"));
         assert!(out.contains("try_join ! (__expr0 , __expr1)"));
+    }
+
+    #[test]
+    fn joined_if_let_stashes_pattern_bindings_into_the_future() {
+        let mut builder = ViewBuilder::new();
+        add_component(&mut builder, "sibling");
+        builder.if_else(
+            &syn::parse_quote!(let Some(status) = opt),
+            |then_branch, _| {
+                add_component(then_branch, "conditional");
+            },
+        );
+        let out = rendered(builder);
+        assert!(out.contains("let mut __expr2 = :: core :: option :: Option :: None"));
+        assert!(out.contains("Option :: Some (status)"));
+        assert!(out.contains("let status = __expr2 . take () . unwrap ()"));
+        assert!(out.contains("try_join ! (__expr0 , __expr1)"));
+    }
+
+    #[test]
+    fn joined_match_stashes_arm_pattern_bindings_into_the_future() {
+        let mut builder = ViewBuilder::new();
+        add_component(&mut builder, "sibling");
+        builder.match_expr(&syn::parse_quote!(opt), |arms| {
+            arms.arm(&syn::parse_quote!(Some(status)), None, |body| {
+                add_component(body, "a");
+            });
+            arms.arm(&syn::parse_quote!(None), None, |body| {
+                add_component(body, "b");
+            });
+        });
+        let out = rendered(builder);
+        assert!(out.contains("Option :: Some (status)"));
+        assert!(out.contains("let status = __expr2 . take () . unwrap ()"));
+        assert!(!out.contains("Option :: Some (None)"));
     }
 
     #[test]

--- a/crates/topcoat-view/macro/tests/concurrent.rs
+++ b/crates/topcoat-view/macro/tests/concurrent.rs
@@ -239,3 +239,125 @@ async fn concurrent_loop_interleaves_static_markup_in_order() {
     })
     .await;
 }
+
+#[derive(Clone, Copy)]
+enum Status {
+    First,
+    Second,
+}
+
+struct Obj {
+    name: String,
+    user_status: Option<Status>,
+    post_status: Option<Status>,
+}
+
+#[component]
+async fn badge(status: Status) -> Result {
+    let text = match status {
+        Status::First => "First",
+        Status::Second => "Second",
+    };
+    view! { <span>(text)</span> }
+}
+
+#[tokio::test]
+async fn joined_if_lets_can_pass_pattern_bindings_to_components() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let items = [Obj {
+        name: "a".into(),
+        user_status: Some(Status::First),
+        post_status: Some(Status::Second),
+    }];
+    let items: Vec<&Obj> = items.iter().collect();
+    let result: Result = view! {
+        <div>
+            for item in items {
+                <div>
+                    <span>(&item.name)</span>
+                    <div>
+                        if let Some(status) = item.user_status {
+                            badge(status: status)
+                        }
+                        if let Some(status) = item.post_status {
+                            badge(status: status)
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    };
+
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<div><div><span>a</span><div><span>First</span><span>Second</span></div></div></div>",
+    );
+}
+
+#[tokio::test]
+async fn joined_if_lets_can_borrow_non_copy_pattern_bindings() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let user = Some(String::from("Ada"));
+    let post = Some(String::from("Hi"));
+    let result: Result = view! {
+        if let Some(name) = user {
+            echo(text: &name)
+        }
+        if let Some(title) = post {
+            echo(text: &title)
+        }
+    };
+
+    assert_eq!(result.unwrap().render(__cx), "<b>Ada</b><b>Hi</b>");
+}
+
+#[tokio::test]
+async fn joined_match_can_pass_pattern_bindings_to_components() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let user = Some(Status::First);
+    let post = Some(Status::Second);
+    let result: Result = view! {
+        match user {
+            Some(status) => badge(status: status),
+            None => {
+
+            }
+        }
+        match post {
+            Some(status) => badge(status: status),
+            None => {
+
+            }
+        }
+    };
+
+    assert_eq!(
+        result.unwrap().render(__cx),
+        "<span>First</span><span>Second</span>",
+    );
+}
+
+#[tokio::test]
+async fn taken_if_let_branch_renders_concurrently_with_siblings() {
+    assert_concurrent(async {
+        let cx = empty_cx();
+        let __cx = &cx;
+        let barrier = Barrier::new(2);
+        let label = Some("sometimes");
+        let result: Result = view! {
+            meet(barrier: &barrier, label: "always")
+            if let Some(label) = label {
+                meet(barrier: &barrier, label: label)
+            }
+        };
+
+        assert_eq!(
+            result.unwrap().render(__cx),
+            "<i>always</i><i>sometimes</i>"
+        );
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

- Joined `if let` / `match` arms in `view!` wrap their bodies in `async` blocks so sibling components can render concurrently. Pattern bindings from those arms were captured by reference and dropped when the arm returned the future, which is the E0597 after 0.6 concurrent rendering (two `if let Some(status)` component calls failed; one did not).
- Stash those bindings in `Option` cells on the enclosing hoist and rebind them inside the branch future so the coroutine owns them for as long as it runs.
- Unit variants such as `None` are not treated as bindings.

Closes #358

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +nightly doc --workspace --all-features --no-deps --locked`
- [x] `cargo check -p topcoat --target wasm32-unknown-unknown --no-default-features --features router,view,runtime,asset,cookie,session,discover,multipart,tower --locked`
- [ ] Confirm the original two-`if let` component call site compiles