### PR TITLE
fix(view): make control-flow futures own their pattern bindings

### DIFF
--- a/crates/topcoat-view/grammar/src/view/hir.rs
+++ b/crates/topcoat-view/grammar/src/view/hir.rs
@@ -1,8 +1,10 @@
+mod bindings;
 mod builder;
 mod emit;
 mod node;
 mod scope;
 
+pub(crate) use bindings::*;
 pub(crate) use builder::*;
 pub(crate) use node::*;
 pub(crate) use scope::*;

--- a/crates/topcoat-view/grammar/src/view/hir/bindings.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/bindings.rs
@@ -1,0 +1,207 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Expr, Ident, Pat, Token};
+
+/// The bindings a control-flow pattern introduces into its body's scope.
+///
+/// A joined body's future must own these values, because they die with the
+/// branch or iteration that produced them while the future lives on until
+/// the join. [`Scope::emit_future`](super::Scope::emit_future) moves them
+/// into the future through `Capture`.
+pub(crate) struct Bindings(Vec<Binding>);
+
+impl Bindings {
+    /// Returns the empty set, for a body without an enclosing pattern.
+    pub(crate) fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Collects the bindings of a single pattern, like a `match` arm's or a
+    /// `for` loop's.
+    pub(crate) fn of_pattern(pat: &Pat) -> Self {
+        let mut bindings = Self::empty();
+        bindings.collect_pattern(pat);
+        bindings
+    }
+
+    /// Collects the bindings of an `if` condition: the patterns of its
+    /// `let`s, walking `&&` chains.
+    pub(crate) fn of_condition(expr: &Expr) -> Self {
+        let mut bindings = Self::empty();
+        bindings.collect_condition(expr);
+        bindings
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the bound identifiers, for packing the values into a
+    /// `Capture` where the pattern's bindings are in scope.
+    pub(crate) fn idents(&self) -> impl Iterator<Item = &Ident> {
+        self.0.iter().map(|binding| &binding.ident)
+    }
+
+    /// Returns the rebinding patterns, for taking the values back out of
+    /// the `Capture` inside the future.
+    pub(crate) fn rebinds(&self) -> impl Iterator<Item = &Binding> {
+        self.0.iter()
+    }
+
+    fn collect_condition(&mut self, expr: &Expr) {
+        match expr {
+            Expr::Let(let_) => self.collect_pattern(&let_.pat),
+            Expr::Binary(binary) if matches!(binary.op, syn::BinOp::And(_)) => {
+                self.collect_condition(&binary.left);
+                self.collect_condition(&binary.right);
+            }
+            Expr::Paren(paren) => self.collect_condition(&paren.expr),
+            Expr::Group(group) => self.collect_condition(&group.expr),
+            _ => {}
+        }
+    }
+
+    fn collect_pattern(&mut self, pat: &Pat) {
+        match pat {
+            Pat::Ident(ident) => {
+                // A bare ident can also be a unit variant or a constant,
+                // which syn cannot tell apart from a binding. Those follow
+                // the uppercase naming convention, so an uppercase-initial
+                // ident is left alone; rebinding it could illegally shadow
+                // the item it names.
+                let name = ident.ident.to_string();
+                let name = name.strip_prefix("r#").unwrap_or(&name);
+                if !name.starts_with(char::is_uppercase) {
+                    self.push(Binding {
+                        mutability: ident.mutability,
+                        ident: ident.ident.clone(),
+                    });
+                }
+                if let Some((_, subpat)) = &ident.subpat {
+                    self.collect_pattern(subpat);
+                }
+            }
+            Pat::Or(or) => {
+                // Every alternative binds the same names, so collecting all
+                // of them relies on `push` deduplicating.
+                for case in &or.cases {
+                    self.collect_pattern(case);
+                }
+            }
+            Pat::Paren(paren) => self.collect_pattern(&paren.pat),
+            Pat::Reference(reference) => self.collect_pattern(&reference.pat),
+            Pat::Slice(slice) => {
+                for elem in &slice.elems {
+                    self.collect_pattern(elem);
+                }
+            }
+            Pat::Struct(struct_) => {
+                for field in &struct_.fields {
+                    self.collect_pattern(&field.pat);
+                }
+            }
+            Pat::Tuple(tuple) => {
+                for elem in &tuple.elems {
+                    self.collect_pattern(elem);
+                }
+            }
+            Pat::TupleStruct(tuple_struct) => {
+                for elem in &tuple_struct.elems {
+                    self.collect_pattern(elem);
+                }
+            }
+            Pat::Type(type_) => self.collect_pattern(&type_.pat),
+            _ => {}
+        }
+    }
+
+    fn push(&mut self, binding: Binding) {
+        if !self.0.iter().any(|other| other.ident == binding.ident) {
+            self.0.push(binding);
+        }
+    }
+}
+
+/// A single bound identifier with the mutability of its binding.
+///
+/// Its tokens are the rebinding pattern inside the future: the identifier
+/// keeps its span, so lints on the binding still point at the source
+/// pattern.
+pub(crate) struct Binding {
+    mutability: Option<Token![mut]>,
+    ident: Ident,
+}
+
+impl ToTokens for Binding {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.mutability.to_tokens(tokens);
+        self.ident.to_tokens(tokens);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+
+    use super::*;
+
+    fn pattern_idents(pat: Pat) -> Vec<String> {
+        let bindings = Bindings::of_pattern(&pat);
+        bindings.idents().map(Ident::to_string).collect()
+    }
+
+    fn condition_idents(expr: &Expr) -> Vec<String> {
+        let bindings = Bindings::of_condition(expr);
+        bindings.idents().map(Ident::to_string).collect()
+    }
+
+    fn parse_pattern(source: &str) -> Pat {
+        syn::parse::Parser::parse_str(Pat::parse_multi, source).unwrap()
+    }
+
+    #[test]
+    fn collects_bindings_from_nested_patterns() {
+        let pat = parse_pattern("Some((a, Obj { name, .. }, [b, ..], &mut c))");
+        assert_eq!(pattern_idents(pat), ["a", "name", "b", "c"]);
+    }
+
+    #[test]
+    fn keeps_the_mut_of_a_binding() {
+        let pat = parse_pattern("Some(mut attrs)");
+        let bindings = Bindings::of_pattern(&pat);
+        let rebinds: Vec<_> = bindings.rebinds().collect();
+        assert_eq!(quote! { #(#rebinds),* }.to_string(), "mut attrs");
+    }
+
+    #[test]
+    fn skips_uppercase_idents() {
+        let pat = parse_pattern("(status, None, Ordering)");
+        assert_eq!(pattern_idents(pat), ["status"]);
+    }
+
+    #[test]
+    fn collects_an_at_binding_and_its_subpattern() {
+        let pat = parse_pattern("whole @ Some(part)");
+        assert_eq!(pattern_idents(pat), ["whole", "part"]);
+    }
+
+    #[test]
+    fn deduplicates_across_or_alternatives() {
+        let pat = parse_pattern("Ok(value) | Err(value)");
+        assert_eq!(pattern_idents(pat), ["value"]);
+    }
+
+    #[test]
+    fn collects_let_patterns_from_a_condition_chain() {
+        let expr = syn::parse_quote! {
+            flag && let Some(a) = first && let Some(b) = second
+        };
+        assert_eq!(condition_idents(&expr), ["a", "b"]);
+    }
+
+    #[test]
+    fn a_plain_condition_has_no_bindings() {
+        let expr = syn::parse_quote! { items.len() > 2 };
+        assert!(Bindings::of_condition(&expr).is_empty());
+    }
+}

--- a/crates/topcoat-view/grammar/src/view/hir/bindings.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/bindings.rs
@@ -145,8 +145,8 @@ mod tests {
 
     use super::*;
 
-    fn pattern_idents(pat: Pat) -> Vec<String> {
-        let bindings = Bindings::of_pattern(&pat);
+    fn pattern_idents(pat: &Pat) -> Vec<String> {
+        let bindings = Bindings::of_pattern(pat);
         bindings.idents().map(Ident::to_string).collect()
     }
 
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn collects_bindings_from_nested_patterns() {
         let pat = parse_pattern("Some((a, Obj { name, .. }, [b, ..], &mut c))");
-        assert_eq!(pattern_idents(pat), ["a", "name", "b", "c"]);
+        assert_eq!(pattern_idents(&pat), ["a", "name", "b", "c"]);
     }
 
     #[test]
@@ -176,19 +176,19 @@ mod tests {
     #[test]
     fn skips_uppercase_idents() {
         let pat = parse_pattern("(status, None, Ordering)");
-        assert_eq!(pattern_idents(pat), ["status"]);
+        assert_eq!(pattern_idents(&pat), ["status"]);
     }
 
     #[test]
     fn collects_an_at_binding_and_its_subpattern() {
         let pat = parse_pattern("whole @ Some(part)");
-        assert_eq!(pattern_idents(pat), ["whole", "part"]);
+        assert_eq!(pattern_idents(&pat), ["whole", "part"]);
     }
 
     #[test]
     fn deduplicates_across_or_alternatives() {
         let pat = parse_pattern("Ok(value) | Err(value)");
-        assert_eq!(pattern_idents(pat), ["value"]);
+        assert_eq!(pattern_idents(&pat), ["value"]);
     }
 
     #[test]

--- a/crates/topcoat-view/grammar/src/view/hir/node/component.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/component.rs
@@ -6,7 +6,7 @@ use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 use crate::view::{
     NamedArg,
     hir::{
-        Scope,
+        Bindings, Scope,
         emit::{Emit, Emitter},
     },
 };
@@ -159,7 +159,7 @@ impl Component {
             let value = &arg.value;
             quote! { .#ident(#value) }
         });
-        let child = children.emit_future();
+        let child = children.emit_future(&Bindings::empty());
 
         quote_spanned! {path.span()=> {
             async {

--- a/crates/topcoat-view/grammar/src/view/hir/node/for_loop.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/for_loop.rs
@@ -4,7 +4,7 @@ use syn::{Expr, Pat};
 use topcoat_core_grammar::paths::topcoat_view;
 
 use crate::view::hir::{
-    Scope,
+    Bindings, Scope,
     emit::{Emit, Emitter},
 };
 
@@ -23,9 +23,10 @@ impl Emit for ForLoop {
         if body.is_async() {
             // A body that renders components yields one future per
             // iteration; joining them renders all iterations concurrently.
-            // The future owns its iteration's bindings, so it outlives the
-            // iteration that produced it.
-            let body = body.emit_owned_future();
+            // Each future carries its iteration's pattern bindings, which
+            // die with the iteration, and borrows the rest of its
+            // environment, so iterations share outer values.
+            let body = body.emit_future(&Bindings::of_pattern(pat));
             emitter.hoist_future(
                 Span::call_site(),
                 &ident,

--- a/crates/topcoat-view/grammar/src/view/hir/node/if_else.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/if_else.rs
@@ -4,7 +4,7 @@ use syn::Expr;
 use topcoat_core_grammar::paths::topcoat_view;
 
 use crate::view::hir::{
-    Scope,
+    Bindings, Scope,
     emit::{Emit, Emitter},
 };
 
@@ -37,9 +37,11 @@ impl Emit for IfElse {
         } else {
             // In a joined position the branches yield futures instead of
             // views, so the taken branch joins with the scope's other
-            // components. `Either` unifies the two future types.
-            let then_branch = then_branch.emit_future();
-            let else_branch = else_branch.emit_future();
+            // components. `Either` unifies the two future types. The then
+            // future carries the bindings of the condition's `let` patterns,
+            // which die with the branch it is created in.
+            let then_branch = then_branch.emit_future(&Bindings::of_condition(expr));
+            let else_branch = else_branch.emit_future(&Bindings::empty());
 
             emitter.hoist_future(
                 Span::call_site(),

--- a/crates/topcoat-view/grammar/src/view/hir/node/match_expr.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/node/match_expr.rs
@@ -4,7 +4,7 @@ use syn::{Expr, Pat};
 use topcoat_core_grammar::paths::topcoat_view;
 
 use crate::view::hir::{
-    Scope,
+    Bindings, Scope,
     emit::{Emit, Emitter},
 };
 
@@ -37,11 +37,14 @@ impl Emit for MatchExpr {
             // In a joined position the arm bodies yield futures instead of
             // views, so the taken arm joins with the scope's other
             // components. Nested `Either`s unify the arms' future types.
+            // Each arm's future carries its pattern's bindings, which die
+            // with the arm it is created in.
             let arm_count = self.arms.len();
             let arms = self.arms.iter().enumerate().map(|(index, arm)| {
                 let pat = &arm.pat;
                 let guard = arm.guard.as_ref().map(|guard| quote! { if #guard });
-                let body = nest_either(arm.body.emit_future(), index, arm_count);
+                let body = arm.body.emit_future(&Bindings::of_pattern(pat));
+                let body = nest_either(body, index, arm_count);
                 quote! { #pat #guard => #body }
             });
 

--- a/crates/topcoat-view/grammar/src/view/hir/scope.rs
+++ b/crates/topcoat-view/grammar/src/view/hir/scope.rs
@@ -3,7 +3,7 @@ use quote::quote;
 use topcoat_core_grammar::paths::{topcoat_error, topcoat_view};
 
 use super::{
-    Node, StaticSegment,
+    Bindings, Node, StaticSegment,
     emit::{Emit, Emitter},
 };
 
@@ -78,37 +78,36 @@ impl Scope {
     }
 
     /// Emits this scope as an expression yielding a future of the view, for a
-    /// position joined with sibling futures in the block the expression is
-    /// evaluated in, like the branches of an `if`.
+    /// position joined with sibling futures, like the branches of an `if` or
+    /// the iterations of a `for` loop.
     ///
-    /// The future borrows from its environment, so it must not outlive the
-    /// enclosing block; for one that does, use
-    /// [`emit_owned_future`](Self::emit_owned_future).
-    pub(crate) fn emit_future(&self) -> TokenStream {
-        self.future(&quote! { async })
-    }
-
-    /// Emits this scope as an expression yielding a future of the view that
-    /// owns everything it captures, so it can outlive the block the
-    /// expression is evaluated in, like one iteration's future outliving the
-    /// iteration in a joined `for` loop.
-    pub(crate) fn emit_owned_future(&self) -> TokenStream {
-        self.future(&quote! { async move })
-    }
-
-    fn future(&self, header: &TokenStream) -> TokenStream {
+    /// The future borrows its environment, except for the values bound by
+    /// the enclosing pattern: those die with the branch or iteration that
+    /// produced them, so the future carries them in a `Capture` packed where
+    /// they are still alive and taken back apart inside the future.
+    pub(crate) fn emit_future(&self, bindings: &Bindings) -> TokenStream {
         let view = self.emit_view();
-        if self.is_async() {
-            quote! {
-                #header {
-                    ::core::result::Result::<_, #topcoat_error::Error>::Ok(#view)
-                }
-            }
-        } else {
+        if !self.is_async() {
             // Without components the view builds synchronously where the
             // expression is evaluated and only needs wrapping into a ready
             // future.
             quote! { #topcoat_view::internal::ready(#view) }
+        } else if bindings.is_empty() {
+            quote! {
+                async {
+                    ::core::result::Result::<_, #topcoat_error::Error>::Ok(#view)
+                }
+            }
+        } else {
+            let idents = bindings.idents();
+            let rebinds = bindings.rebinds();
+            quote! {{
+                let __captured = #topcoat_view::internal::Capture((#(#idents,)*));
+                async {
+                    let (#(#rebinds,)*) = __captured.take();
+                    ::core::result::Result::<_, #topcoat_error::Error>::Ok(#view)
+                }
+            }}
         }
     }
 }
@@ -409,10 +408,65 @@ mod tests {
         });
         let out = rendered(builder);
         assert!(out.contains("try_join_all"));
-        // The iteration future owns its bindings, so it outlives the
+        // The iteration future carries the loop binding, so it outlives the
         // iteration; the single loop node then awaits inline.
-        assert!(out.contains("async move"));
+        assert!(out.contains("Capture ((x ,))"));
+        assert!(out.contains("let (x ,) = __captured . take ()"));
         assert!(out.contains(". await ?"));
+    }
+
+    #[test]
+    fn a_for_loop_body_borrows_everything_but_its_bindings() {
+        let mut builder = ViewBuilder::new();
+        builder.for_loop(&syn::parse_quote!(x), &syn::parse_quote!(xs), |body| {
+            add_component(body, "item");
+        });
+        let out = rendered(builder);
+        assert!(!out.contains("async move"));
+    }
+
+    #[test]
+    fn an_if_let_branch_in_a_joined_position_captures_its_bindings() {
+        let mut builder = ViewBuilder::new();
+        add_component(&mut builder, "sibling");
+        builder.if_else(
+            &syn::parse_quote!(let Some(status) = value),
+            |then_branch, _| {
+                add_component(then_branch, "conditional");
+            },
+        );
+        let out = rendered(builder);
+        assert!(out.contains("Capture ((status ,))"));
+        assert!(out.contains("let (status ,) = __captured . take ()"));
+    }
+
+    #[test]
+    fn a_branch_without_bindings_emits_no_capture() {
+        let mut builder = ViewBuilder::new();
+        add_component(&mut builder, "sibling");
+        builder.if_else(&syn::parse_quote!(cond), |then_branch, _| {
+            add_component(then_branch, "conditional");
+        });
+        let out = rendered(builder);
+        assert!(!out.contains("Capture"));
+    }
+
+    #[test]
+    fn match_arms_in_a_joined_position_capture_their_own_bindings() {
+        let mut builder = ViewBuilder::new();
+        add_component(&mut builder, "sibling");
+        builder.match_expr(&syn::parse_quote!(v), |arms| {
+            arms.arm(&syn::parse_quote!(Some(status)), None, |body| {
+                add_component(body, "a");
+            });
+            arms.arm(&syn::parse_quote!(None), None, |body| {
+                add_component(body, "b");
+            });
+        });
+        let out = rendered(builder);
+        assert!(out.contains("Capture ((status ,))"));
+        // The binding-free arm needs no capture.
+        assert_eq!(out.matches("Capture (").count(), 1);
     }
 
     #[test]

--- a/crates/topcoat-view/macro/tests/concurrent.rs
+++ b/crates/topcoat-view/macro/tests/concurrent.rs
@@ -58,13 +58,10 @@ async fn loop_iterations_render_concurrently_in_iteration_order() {
         let cx = empty_cx();
         let __cx = &cx;
         let barrier = Barrier::new(3);
-        // An iteration's future takes ownership of what it captures, so
-        // values shared by all iterations are borrowed up front.
-        let barrier = &barrier;
         let result: Result = view! {
             <ul>
                 for label in ["a", "b", "c"] {
-                    <li>meet(barrier: barrier, label: label)</li>
+                    <li>meet(barrier: &barrier, label: label)</li>
                 }
             </ul>
         };
@@ -220,12 +217,11 @@ async fn concurrent_loop_interleaves_static_markup_in_order() {
         let cx = empty_cx();
         let __cx = &cx;
         let barrier = Barrier::new(2);
-        let barrier = &barrier;
         let result: Result = view! {
             <ol>
                 for (index, label) in ["a", "b"].into_iter().enumerate() {
                     <li value=(index + 1)>
-                        meet(barrier: barrier, label: label)
+                        meet(barrier: &barrier, label: label)
                         (label.to_uppercase())
                     </li>
                 }
@@ -238,4 +234,61 @@ async fn concurrent_loop_interleaves_static_markup_in_order() {
         );
     })
     .await;
+}
+
+#[tokio::test]
+async fn taken_branches_carry_their_pattern_bindings_to_the_join() {
+    assert_concurrent(async {
+        let cx = empty_cx();
+        let __cx = &cx;
+        let barrier = Barrier::new(2);
+        let first = Some("one");
+        let second = Some("two");
+        let result: Result = view! {
+            if let Some(label) = first {
+                meet(barrier: &barrier, label: label)
+            }
+            if let Some(label) = second {
+                meet(barrier: &barrier, label: label)
+            }
+        };
+
+        assert_eq!(result.unwrap().render(__cx), "<i>one</i><i>two</i>");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn taken_match_arms_carry_their_pattern_bindings_to_the_join() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let choice = Some(String::from("picked"));
+    let result: Result = view! {
+        echo(text: "always")
+        match choice {
+            Some(text) => {
+                echo(text: &text)
+            }
+            None => {
+                echo(text: "none")
+            }
+        }
+    };
+
+    assert_eq!(result.unwrap().render(__cx), "<b>always</b><b>picked</b>");
+}
+
+#[tokio::test]
+async fn a_binding_borrowed_from_an_outer_value_lives_until_the_join() {
+    let cx = empty_cx();
+    let __cx = &cx;
+    let name = Some(String::from("borrowed"));
+    let result: Result = view! {
+        echo(text: "always")
+        if let Some(name) = &name {
+            echo(text: name)
+        }
+    };
+
+    assert_eq!(result.unwrap().render(__cx), "<b>always</b><b>borrowed</b>");
 }

--- a/crates/topcoat-view/src/internal.rs
+++ b/crates/topcoat-view/src/internal.rs
@@ -108,6 +108,29 @@ pub fn ready(view: View) -> futures_util::future::Ready<Result<View>> {
     futures_util::future::ready(Ok(view))
 }
 
+/// Moves a control-flow body's pattern bindings into its render future.
+///
+/// A joined branch or iteration body expands to a future that borrows its
+/// environment, while the values its pattern binds die with the branch or
+/// iteration that produced them. The expansion packs those values into this
+/// wrapper where they are still alive and takes them back inside the future,
+/// which then owns them for as long as it lives.
+///
+/// The wrapper is deliberately not `Copy`, and [`take`](Self::take) consumes
+/// it whole: a by-value use of a whole non-`Copy` place is captured by value
+/// even in a non-`move` async block. Reading the contents through the field
+/// instead would let capture analysis narrow to the possibly `Copy` values
+/// inside and downgrade the capture to a borrow, which would not live long
+/// enough.
+pub struct Capture<T>(pub T);
+
+impl<T> Capture<T> {
+    /// Returns the packed bindings, consuming the wrapper.
+    pub fn take(self) -> T {
+        self.0
+    }
+}
+
 /// Runs `f` with the writer sealing for a different context, then restores
 /// the current context.
 ///


### PR DESCRIPTION
Fixes #358 

This is "technically" a breaking change but a very minor one and I would prefer shipping it as a hotfix. It could prevent mutations running inside a `view!` from compiling that previously compiled, but mutations inside a `view!` are discouraged regardless.