### PR TITLE
fix(cli): don't reload over in-flight navigations on reconnect

### DIFF
--- a/crates/topcoat-cli/src/dev/dev.js
+++ b/crates/topcoat-cli/src/dev/dev.js
@@ -203,10 +203,25 @@
     ws.onclose = reconnect;
   }
 
+  // The browser also closes the WebSocket when the page navigates away - at
+  // navigation start in Firefox, at commit in Chrome. Reloading then would
+  // cancel the in-flight navigation, so probing is deferred while one is
+  // pending; navigateerror resumes it when a navigation fails and the page
+  // lives on.
+  let navigating = false;
+  window.navigation?.addEventListener("navigate", () => (navigating = true));
+  window.navigation?.addEventListener(
+    "navigateerror",
+    () => (navigating = false)
+  );
+  // A page restored from the back/forward cache is no longer navigating.
+  window.addEventListener("pageshow", () => (navigating = false));
+
   // Probe until the dev server is back, then reload to pick up whatever it
   // now serves.
   function reconnect() {
     setTimeout(() => {
+      if (navigating) return reconnect();
       const probe = new WebSocket(wsUrl);
       probe.onopen = () => {
         probe.close();


### PR DESCRIPTION
The browser closes the page's dev WebSocket during navigation - at navigation start in Firefox, at commit in Chrome. reconnect() treated any close as the dev server going away and reloaded as soon as a probe connected, which always succeeds because the broadcast server outlives app rebuilds. Firing ~500ms into a still-pending navigation, that reload cancelled it and snapped the browser back to the old URL.

Track pending navigations via the Navigation API and defer probing while one is in flight; navigateerror resumes probing when a navigation fails and the page survives, and pageshow resets the flag for pages restored from the back/forward cache.

Reproduction / verification repo (swap flake input to fix branch): https://github.com/ankarhem/topcoat-ws-unload

Assisted by: glm-5.3

Closes #331 