### PR TITLE
feat(cli): port retry on dev server init

### DIFF
--- a/crates/topcoat-cli/src/dev.rs
+++ b/crates/topcoat-cli/src/dev.rs
@@ -1,14 +1,13 @@
 //! The `topcoat dev` command: an auto-rebuilding development server.
 //!
-//! Five pieces cooperate, tied together by the event loop in
+//! Six pieces cooperate, tied together by the event loop in
 //! [`DevCommand::run`]:
 //!
 //! - [`broadcast_server`]: a long-lived local WebSocket server that browsers connect to; it
 //!   broadcasts a reload message whenever a freshly started application reports ready.
 //! - [`watch`]: watches every local package -- workspace members and path dependencies alike -- and
 //!   coalesces bursts of filesystem events into single change notifications.
-//! - [`keyboard`]: reports the `r` keypress that triggers a manual rebuild, and owns the terminal
-//!   for [`port`]'s prompt.
+//! - [`keyboard`]: reports the `r` keypress that triggers a manual rebuild.
 //! - [`build`]: compiles the application and bundles its assets in a cancellable background task.
 //! - [`app_server`]: the application process itself.
 //! - [`port`]: resolves the host and port the application will bind before each start.
@@ -134,7 +133,7 @@ impl DevCommand {
                             if let Some(old) = server.take() {
                                 old.shutdown().await;
                             }
-                            server = start_app(&exe, &dev_url, &events, &mut keyboard).await;
+                            server = start_app(&exe, &dev_url, &events);
                         }
                     } else {
                         // The failure is already on the terminal; keep the
@@ -191,13 +190,8 @@ async fn rebuild(build: &mut Option<BuildTask>, opts: &BuildOpts, events: &Event
 
 /// Start the built executable, reporting a failure to the terminal and to
 /// connected browsers.
-async fn start_app(
-    exe: &Path,
-    dev_url: &str,
-    events: &EventBus,
-    keyboard: &mut Keyboard,
-) -> Option<AppServer> {
-    let Some(address) = port::resolve(keyboard).await else {
+fn start_app(exe: &Path, dev_url: &str, events: &EventBus) -> Option<AppServer> {
+    let Some(address) = port::resolve() else {
         events.publish(Event::AppExited);
         eprintln!(
             "  {}",

--- a/crates/topcoat-cli/src/dev.rs
+++ b/crates/topcoat-cli/src/dev.rs
@@ -7,9 +7,11 @@
 //!   broadcasts a reload message whenever a freshly started application reports ready.
 //! - [`watch`]: watches every local package -- workspace members and path dependencies alike -- and
 //!   coalesces bursts of filesystem events into single change notifications.
-//! - [`keyboard`]: reports the `r` keypress that triggers a manual rebuild.
+//! - [`keyboard`]: reports the `r` keypress that triggers a manual rebuild, and owns the terminal
+//!   for [`port`]'s prompt.
 //! - [`build`]: compiles the application and bundles its assets in a cancellable background task.
 //! - [`app_server`]: the application process itself.
+//! - [`port`]: resolves the host and port the application will bind before each start.
 //!
 //! The loop's core policy is that the running application is only ever
 //! replaced by a *successful* build: while a rebuild is in flight, and after
@@ -21,6 +23,7 @@ mod app_server;
 mod broadcast_server;
 mod build;
 mod keyboard;
+mod port;
 mod spinner;
 mod watch;
 
@@ -131,7 +134,7 @@ impl DevCommand {
                             if let Some(old) = server.take() {
                                 old.shutdown().await;
                             }
-                            server = start_app(&exe, &dev_url, &events);
+                            server = start_app(&exe, &dev_url, &events, &mut keyboard).await;
                         }
                     } else {
                         // The failure is already on the terminal; keep the
@@ -188,8 +191,26 @@ async fn rebuild(build: &mut Option<BuildTask>, opts: &BuildOpts, events: &Event
 
 /// Start the built executable, reporting a failure to the terminal and to
 /// connected browsers.
-fn start_app(exe: &Path, dev_url: &str, events: &EventBus) -> Option<AppServer> {
-    match AppServer::spawn(exe, dev_url) {
+async fn start_app(
+    exe: &Path,
+    dev_url: &str,
+    events: &EventBus,
+    keyboard: &mut Keyboard,
+) -> Option<AppServer> {
+    let Some(address) = port::resolve(keyboard).await else {
+        events.publish(Event::AppExited);
+        eprintln!(
+            "  {}",
+            style("failed to start application: no port available")
+                .red()
+                .bold()
+        );
+        eprintln!();
+        report_waiting(false);
+        return None;
+    };
+
+    match AppServer::spawn(exe, dev_url, &address) {
         Ok(server) => Some(server),
         Err(error) => {
             events.publish(Event::AppExited);

--- a/crates/topcoat-cli/src/dev/app_server.rs
+++ b/crates/topcoat-cli/src/dev/app_server.rs
@@ -6,6 +6,8 @@ use std::{
 
 use tokio::process::{Child, Command};
 
+use super::port::Address;
+
 /// A running instance of the application under development.
 ///
 /// The process inherits the terminal's stdio and receives the broadcast
@@ -22,10 +24,12 @@ impl AppServer {
     /// run instead: a running process locks its image file, so launching the
     /// original would make every subsequent rebuild fail at the link step
     /// ("Access is denied") while the server keeps serving.
-    pub fn spawn(exe: &Path, dev_url: &str) -> io::Result<Self> {
+    pub fn spawn(exe: &Path, dev_url: &str, address: &Address) -> io::Result<Self> {
         let exe = shadow_copy_for_windows(exe)?;
         let child = Command::new(exe)
             .env("TOPCOAT_DEV_URL", dev_url)
+            .env("HOST", &address.host)
+            .env("PORT", address.port.to_string())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .stdin(Stdio::inherit())

--- a/crates/topcoat-cli/src/dev/keyboard.rs
+++ b/crates/topcoat-cli/src/dev/keyboard.rs
@@ -1,17 +1,17 @@
 use std::{future::pending, thread};
 
-use console::{Key, Term, style};
+use console::{Key, Term};
 use tokio::sync::mpsc;
 
-/// Owns the dev server's terminal input.
+/// Listens for the manual reload key on the terminal.
 ///
-/// Reads every keypress on a single background thread, so nothing else ever
-/// contends with it for stdin, and dispatches keys to whichever listener is
-/// currently interested: the manual-reload shortcut, or an in-flight
-/// [`confirm`](Self::confirm) prompt.
+/// Reads single keys from stdin on a background thread and reports each press
+/// of `r`, the manual reload shortcut. Active only when attached to an
+/// interactive terminal; otherwise [`Self::reload_requested`] never resolves,
+/// leaving the event loop driven entirely by file changes.
 pub struct Keyboard {
     /// `None` when there is no terminal to read keys from.
-    keys: Option<mpsc::UnboundedReceiver<Key>>,
+    presses: Option<mpsc::UnboundedReceiver<()>>,
 }
 
 impl Keyboard {
@@ -19,29 +19,31 @@ impl Keyboard {
     pub fn start() -> Self {
         let term = Term::stdout();
         if !term.is_term() {
-            return Self { keys: None };
+            return Self { presses: None };
         }
 
-        let (tx, keys) = mpsc::unbounded_channel();
+        let (tx, presses) = mpsc::unbounded_channel();
         // A detached thread: `read_key` blocks, so it cannot run on the async
         // runtime, and the process exits without waiting for it on shutdown.
         thread::spawn(move || {
             // `read_key` re-raises SIGINT on Ctrl-C, so the dev server's
             // Ctrl-C handler still shuts everything down.
             while let Ok(key) = term.read_key() {
-                if tx.send(key).is_err() {
+                if matches!(key, Key::Char('r' | 'R')) && tx.send(()).is_err() {
                     break;
                 }
             }
         });
 
-        Self { keys: Some(keys) }
+        Self {
+            presses: Some(presses),
+        }
     }
 
     /// Whether keypresses are being listened for, and so the shortcut is worth
     /// announcing.
     pub fn is_listening(&self) -> bool {
-        self.keys.is_some()
+        self.presses.is_some()
     }
 
     /// Wait until the manual reload key (`r`) is pressed.
@@ -53,44 +55,12 @@ impl Keyboard {
     /// Cancel-safe: a press arriving before cancellation is queued by the
     /// reader thread and reported by the next call.
     pub async fn reload_requested(&mut self) {
-        loop {
-            let key = match &mut self.keys {
-                Some(keys) => keys.recv().await,
-                None => None,
-            };
-            match key {
-                Some(Key::Char('r' | 'R')) => return,
-                Some(_) => {}
-                None => return pending::<()>().await,
-            }
+        let press = match &mut self.presses {
+            Some(presses) => presses.recv().await,
+            None => None,
+        };
+        if press.is_none() {
+            pending::<()>().await;
         }
-    }
-
-    /// Print `prompt` and wait for a yes/no answer: `y`/`Y`/Enter is yes,
-    /// `n`/`N` is no, and any other key is ignored.
-    pub async fn confirm(&mut self, prompt: &str) -> bool {
-        let Some(keys) = &mut self.keys else {
-            return true;
-        };
-
-        eprint!("{prompt}");
-
-        let answer = loop {
-            match keys.recv().await {
-                Some(Key::Enter | Key::Char('y' | 'Y')) => break true,
-                Some(Key::Char('n' | 'N')) | None => break false,
-                Some(_) => {}
-            }
-        };
-
-        let echo = if answer {
-            style("y").for_stderr().green().bold()
-        } else {
-            style("n").for_stderr().red().bold()
-        };
-        eprintln!("{echo}");
-        eprintln!();
-
-        answer
     }
 }

--- a/crates/topcoat-cli/src/dev/keyboard.rs
+++ b/crates/topcoat-cli/src/dev/keyboard.rs
@@ -1,17 +1,17 @@
 use std::{future::pending, thread};
 
-use console::{Key, Term};
+use console::{Key, Term, style};
 use tokio::sync::mpsc;
 
-/// Listens for the manual reload key on the terminal.
+/// Owns the dev server's terminal input.
 ///
-/// Reads single keys from stdin on a background thread and reports each press
-/// of `r`, the manual reload shortcut. Active only when attached to an
-/// interactive terminal; otherwise [`Self::reload_requested`] never resolves,
-/// leaving the event loop driven entirely by file changes.
+/// Reads every keypress on a single background thread, so nothing else ever
+/// contends with it for stdin, and dispatches keys to whichever listener is
+/// currently interested: the manual-reload shortcut, or an in-flight
+/// [`confirm`](Self::confirm) prompt.
 pub struct Keyboard {
     /// `None` when there is no terminal to read keys from.
-    presses: Option<mpsc::UnboundedReceiver<()>>,
+    keys: Option<mpsc::UnboundedReceiver<Key>>,
 }
 
 impl Keyboard {
@@ -19,31 +19,29 @@ impl Keyboard {
     pub fn start() -> Self {
         let term = Term::stdout();
         if !term.is_term() {
-            return Self { presses: None };
+            return Self { keys: None };
         }
 
-        let (tx, presses) = mpsc::unbounded_channel();
+        let (tx, keys) = mpsc::unbounded_channel();
         // A detached thread: `read_key` blocks, so it cannot run on the async
         // runtime, and the process exits without waiting for it on shutdown.
         thread::spawn(move || {
             // `read_key` re-raises SIGINT on Ctrl-C, so the dev server's
             // Ctrl-C handler still shuts everything down.
             while let Ok(key) = term.read_key() {
-                if matches!(key, Key::Char('r' | 'R')) && tx.send(()).is_err() {
+                if tx.send(key).is_err() {
                     break;
                 }
             }
         });
 
-        Self {
-            presses: Some(presses),
-        }
+        Self { keys: Some(keys) }
     }
 
     /// Whether keypresses are being listened for, and so the shortcut is worth
     /// announcing.
     pub fn is_listening(&self) -> bool {
-        self.presses.is_some()
+        self.keys.is_some()
     }
 
     /// Wait until the manual reload key (`r`) is pressed.
@@ -55,12 +53,44 @@ impl Keyboard {
     /// Cancel-safe: a press arriving before cancellation is queued by the
     /// reader thread and reported by the next call.
     pub async fn reload_requested(&mut self) {
-        let press = match &mut self.presses {
-            Some(presses) => presses.recv().await,
-            None => None,
-        };
-        if press.is_none() {
-            pending::<()>().await;
+        loop {
+            let key = match &mut self.keys {
+                Some(keys) => keys.recv().await,
+                None => None,
+            };
+            match key {
+                Some(Key::Char('r' | 'R')) => return,
+                Some(_) => {}
+                None => return pending::<()>().await,
+            }
         }
+    }
+
+    /// Print `prompt` and wait for a yes/no answer: `y`/`Y`/Enter is yes,
+    /// `n`/`N` is no, and any other key is ignored.
+    pub async fn confirm(&mut self, prompt: &str) -> bool {
+        let Some(keys) = &mut self.keys else {
+            return true;
+        };
+
+        eprint!("{prompt}");
+
+        let answer = loop {
+            match keys.recv().await {
+                Some(Key::Enter | Key::Char('y' | 'Y')) => break true,
+                Some(Key::Char('n' | 'N')) | None => break false,
+                Some(_) => {}
+            }
+        };
+
+        let echo = if answer {
+            style("y").for_stderr().green().bold()
+        } else {
+            style("n").for_stderr().red().bold()
+        };
+        eprintln!("{echo}");
+        eprintln!();
+
+        answer
     }
 }

--- a/crates/topcoat-cli/src/dev/port.rs
+++ b/crates/topcoat-cli/src/dev/port.rs
@@ -2,8 +2,6 @@ use std::{env, io, net::TcpListener};
 
 use console::style;
 
-use super::keyboard::Keyboard;
-
 /// Mirrors the defaults `topcoat::serve::start` applies when `HOST`/`PORT`
 /// are unset.
 const DEFAULT_HOST: &str = "127.0.0.1";
@@ -28,8 +26,12 @@ impl Address {
 }
 
 /// Find a host and port for the application to bind, starting from
-/// `HOST`/`PORT`.
-pub async fn resolve(keyboard: &mut Keyboard) -> Option<Address> {
+/// `HOST`/`PORT` and walking up from an occupied port to the first free one.
+/// Picking a different port than the configured one is reported on the
+/// terminal.
+///
+/// Returns `None` when every port from the configured one upward is occupied.
+pub fn resolve() -> Option<Address> {
     let mut address = Address::from_env();
     let original_port = address.port;
 
@@ -39,28 +41,22 @@ pub async fn resolve(keyboard: &mut Keyboard) -> Option<Address> {
             Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
                 address.port = address.port.checked_add(1)?;
             }
+            // Any other error (an unresolvable host, a privileged port) is
+            // left for the application to run into and report itself.
             Err(_) => break,
         }
     }
 
-    if address.port == original_port {
-        return Some(address);
-    }
-
-    let question = style(format!(
-        "  Port {original_port} is already in use. Use port {} instead? [",
-        address.port
-    ))
-    .for_stderr()
-    .dim();
-    let yes = style("Y").for_stderr().green().bold();
-    let slash = style("/").for_stderr().dim();
-    let no = style("n").for_stderr().red().bold();
-    let suffix = style("] ").for_stderr().dim();
-    let message = format!("{question}{yes}{slash}{no}{suffix}");
-
-    if !keyboard.confirm(&message).await {
-        return None;
+    if address.port != original_port {
+        eprintln!(
+            "  {}",
+            style(format!(
+                "port {original_port} is in use; starting on port {} instead",
+                address.port
+            ))
+            .yellow()
+        );
+        eprintln!();
     }
 
     Some(address)

--- a/crates/topcoat-cli/src/dev/port.rs
+++ b/crates/topcoat-cli/src/dev/port.rs
@@ -1,0 +1,67 @@
+use std::{env, io, net::TcpListener};
+
+use console::style;
+
+use super::keyboard::Keyboard;
+
+/// Mirrors the defaults `topcoat::serve::start` applies when `HOST`/`PORT`
+/// are unset.
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 3000;
+
+/// The host and port the application should bind.
+pub(crate) struct Address {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Address {
+    fn from_env() -> Self {
+        Self {
+            host: env::var("HOST").unwrap_or_else(|_| DEFAULT_HOST.to_owned()),
+            port: env::var("PORT")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(DEFAULT_PORT),
+        }
+    }
+}
+
+/// Find a host and port for the application to bind, starting from
+/// `HOST`/`PORT`.
+pub async fn resolve(keyboard: &mut Keyboard) -> Option<Address> {
+    let mut address = Address::from_env();
+    let original_port = address.port;
+
+    loop {
+        match TcpListener::bind((address.host.as_str(), address.port)) {
+            Ok(_listener) => break,
+            Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
+                address.port = address.port.checked_add(1)?;
+            }
+            Err(_) => break,
+        }
+    }
+
+    if address.port == original_port {
+        return Some(address);
+    }
+
+    let question = style(format!(
+        "  Port {original_port} is already in use. Use port {} instead? [",
+        address.port
+    ))
+    .for_stderr()
+    .dim();
+    let yes = style("Y").for_stderr().green().bold();
+    let slash = style("/").for_stderr().dim();
+    let no = style("n").for_stderr().red().bold();
+    let suffix = style("] ").for_stderr().dim();
+    let message = format!("{question}{yes}{slash}{no}{suffix}");
+
+    if !keyboard.confirm(&message).await {
+        return None;
+    }
+
+    Some(address)
+}


### PR DESCRIPTION
When using the CLI, I kept running into the problem where the port was occupied. Most CLIs ask you to try another port if this happens, but as it is now `topcoat dev` crashes. I made it so it selects the first port. :) Open to feedback on styling here, and I also get if this needs to be thrown out because the whole CLI will be rewritten soon.

<img width="450" height="142" alt="Screenshot 2026-08-20 at 7 50 14 PM" src="https://github.com/user-attachments/assets/aa0aca31-2720-4d96-afb3-b6e4fb26f87c" />

