### PR TITLE
feat(router): implement `HrefTarget` for `&T: HrefTarget` to support dyn

### DIFF
--- a/crates/topcoat-router/src/href.rs
+++ b/crates/topcoat-router/src/href.rs
@@ -38,6 +38,15 @@ impl HrefTarget for &'static str {
     }
 }
 
+impl<T> HrefTarget for &T
+where
+    T: HrefTarget + ?Sized,
+{
+    fn path<'cx>(&self, cx: &'cx Cx) -> &'cx Path {
+        (*self).path(cx)
+    }
+}
+
 /// A value for one path parameter, named after the parameter it fills.
 ///
 /// The `path_param!` macro implements this trait for the types it declares.


### PR DESCRIPTION
`HrefTarget` is now implemented for `&T`where `T: HrefTarget`, which means that `&dyn Route` is also an `HrefTarget`. This means a type erased route can be stored in an array or passed as a parameter and still be used in `href!(...)`:

```rust
const NAV_LINKS: &[(&str, &dyn HrefTarget)] = &[
    ("Contacts", &contacts::index::page),
    ("History", &history::index::page),
];

// rendered using:
#[component]
pub async fn menu(cx: &Cx) -> Result {
    view! {
        for (label, target) in NAV_LINKS {
            let href = href!(target);
            let current = href.is_current(cx);
            <a
                href=(href)
                aria-current=(current.then_some("page"))
            >
                (label)
            </a>
        }
    }
}
```

```rust
#[component]
pub async fn nav_link(cx: &Cx, label: &'static str, route: &dyn HrefTarget) -> Result {
    let href = href!(route);
    let current = href.is_current(cx);
    view! {
        <a
            href=(href)
            aria-current=(current.then_some("page"))
        >
            (label)
        </a>
    }
}

// call with
nav_link(label: "home", route: &home)
```