### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alpine-ajax"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -160,7 +160,7 @@ checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "app-context"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "asset"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -424,7 +424,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coffee-shop"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "toasty",
@@ -477,7 +477,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "context"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tokio",
@@ -640,7 +640,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datastar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "error"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -842,7 +842,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1082,7 +1082,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "htmx"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "icon"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1532,7 +1532,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "live"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1555,7 +1555,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mail"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tokio",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "manual-router"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "module-router"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "path-query-params"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "procedure"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2088,7 +2088,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "request-response"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "tokio",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "sse"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2429,7 +2429,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storefront-topcoat"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2452,7 +2452,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suspense"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "tailwind"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "toasty-todo"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "toasty",
@@ -2803,7 +2803,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "topcoat"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-alpine-ajax"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "http",
  "tokio",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-asset"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "http",
  "memchr",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cli"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "clap",
  "console",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-cookie"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "cookie 0.18.1",
  "getrandom 0.2.17",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-core-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "quote",
  "serde",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-datastar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures-util",
  "http",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "heck",
  "inventory",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-font-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-htmx"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "http",
  "serde",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-icon-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "lettre",
  "thiserror",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-mail-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-router-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "http",
  "quote",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "inventory",
  "ref-cast",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-runtime-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "quote",
  "syn",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-session"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-tailwind"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "sha2 0.11.0",
  "thiserror",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-ui-registry"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "topcoat",
  "topcoat-icon",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "futures-core",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-grammar"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "topcoat-view-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures-core",
  "quote",
@@ -3380,7 +3380,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ui"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "websocket"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "topcoat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 authors = ["Julien Scholz <hello@julien-scholz.dev>"]
 license = "MIT"
@@ -115,36 +115,36 @@ debug = false
 # before the facade does. Path-only dev-dependencies are dropped from the published
 # manifest, sidestepping the facade<->sub-crate cycle. Do not add a version here.
 topcoat = { path = "crates/topcoat" }
-topcoat-alpine-ajax = { version = "0.6.2", path = "crates/topcoat-alpine-ajax" }
-topcoat-asset = { version = "0.6.2", path = "crates/topcoat-asset" }
-topcoat-cookie = { version = "0.6.2", path = "crates/topcoat-cookie" }
-topcoat-core = { version = "0.6.2", path = "crates/topcoat-core" }
-topcoat-core-grammar = { version = "0.6.2", path = "crates/topcoat-core/grammar" }
-topcoat-core-macro = { version = "0.6.2", path = "crates/topcoat-core/macro" }
-topcoat-datastar = { version = "0.6.2", path = "crates/topcoat-datastar" }
-topcoat-font = { version = "0.6.2", path = "crates/topcoat-font" }
-topcoat-font-grammar = { version = "0.6.2", path = "crates/topcoat-font/grammar" }
-topcoat-font-macro = { version = "0.6.2", path = "crates/topcoat-font/macro" }
-topcoat-htmx = { version = "0.6.2", path = "crates/topcoat-htmx" }
-topcoat-icon = { version = "0.6.2", path = "crates/topcoat-icon" }
-topcoat-icon-grammar = { version = "0.6.2", path = "crates/topcoat-icon/grammar" }
-topcoat-icon-macro = { version = "0.6.2", path = "crates/topcoat-icon/macro" }
-topcoat-mail = { version = "0.6.2", path = "crates/topcoat-mail" }
-topcoat-mail-grammar = { version = "0.6.2", path = "crates/topcoat-mail/grammar" }
-topcoat-mail-macro = { version = "0.6.2", path = "crates/topcoat-mail/macro" }
-topcoat-router = { version = "0.6.2", path = "crates/topcoat-router" }
-topcoat-router-grammar = { version = "0.6.2", path = "crates/topcoat-router/grammar" }
-topcoat-router-macro = { version = "0.6.2", path = "crates/topcoat-router/macro" }
-topcoat-runtime = { version = "0.6.2", path = "crates/topcoat-runtime" }
-topcoat-runtime-grammar = { version = "0.6.2", path = "crates/topcoat-runtime/grammar" }
-topcoat-runtime-macro = { version = "0.6.2", path = "crates/topcoat-runtime/macro" }
-topcoat-session = { version = "0.6.2", path = "crates/topcoat-session" }
-topcoat-tailwind = { version = "0.6.2", path = "crates/topcoat-tailwind" }
-topcoat-ui = { version = "0.6.2", path = "crates/topcoat-ui" }
-topcoat-ui-registry = { version = "0.6.2", path = "crates/topcoat-ui/registry" }
-topcoat-view = { version = "0.6.2", path = "crates/topcoat-view" }
-topcoat-view-grammar = { version = "0.6.2", path = "crates/topcoat-view/grammar" }
-topcoat-view-macro = { version = "0.6.2", path = "crates/topcoat-view/macro" }
+topcoat-alpine-ajax = { version = "0.7.0", path = "crates/topcoat-alpine-ajax" }
+topcoat-asset = { version = "0.7.0", path = "crates/topcoat-asset" }
+topcoat-cookie = { version = "0.7.0", path = "crates/topcoat-cookie" }
+topcoat-core = { version = "0.7.0", path = "crates/topcoat-core" }
+topcoat-core-grammar = { version = "0.7.0", path = "crates/topcoat-core/grammar" }
+topcoat-core-macro = { version = "0.7.0", path = "crates/topcoat-core/macro" }
+topcoat-datastar = { version = "0.7.0", path = "crates/topcoat-datastar" }
+topcoat-font = { version = "0.7.0", path = "crates/topcoat-font" }
+topcoat-font-grammar = { version = "0.7.0", path = "crates/topcoat-font/grammar" }
+topcoat-font-macro = { version = "0.7.0", path = "crates/topcoat-font/macro" }
+topcoat-htmx = { version = "0.7.0", path = "crates/topcoat-htmx" }
+topcoat-icon = { version = "0.7.0", path = "crates/topcoat-icon" }
+topcoat-icon-grammar = { version = "0.7.0", path = "crates/topcoat-icon/grammar" }
+topcoat-icon-macro = { version = "0.7.0", path = "crates/topcoat-icon/macro" }
+topcoat-mail = { version = "0.7.0", path = "crates/topcoat-mail" }
+topcoat-mail-grammar = { version = "0.7.0", path = "crates/topcoat-mail/grammar" }
+topcoat-mail-macro = { version = "0.7.0", path = "crates/topcoat-mail/macro" }
+topcoat-router = { version = "0.7.0", path = "crates/topcoat-router" }
+topcoat-router-grammar = { version = "0.7.0", path = "crates/topcoat-router/grammar" }
+topcoat-router-macro = { version = "0.7.0", path = "crates/topcoat-router/macro" }
+topcoat-runtime = { version = "0.7.0", path = "crates/topcoat-runtime" }
+topcoat-runtime-grammar = { version = "0.7.0", path = "crates/topcoat-runtime/grammar" }
+topcoat-runtime-macro = { version = "0.7.0", path = "crates/topcoat-runtime/macro" }
+topcoat-session = { version = "0.7.0", path = "crates/topcoat-session" }
+topcoat-tailwind = { version = "0.7.0", path = "crates/topcoat-tailwind" }
+topcoat-ui = { version = "0.7.0", path = "crates/topcoat-ui" }
+topcoat-ui-registry = { version = "0.7.0", path = "crates/topcoat-ui/registry" }
+topcoat-view = { version = "0.7.0", path = "crates/topcoat-view" }
+topcoat-view-grammar = { version = "0.7.0", path = "crates/topcoat-view/grammar" }
+topcoat-view-macro = { version = "0.7.0", path = "crates/topcoat-view/macro" }
 
 anyhow = "1.0"
 anymap3 = "1.0"

--- a/crates/topcoat-asset/CHANGELOG.md
+++ b/crates/topcoat-asset/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.6.2...topcoat-asset-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.5.0...topcoat-asset-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-cli/CHANGELOG.md
+++ b/crates/topcoat-cli/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.6.2...topcoat-cli-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(cli)* port retry on dev server init ([#364](https://github.com/tokio-rs/topcoat/pull/364))
+- *(cli)* expose run method on `TopcoatCli` ([#363](https://github.com/tokio-rs/topcoat/pull/363))
+
+### Fixed
+
+- *(cli)* don't reload over in-flight navigations on reconnect ([#365](https://github.com/tokio-rs/topcoat/pull/365))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.5.0...topcoat-cli-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-core/CHANGELOG.md
+++ b/crates/topcoat-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.6.2...topcoat-core-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+
+### Fixed
+
+- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.5.0...topcoat-core-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-core/grammar/CHANGELOG.md
+++ b/crates/topcoat-core/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.6.2...topcoat-core-grammar-v0.7.0) - 2026-09-04
+
+### Added
+
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+
+### Fixed
+
+- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.5.0...topcoat-core-grammar-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-core/macro/CHANGELOG.md
+++ b/crates/topcoat-core/macro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.6.2...topcoat-core-macro-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
+### Fixed
+
+- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.5.0...topcoat-core-macro-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-font/CHANGELOG.md
+++ b/crates/topcoat-font/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.6.2...topcoat-font-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.5.0...topcoat-font-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-icon/CHANGELOG.md
+++ b/crates/topcoat-icon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.6.2...topcoat-icon-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.1.3...topcoat-icon-v0.2.0) - 2026-07-19
 
 ### Other

--- a/crates/topcoat-mail/CHANGELOG.md
+++ b/crates/topcoat-mail/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.6.2...topcoat-mail-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.5.0...topcoat-mail-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-mail/grammar/CHANGELOG.md
+++ b/crates/topcoat-mail/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.6.2...topcoat-mail-grammar-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.5.0...topcoat-mail-grammar-v0.6.0) - 2026-08-17
 
 ### Other

--- a/crates/topcoat-mail/macro/CHANGELOG.md
+++ b/crates/topcoat-mail/macro/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.6.2...topcoat-mail-macro-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.5.0...topcoat-mail-macro-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-router/CHANGELOG.md
+++ b/crates/topcoat-router/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.6.2...topcoat-router-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(router)* implement `HrefTarget` for `&T: HrefTarget` to support dyn ([#370](https://github.com/tokio-rs/topcoat/pull/370))
+- *(router)* is_current methods for Href, routes, and pages ([#362](https://github.com/tokio-rs/topcoat/pull/362))
+
+### Other
+
+- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
+
 ## [0.6.2](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.6.1...topcoat-router-v0.6.2) - 2026-08-18
 
 ### Added

--- a/crates/topcoat-router/grammar/CHANGELOG.md
+++ b/crates/topcoat-router/grammar/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.6.2...topcoat-router-grammar-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.5.0...topcoat-router-grammar-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-router/macro/CHANGELOG.md
+++ b/crates/topcoat-router/macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.6.2...topcoat-router-macro-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.5.0...topcoat-router-macro-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-runtime/CHANGELOG.md
+++ b/crates/topcoat-runtime/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.6.2...topcoat-runtime-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
+### Fixed
+
+- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.5.0...topcoat-runtime-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-runtime/grammar/CHANGELOG.md
+++ b/crates/topcoat-runtime/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.6.2...topcoat-runtime-grammar-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
+### Fixed
+
+- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
+
 ## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.6.0...topcoat-runtime-grammar-v0.6.1) - 2026-08-18
 
 ### Fixed

--- a/crates/topcoat-runtime/macro/CHANGELOG.md
+++ b/crates/topcoat-runtime/macro/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.6.2...topcoat-runtime-macro-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+
+### Fixed
+
+- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
+
 ## [0.6.1](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.6.0...topcoat-runtime-macro-v0.6.1) - 2026-08-18
 
 ### Fixed

--- a/crates/topcoat-ui/registry/CHANGELOG.md
+++ b/crates/topcoat-ui/registry/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.6.2...topcoat-ui-registry-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(ui)* slightly adapt topcoat-ui default colors ([#379](https://github.com/tokio-rs/topcoat/pull/379))
+- *(ui)* switch from feather icons to lucide in topcoat-ui ([#378](https://github.com/tokio-rs/topcoat/pull/378))
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+
 ## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.5.0...topcoat-ui-registry-v0.6.0) - 2026-08-17
 
 ### Added

--- a/crates/topcoat-view/CHANGELOG.md
+++ b/crates/topcoat-view/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.6.2...topcoat-view-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
+### Other
+
+- *(view)* remove `itoa` dependency in favor of `format_into` ([#366](https://github.com/tokio-rs/topcoat/pull/366))
+- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
+
 ## [0.6.2](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.6.1...topcoat-view-v0.6.2) - 2026-08-18
 
 ### Fixed

--- a/crates/topcoat-view/grammar/CHANGELOG.md
+++ b/crates/topcoat-view/grammar/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.6.2...topcoat-view-grammar-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
+### Other
+
+- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
+
 ## [0.6.2](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.6.1...topcoat-view-grammar-v0.6.2) - 2026-08-18
 
 ### Fixed

--- a/crates/topcoat-view/macro/CHANGELOG.md
+++ b/crates/topcoat-view/macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.6.2...topcoat-view-macro-v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+
 ## [0.6.2](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.6.1...topcoat-view-macro-v0.6.2) - 2026-08-18
 
 ### Fixed

--- a/crates/topcoat/CHANGELOG.md
+++ b/crates/topcoat/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/tokio-rs/topcoat/compare/v0.6.2...v0.7.0) - 2026-09-04
+
+### Added
+
+- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
+- *(cli)* port retry on dev server init ([#364](https://github.com/tokio-rs/topcoat/pull/364))
+- *(cli)* expose run method on `TopcoatCli` ([#363](https://github.com/tokio-rs/topcoat/pull/363))
+- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
+- *(router)* implement `HrefTarget` for `&T: HrefTarget` to support dyn ([#370](https://github.com/tokio-rs/topcoat/pull/370))
+- *(router)* is_current methods for Href, routes, and pages ([#362](https://github.com/tokio-rs/topcoat/pull/362))
+- *(ui)* slightly adapt topcoat-ui default colors ([#379](https://github.com/tokio-rs/topcoat/pull/379))
+- *(ui)* switch from feather icons to lucide in topcoat-ui ([#378](https://github.com/tokio-rs/topcoat/pull/378))
+
+### Fixed
+
+- *(cli)* don't reload over in-flight navigations on reconnect ([#365](https://github.com/tokio-rs/topcoat/pull/365))
+- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
+- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
+
+### Other
+
+- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
+- *(view)* remove `itoa` dependency in favor of `format_into` ([#366](https://github.com/tokio-rs/topcoat/pull/366))
+
 ## [0.6.2](https://github.com/tokio-rs/topcoat/compare/v0.6.1...v0.6.2) - 2026-08-18
 
 ### Added

--- a/crates/topcoat/docs/alpine-ajax.md
+++ b/crates/topcoat/docs/alpine-ajax.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::alpine_ajax` and gated behind the
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["alpine-ajax"] }
+topcoat = { version = "0.7.0", features = ["alpine-ajax"] }
 ```
 
 # Loading the Alpine AJAX script

--- a/crates/topcoat/docs/datastar.md
+++ b/crates/topcoat/docs/datastar.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::datastar` and gated behind the `d
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["datastar"] }
+topcoat = { version = "0.7.0", features = ["datastar"] }
 ```
 
 # Loading the Datastar script

--- a/crates/topcoat/docs/font.md
+++ b/crates/topcoat/docs/font.md
@@ -78,7 +78,7 @@ Local files work similarly with the asset system: `url(asset!("./fonts/inter-400
 Fontsource support lives behind the `font-fontsource` feature:
 
 ```toml
-topcoat = { version = "0.6.2", features = ["font-fontsource"] }
+topcoat = { version = "0.7.0", features = ["font-fontsource"] }
 ```
 
 Then specify which font from the [`families`] module you would like to use. By default, this will include every weight and style the font ships, only in its default character subset, loaded by the browser from the [jsDelivr] CDN:

--- a/crates/topcoat/docs/htmx.md
+++ b/crates/topcoat/docs/htmx.md
@@ -7,7 +7,7 @@ Everything below is re-exported from `topcoat::htmx` and gated behind the `htmx`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["htmx"] }
+topcoat = { version = "0.7.0", features = ["htmx"] }
 ```
 
 # Loading the htmx script

--- a/crates/topcoat/docs/icon.md
+++ b/crates/topcoat/docs/icon.md
@@ -59,10 +59,10 @@ Iconify support lives behind the `icon-iconify` feature, for both your runtime d
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["icon-iconify"] }
+topcoat = { version = "0.7.0", features = ["icon-iconify"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.2", default-features = false, features = ["icon-iconify"] }
+topcoat = { version = "0.7.0", default-features = false, features = ["icon-iconify"] }
 ```
 
 Icon sets are staged by a build script. Add a `build.rs` next to `Cargo.toml` naming the sets you use; each set downloads on the first build and is cached, so subsequent builds stay offline:

--- a/crates/topcoat/docs/mail.md
+++ b/crates/topcoat/docs/mail.md
@@ -5,7 +5,7 @@ Everything below is re-exported from `topcoat::mail` and gated behind the `mail`
 ```toml
 # Cargo.toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["mail", "mail-smtp"] }
+topcoat = { version = "0.7.0", features = ["mail", "mail-smtp"] }
 ```
 
 # Setup

--- a/crates/topcoat/docs/tailwind.md
+++ b/crates/topcoat/docs/tailwind.md
@@ -8,10 +8,10 @@ Enable the `tailwind` feature for both your runtime dependency and your build de
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["tailwind"] }
+topcoat = { version = "0.7.0", features = ["tailwind"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.2", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.7.0", default-features = false, features = ["tailwind"] }
 ```
 
 Add a `build.rs` next to `Cargo.toml`:

--- a/crates/topcoat/docs/ui.md
+++ b/crates/topcoat/docs/ui.md
@@ -8,10 +8,10 @@ You need the [`topcoat` CLI](https://github.com/tokio-rs/topcoat/blob/main/crate
 
 ```toml
 [dependencies]
-topcoat = { version = "0.6.2", features = ["font-fontsource", "tailwind", "ui"] }
+topcoat = { version = "0.7.0", features = ["font-fontsource", "tailwind", "ui"] }
 
 [build-dependencies]
-topcoat = { version = "0.6.2", default-features = false, features = ["tailwind"] }
+topcoat = { version = "0.7.0", default-features = false, features = ["tailwind"] }
 ```
 
 ## Initialize the package


### PR DESCRIPTION



## 🤖 New release

* `topcoat-core`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-alpine-ajax`: 0.6.2 -> 0.7.0
* `topcoat-view`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `topcoat-router`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `topcoat-asset`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-cookie`: 0.6.2 -> 0.7.0
* `topcoat-core-grammar`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-core-macro`: 0.6.2 -> 0.7.0
* `topcoat-datastar`: 0.6.2 -> 0.7.0
* `topcoat-view-grammar`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `topcoat-view-macro`: 0.6.2 -> 0.7.0
* `topcoat-font`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `topcoat-font-grammar`: 0.6.2 -> 0.7.0
* `topcoat-font-macro`: 0.6.2 -> 0.7.0
* `topcoat-htmx`: 0.6.2 -> 0.7.0
* `topcoat-icon`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-icon-grammar`: 0.6.2 -> 0.7.0
* `topcoat-icon-macro`: 0.6.2 -> 0.7.0
* `topcoat-mail`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-mail-grammar`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-mail-macro`: 0.6.2 -> 0.7.0
* `topcoat-router-grammar`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-router-macro`: 0.6.2 -> 0.7.0
* `topcoat-runtime`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-runtime-grammar`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-runtime-macro`: 0.6.2 -> 0.7.0
* `topcoat-session`: 0.6.2 -> 0.7.0
* `topcoat-tailwind`: 0.6.2 -> 0.7.0
* `topcoat-ui-registry`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat`: 0.6.2 -> 0.7.0 (✓ API compatible changes)
* `topcoat-ui`: 0.6.2 -> 0.7.0
* `topcoat-cli`: 0.6.2 -> 0.7.0 (✓ API compatible changes)

### ⚠ `topcoat-view` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct topcoat_view::identity::IdentityFuture, previously in file /tmp/.tmpC9wIQN/topcoat-view/src/identity/future.rs:10
  struct topcoat_view::View, previously in file /tmp/.tmpC9wIQN/topcoat-view/src/view.rs:34

--- failure struct_with_no_pub_fields_changed_type: public API struct with no public fields is no longer a struct ---

Description:
A struct without pub fields became an enum or union, breaking pattern matching.
        ref: https://internals.rust-lang.org/t/rest-patterns-foo-should-match-non-struct-types/21607
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_with_no_pub_fields_changed_type.ron

Failed in:
  struct topcoat_view::AttributeValue became enum in file /tmp/.tmphy9I4z/topcoat/crates/topcoat-view/src/html/attribute/value.rs:307
```

### ⚠ `topcoat-router` breaking changes

```text
--- failure trait_associated_const_added: non-sealed trait added associated constant without default value ---

Description:
A non-sealed trait has gained an associated constant without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_associated_const_added.ron

Failed in:
  trait constant topcoat_router::HrefQueries::SPECIFIED in file /tmp/.tmphy9I4z/topcoat/crates/topcoat-router/src/href.rs:323

--- failure trait_no_longer_dyn_compatible: trait no longer dyn compatible ---

Description:
Trait is no longer dyn compatible, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_no_longer_dyn_compatible.ron

Failed in:
  trait HrefQueries in file /tmp/.tmphy9I4z/topcoat/crates/topcoat-router/src/href.rs:320
```

### ⚠ `topcoat-view-grammar` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron

Failed in:
  ComponentAttr::boxed, previously in file /tmp/.tmpC9wIQN/topcoat-view-grammar/src/component/attr.rs:20
```

### ⚠ `topcoat-font` breaking changes

```text
--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct preload_link (1 -> 0 lifetime params) in /tmp/.tmphy9I4z/topcoat/crates/topcoat-font/src/component.rs:49
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `topcoat-core`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-v0.6.2...topcoat-core-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))

### Fixed

- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
</blockquote>

## `topcoat-alpine-ajax`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-alpine-ajax-v0.5.0...topcoat-alpine-ajax-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))
</blockquote>

## `topcoat-view`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-v0.6.2...topcoat-view-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))

### Other

- *(view)* remove `itoa` dependency in favor of `format_into` ([#366](https://github.com/tokio-rs/topcoat/pull/366))
- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
</blockquote>

## `topcoat-router`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-v0.6.2...topcoat-router-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(router)* implement `HrefTarget` for `&T: HrefTarget` to support dyn ([#370](https://github.com/tokio-rs/topcoat/pull/370))
- *(router)* is_current methods for Href, routes, and pages ([#362](https://github.com/tokio-rs/topcoat/pull/362))

### Other

- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
</blockquote>

## `topcoat-asset`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-asset-v0.6.2...topcoat-asset-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-cookie`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cookie-v0.5.0...topcoat-cookie-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(cookie)* protect cookie jar from being written to after response… ([#324](https://github.com/tokio-rs/topcoat/pull/324))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-core-grammar`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-grammar-v0.6.2...topcoat-core-grammar-v0.7.0) - 2026-09-04

### Added

- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))

### Fixed

- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
</blockquote>

## `topcoat-core-macro`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-core-macro-v0.6.2...topcoat-core-macro-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))

### Fixed

- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
</blockquote>

## `topcoat-datastar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-datastar-v0.5.0...topcoat-datastar-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Fixed

- *(datastar)* reject multiline selectors ([#256](https://github.com/tokio-rs/topcoat/pull/256))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-view-grammar`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-grammar-v0.6.2...topcoat-view-grammar-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))

### Other

- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
</blockquote>

## `topcoat-view-macro`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-view-macro-v0.6.2...topcoat-view-macro-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-font`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-v0.6.2...topcoat-font-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-font-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-grammar-v0.5.0...topcoat-font-grammar-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-font-macro`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-font-macro-v0.5.0...topcoat-font-macro-v0.6.0) - 2026-08-17

### Fixed

- *(font)* support unicode ranges ending in E ([#307](https://github.com/tokio-rs/topcoat/pull/307))

### Other

- sort imports
</blockquote>

## `topcoat-htmx`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-htmx-v0.5.0...topcoat-htmx-v0.6.0) - 2026-08-17

### Added

- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-icon`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-v0.6.2...topcoat-icon-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-icon-grammar`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-grammar-v0.5.0...topcoat-icon-grammar-v0.6.0) - 2026-08-17

### Other

- sort imports
</blockquote>

## `topcoat-icon-macro`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-icon-macro-v0.1.3...topcoat-icon-macro-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-mail`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-v0.6.2...topcoat-mail-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-mail-grammar`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-grammar-v0.6.2...topcoat-mail-grammar-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-mail-macro`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-mail-macro-v0.6.2...topcoat-mail-macro-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
</blockquote>

## `topcoat-router-grammar`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-grammar-v0.6.2...topcoat-router-grammar-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-router-macro`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-router-macro-v0.6.2...topcoat-router-macro-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
</blockquote>

## `topcoat-runtime`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-v0.6.2...topcoat-runtime-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))

### Fixed

- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
</blockquote>

## `topcoat-runtime-grammar`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-grammar-v0.6.2...topcoat-runtime-grammar-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))

### Fixed

- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
</blockquote>

## `topcoat-runtime-macro`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-runtime-macro-v0.6.2...topcoat-runtime-macro-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))

### Fixed

- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))
</blockquote>

## `topcoat-session`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-session-v0.5.0...topcoat-session-v0.6.0) - 2026-08-17

### Added

- *(core)* [**breaking**] add scoped context using `cx.with(...)` ([#338](https://github.com/tokio-rs/topcoat/pull/338))
- *(core)* [**breaking**] make Cx detachable, remove CxBuilder ([#322](https://github.com/tokio-rs/topcoat/pull/322))
- *(router)* [**breaking**] global origin policy ([#276](https://github.com/tokio-rs/topcoat/pull/276))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(router)* [**breaking**] replace handler structs with traits in preparation for href ([#346](https://github.com/tokio-rs/topcoat/pull/346))
- sort imports
- make request and response dedicated modules
</blockquote>

## `topcoat-tailwind`

<blockquote>

## [0.2.0](https://github.com/tokio-rs/topcoat/compare/topcoat-tailwind-v0.1.3...topcoat-tailwind-v0.2.0) - 2026-07-19

### Other

- add annotations to show feature flags in docs.rs ([#127](https://github.com/tokio-rs/topcoat/pull/127))
</blockquote>

## `topcoat-ui-registry`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-registry-v0.6.2...topcoat-ui-registry-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(ui)* slightly adapt topcoat-ui default colors ([#379](https://github.com/tokio-rs/topcoat/pull/379))
- *(ui)* switch from feather icons to lucide in topcoat-ui ([#378](https://github.com/tokio-rs/topcoat/pull/378))
- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
</blockquote>

## `topcoat`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/v0.6.2...v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(cli)* port retry on dev server init ([#364](https://github.com/tokio-rs/topcoat/pull/364))
- *(cli)* expose run method on `TopcoatCli` ([#363](https://github.com/tokio-rs/topcoat/pull/363))
- *(core)* add pretty printing impls for all `syn` types, remove `prettyplease` ([#372](https://github.com/tokio-rs/topcoat/pull/372))
- *(router)* implement `HrefTarget` for `&T: HrefTarget` to support dyn ([#370](https://github.com/tokio-rs/topcoat/pull/370))
- *(router)* is_current methods for Href, routes, and pages ([#362](https://github.com/tokio-rs/topcoat/pull/362))
- *(ui)* slightly adapt topcoat-ui default colors ([#379](https://github.com/tokio-rs/topcoat/pull/379))
- *(ui)* switch from feather icons to lucide in topcoat-ui ([#378](https://github.com/tokio-rs/topcoat/pull/378))

### Fixed

- *(cli)* don't reload over in-flight navigations on reconnect ([#365](https://github.com/tokio-rs/topcoat/pull/365))
- *(core)* memoize + borrowed async arg fails with AsyncFnOnce lifetime error ([#371](https://github.com/tokio-rs/topcoat/pull/371))
- *(runtime)* preserve boolean procedure results ([#375](https://github.com/tokio-rs/topcoat/pull/375))

### Other

- upgrade to rust 1.98 ([#367](https://github.com/tokio-rs/topcoat/pull/367))
- *(view)* remove `itoa` dependency in favor of `format_into` ([#366](https://github.com/tokio-rs/topcoat/pull/366))
</blockquote>

## `topcoat-ui`

<blockquote>

## [0.6.0](https://github.com/tokio-rs/topcoat/compare/topcoat-ui-v0.5.0...topcoat-ui-v0.6.0) - 2026-08-17

### Added

- *(ui)* add 17 new topcoat-ui components ([#341](https://github.com/tokio-rs/topcoat/pull/341))
- use #[track_caller] where appropriate ([#262](https://github.com/tokio-rs/topcoat/pull/262))

### Other

- *(view)* add promoted str optimization to avoid allocations ([#330](https://github.com/tokio-rs/topcoat/pull/330))
- sort imports
</blockquote>

## `topcoat-cli`

<blockquote>

## [0.7.0](https://github.com/tokio-rs/topcoat/compare/topcoat-cli-v0.6.2...topcoat-cli-v0.7.0) - 2026-09-04

### Added

- [**breaking**] streaming SSR and `live!` + `emit!` regions ([#373](https://github.com/tokio-rs/topcoat/pull/373))
- *(cli)* port retry on dev server init ([#364](https://github.com/tokio-rs/topcoat/pull/364))
- *(cli)* expose run method on `TopcoatCli` ([#363](https://github.com/tokio-rs/topcoat/pull/363))

### Fixed

- *(cli)* don't reload over in-flight navigations on reconnect ([#365](https://github.com/tokio-rs/topcoat/pull/365))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).