### PR TITLE
docs(ui): revise `ui` example to avoid misleading showcases

### DIFF
--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -343,23 +343,24 @@ async fn home(cx: &Cx) -> Result {
                     </header>
 
                     // A masonry of small, self-contained demos, each built
-                    // from the installed components.
+                    // from the installed components. They run from the plainest
+                    // components to the ones assembled out of them.
                     <div class="mt-14 columns-1 gap-4 sm:columns-2 xl:columns-3">
-                        demo(overlays_card(state: &state))
-                        demo(team_card())
                         demo(buttons_card())
                         demo(notices())
-                        demo(create_card())
-                        demo(overview_card(state: &state))
+                        demo(team_card())
                         demo(status_card())
+                        demo(create_card())
+                        demo(notifications_card())
+                        demo(plan_card())
+                        demo(overlays_card(state: &state))
+                        demo(overview_card(state: &state))
+                        demo(faq_card())
+                        demo(branches_card(state: &state))
+                        demo(toolbar_card())
+                        demo(share_card())
                         demo(settings_card(state: &state))
                         demo(deployments_card(state: &state))
-                        demo(notifications_card())
-                        demo(branches_card(state: &state))
-                        demo(plan_card())
-                        demo(faq_card())
-                        demo(share_card())
-                        demo(toolbar_card())
                         demo(docs_card())
                         demo(pending_card())
                         demo(deploy_card())
@@ -419,40 +420,84 @@ async fn state_fields(state: &State, sets: &str) -> Result {
     }
 }
 
-/// The overlays gathered in one place, so each is one click from the top of
-/// the page.
-///
-/// A trigger is a plain link to this page with the overlay named in its query
-/// string, which is all it takes to open one: the same overlays are opened
-/// from the cards they belong to further down.
+/// The button family: variants, sizes, and states at a glance.
 #[component]
-async fn overlays_card(state: &State) -> Result {
+async fn buttons_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Overlays")
-                card_description(
-                    "The URL is what holds one open, so it survives a reload \
-                     and can be linked to."
-                )
+                card_title("Buttons")
+                card_description("Every variant, size, and state.")
             )
             card_content(
-                <div class="flex flex-wrap gap-2">
-                    for (overlay, name) in OVERLAYS {
-                        <a
-                            href=(state.href("overlay", Some(overlay)))
-                            class=(button_variants(
-                                ButtonVariant::Outline,
-                                ButtonSize::Sm,
-                            ))
-                        >
-                            "Open "
-                            (name.to_lowercase())
-                        </a>
-                    }
+                <div class="flex flex-col gap-3">
+                    <div class="flex flex-wrap items-center gap-2">
+                        for (variant, name) in [
+                            (ButtonVariant::Primary, "Primary"),
+                            (ButtonVariant::Secondary, "Secondary"),
+                            (ButtonVariant::Outline, "Outline"),
+                            (ButtonVariant::Ghost, "Ghost"),
+                            (ButtonVariant::Destructive, "Destructive"),
+                        ] {
+                            button(size: ButtonSize::Sm, variant: variant, (name))
+                        }
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        button(size: ButtonSize::Sm, "Small")
+                        button(size: ButtonSize::Md, "Medium")
+                        button(size: ButtonSize::Lg, "Large")
+                        button(
+                            size: ButtonSize::Icon,
+                            variant: ButtonVariant::Outline,
+                            icon(data: iconify_icon!("feather:plus"), label: "Add item")
+                        )
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        button(
+                            variant: ButtonVariant::Outline,
+                            attrs: attributes! { disabled="" },
+                            "Disabled"
+                        )
+                        button(
+                            attrs: attributes! { disabled="" },
+                            spinner()
+                            "Saving..."
+                        )
+                    </div>
                 </div>
             )
         )
+    }
+}
+
+/// Notices standing on their own: an alert is a surface already, so it needs
+/// no card under it.
+#[component]
+async fn notices() -> Result {
+    view! {
+        <div class="flex flex-col gap-3">
+            // The leading icon is an ordinary child: the alert lays out a
+            // column for it only when one is there.
+            alert(
+                icon(data: iconify_icon!("feather:info"))
+                alert_title("Scheduled maintenance")
+                alert_description(
+                    "The dashboard is read-only on Sunday, 02:00 to 04:00 UTC."
+                )
+            )
+            alert(
+                variant: AlertVariant::Destructive,
+                icon(data: iconify_icon!("feather:alert-triangle"))
+                alert_title("Build failed")
+                alert_description(
+                    "The preview build could not resolve its dependencies."
+                )
+            )
+            alert(
+                alert_title("No deployments yet")
+                alert_description("Push to a branch to see it build here.")
+            )
+        </div>
     }
 }
 
@@ -540,84 +585,52 @@ async fn team_card() -> Result {
     }
 }
 
-/// The button family: variants, sizes, and states at a glance.
+/// Environment statuses told through the badge variants, and a rollout told
+/// through the progress bar.
 #[component]
-async fn buttons_card() -> Result {
+async fn status_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Buttons")
-                card_description("Every variant, size, and state.")
+                card_title("Deployment status")
+                card_description("How the last builds ended up.")
             )
             card_content(
                 <div class="flex flex-col gap-3">
-                    <div class="flex flex-wrap items-center gap-2">
-                        for (variant, name) in [
-                            (ButtonVariant::Primary, "Primary"),
-                            (ButtonVariant::Secondary, "Secondary"),
-                            (ButtonVariant::Outline, "Outline"),
-                            (ButtonVariant::Ghost, "Ghost"),
-                            (ButtonVariant::Destructive, "Destructive"),
-                        ] {
-                            button(size: ButtonSize::Sm, variant: variant, (name))
-                        }
+                    for (status, variant) in STATUSES {
+                        let count = DEPLOYMENTS
+                            .iter()
+                            .filter(|(_, _, value)| *value == status)
+                            .count();
+
+                        <div class="flex items-center justify-between gap-4">
+                            badge(variant: variant, (status))
+                            <p class="text-sm text-muted-foreground">
+                                (format!("{count} deployments"))
+                            </p>
+                        </div>
+                    }
+                </div>
+                separator(attrs: attributes! { class="my-4" })
+                <div class="flex flex-col gap-2">
+                    <div class="flex items-center justify-between gap-4">
+                        <p class="text-sm text-muted-foreground">
+                            "Rolling out to production"
+                        </p>
+                        <p class="text-sm font-medium">"62%"</p>
                     </div>
-                    <div class="flex flex-wrap items-center gap-2">
-                        button(size: ButtonSize::Sm, "Small")
-                        button(size: ButtonSize::Md, "Medium")
-                        button(size: ButtonSize::Lg, "Large")
-                        button(
-                            size: ButtonSize::Icon,
-                            variant: ButtonVariant::Outline,
-                            icon(data: iconify_icon!("feather:plus"), label: "Add item")
-                        )
-                    </div>
-                    <div class="flex flex-wrap items-center gap-2">
-                        button(
-                            variant: ButtonVariant::Outline,
-                            attrs: attributes! { disabled="" },
-                            "Disabled"
-                        )
-                        button(
-                            attrs: attributes! { disabled="" },
-                            spinner()
-                            "Saving..."
-                        )
-                    </div>
+                    progress(value: 62.0)
                 </div>
             )
+            card_footer(
+                <p class="text-sm text-muted-foreground">"Rolled out with"</p>
+                // Anything can borrow a badge's looks: `badge_variants`
+                // returns the class string for a variant.
+                <a href="#changelog" class=(badge_variants(BadgeVariant::Outline))>
+                    "v2.0.4"
+                </a>
+            )
         )
-    }
-}
-
-/// Notices standing on their own: an alert is a surface already, so it needs
-/// no card under it.
-#[component]
-async fn notices() -> Result {
-    view! {
-        <div class="flex flex-col gap-3">
-            // The leading icon is an ordinary child: the alert lays out a
-            // column for it only when one is there.
-            alert(
-                icon(data: iconify_icon!("feather:info"))
-                alert_title("Scheduled maintenance")
-                alert_description(
-                    "The dashboard is read-only on Sunday, 02:00 to 04:00 UTC."
-                )
-            )
-            alert(
-                variant: AlertVariant::Destructive,
-                icon(data: iconify_icon!("feather:alert-triangle"))
-                alert_title("Build failed")
-                alert_description(
-                    "The preview build could not resolve its dependencies."
-                )
-            )
-            alert(
-                alert_title("No deployments yet")
-                alert_description("Push to a branch to see it build here.")
-            )
-        </div>
     }
 }
 
@@ -687,6 +700,151 @@ async fn create_card() -> Result {
     }
 }
 
+/// Notification settings mixing checkboxes and switches through their states.
+#[component]
+async fn notifications_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Notifications")
+                card_description("Pick what lands in your inbox.")
+            )
+            card_content(
+                <div class="flex flex-col gap-3">
+                    <div class="flex items-center gap-2">
+                        checkbox(attrs: attributes! { id="notify-deploys" checked="" })
+                        label(
+                            attrs: attributes! { for="notify-deploys" },
+                            "Deploy results"
+                        )
+                    </div>
+                    <div class="flex items-center gap-2">
+                        checkbox(attrs: attributes! { id="notify-mentions" })
+                        label(attrs: attributes! { for="notify-mentions" }, "Mentions")
+                    </div>
+                    <div class="flex items-center gap-2">
+                        checkbox(
+                            attrs: attributes! { id="notify-digest" checked="" disabled="" }
+                        )
+                        label(
+                            attrs: attributes! { for="notify-digest" class="opacity-50" },
+                            "Weekly digest (managed by your org)"
+                        )
+                    </div>
+                </div>
+                separator(attrs: attributes! { class="my-4" })
+                <div class="flex flex-col gap-3">
+                    <div class="flex items-center justify-between gap-4">
+                        label(
+                            attrs: attributes! { for="notify-push" },
+                            "Push notifications"
+                        )
+                        switch(attrs: attributes! { id="notify-push" checked="" })
+                    </div>
+                    <div class="flex items-center justify-between gap-4">
+                        label(attrs: attributes! { for="notify-quiet" }, "Quiet hours")
+                        switch(attrs: attributes! { id="notify-quiet" })
+                    </div>
+                    <div class="flex items-center justify-between gap-4">
+                        label(
+                            attrs: attributes! { for="notify-sms" class="opacity-50" },
+                            "Text messages (not on this plan)"
+                        )
+                        switch(attrs: attributes! { id="notify-sms" disabled="" })
+                    </div>
+                </div>
+            )
+        )
+    }
+}
+
+/// The plans a workspace can run on: the value each goes by, its name, its
+/// price, and whether it can be picked here.
+const PLANS: [(&str, &str, &str, bool); 4] = [
+    ("starter", "Starter", "Free", true),
+    ("pro", "Pro", "$24 / month", true),
+    ("scale", "Scale", "$96 / month", true),
+    ("enterprise", "Enterprise", "Contact sales", false),
+];
+
+/// A plan picker, built on a radio group.
+#[component]
+async fn plan_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Billing plan")
+                card_description("Pick the plan this workspace runs on.")
+            )
+            card_content(
+                radio_group(
+                    // The name the options share is what has the browser let
+                    // go of one when another is picked.
+                    for (value, name, price, available) in PLANS {
+                        <div class="flex items-center gap-2">
+                            radio_group_item(
+                                attrs: attributes! {
+                                    id=(value)
+                                    name="plan"
+                                    value=(value)
+                                    checked=(value == "pro")
+                                    disabled=(!available)
+                                }
+                            )
+                            label(
+                                attrs: attributes! {
+                                    for=(value)
+                                    class=(class!("flex-1", "opacity-50" if !available))
+                                },
+                                (name)
+                            )
+                            <p class="text-sm text-muted-foreground">(price)</p>
+                        </div>
+                    }
+                )
+            )
+            card_footer(button(attrs: attributes! { class="w-full" }, "Upgrade"))
+        )
+    }
+}
+
+/// The overlays gathered in one place, so each can be opened without hunting
+/// for the card it belongs to.
+///
+/// A trigger is a plain link to this page with the overlay named in its query
+/// string, which is all it takes to open one: the same overlays are opened
+/// from the cards they belong to further down.
+#[component]
+async fn overlays_card(state: &State) -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Overlays")
+                card_description(
+                    "The URL is what holds one open, so it survives a reload \
+                     and can be linked to."
+                )
+            )
+            card_content(
+                <div class="flex flex-wrap gap-2">
+                    for (overlay, name) in OVERLAYS {
+                        <a
+                            href=(state.href("overlay", Some(overlay)))
+                            class=(button_variants(
+                                ButtonVariant::Outline,
+                                ButtonSize::Sm,
+                            ))
+                        >
+                            "Open "
+                            (name.to_lowercase())
+                        </a>
+                    }
+                </div>
+            )
+        )
+    }
+}
+
 /// A card that tabs between panels.
 ///
 /// Which panel shows is in the URL, so each trigger is a link and only the
@@ -727,50 +885,224 @@ async fn overview_card(state: &State) -> Result {
     }
 }
 
-/// Environment statuses told through the badge variants, and a rollout told
-/// through the progress bar.
+/// A FAQ whose answers fold away, one open at a time.
 #[component]
-async fn status_card() -> Result {
+async fn faq_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Deployment status")
-                card_description("How the last builds ended up.")
+                card_title("Questions")
+                card_description("The rest is in the docs.")
             )
             card_content(
-                <div class="flex flex-col gap-3">
-                    for (status, variant) in STATUSES {
-                        let count = DEPLOYMENTS
-                            .iter()
-                            .filter(|(_, _, value)| *value == status)
-                            .count();
-
-                        <div class="flex items-center justify-between gap-4">
-                            badge(variant: variant, (status))
-                            <p class="text-sm text-muted-foreground">
-                                (format!("{count} deployments"))
-                            </p>
-                        </div>
+                accordion(
+                    // The name the sections share is what closes the open one
+                    // when another is opened.
+                    for (question, answer, open) in [
+                        (
+                            "Where do the components live?",
+                            "In your own source tree, under the components \
+                             directory you picked.",
+                            true,
+                        ),
+                        (
+                            "Can I edit them?",
+                            "They are yours: restyle, rewrite, and extend them \
+                             like any other file.",
+                            false,
+                        ),
+                        (
+                            "How do updates work?",
+                            "`topcoat ui list` marks what the registry has \
+                             changed since you added it.",
+                            false,
+                        ),
+                    ] {
+                        accordion_item(
+                            attrs: attributes! { name="faq" open=(open) },
+                            accordion_trigger((question))
+                            accordion_content((answer))
+                        )
                     }
-                </div>
-                separator(attrs: attributes! { class="my-4" })
-                <div class="flex flex-col gap-2">
-                    <div class="flex items-center justify-between gap-4">
-                        <p class="text-sm text-muted-foreground">
-                            "Rolling out to production"
-                        </p>
-                        <p class="text-sm font-medium">"62%"</p>
+                )
+            )
+        )
+    }
+}
+
+/// A branch switcher: a menu whose items reach the server, since a menu item
+/// is a button and a form around it is all it takes.
+#[component]
+async fn branches_card(state: &State) -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Branches")
+                card_description("Switch the branch this preview builds from.")
+            )
+            card_content(
+                // The form carries the rest of the page's state along, and the
+                // item that was clicked adds the branch it stands for; the
+                // page comes back built from that branch.
+                <form>
+                    state_fields(state: state, sets: "branch")
+                    dropdown_menu(
+                        // The trigger takes any content; this one borrows the
+                        // outline button's looks and adds a flipping chevron.
+                        dropdown_menu_trigger(
+                            attrs: attributes! {
+                                class=(button_variants(
+                                    ButtonVariant::Outline,
+                                    ButtonSize::Sm,
+                                ))
+                            },
+                            (state.branch)
+                            icon(
+                                data: iconify_icon!("feather:chevron-down"),
+                                attrs: attributes! { class="transition-transform group-open:rotate-180" }
+                            )
+                        )
+                        dropdown_menu_content(
+                            dropdown_menu_label("Switch branch")
+                            for branch in BRANCHES {
+                                dropdown_menu_item(
+                                    attrs: attributes! { name="branch" value=(branch) },
+                                    (branch)
+                                )
+                            }
+                            dropdown_menu_separator()
+                            // A submenu opens its own panel beside this row.
+                            dropdown_menu_sub(
+                                dropdown_menu_sub_trigger("Checkout tag")
+                                dropdown_menu_sub_content(
+                                    for tag in TAGS {
+                                        dropdown_menu_item(
+                                            attrs: attributes! { name="branch" value=(tag) },
+                                            (tag)
+                                        )
+                                    }
+                                )
+                            )
+                        )
+                    )
+                </form>
+            )
+        )
+    }
+}
+
+/// A toolbar of toggles: a segmented control where picking one lets go of the
+/// rest, and toggles that press on their own.
+#[component]
+async fn toolbar_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Report")
+                card_description("The range it covers, and how it reads.")
+            )
+            card_content(
+                <div class="flex flex-col items-start gap-4">
+                    toggle_group(
+                        for (value, text, picked) in [
+                            ("day", "Day", false),
+                            ("week", "Week", true),
+                            ("month", "Month", false),
+                        ] {
+                            toggle(
+                                kind: ToggleKind::Exclusive,
+                                size: ToggleSize::Sm,
+                                attrs: attributes! { name="range" value=(value) checked=(picked) },
+                                (text)
+                            )
+                        }
+                    )
+                    <div class="flex items-center gap-1">
+                        for (name, data, text, pressed) in [
+                            ("bold", iconify_icon!("feather:bold"), "Bold", true),
+                            ("italic", iconify_icon!("feather:italic"), "Italic", false),
+                            (
+                                "underline",
+                                iconify_icon!("feather:underline"),
+                                "Underline",
+                                false,
+                            ),
+                        ] {
+                            toggle(
+                                attrs: attributes! { name=(name) checked=(pressed) },
+                                icon(data: data, label: text)
+                            )
+                        }
                     </div>
-                    progress(value: 62.0)
+                    toggle(
+                        size: ToggleSize::Lg,
+                        attrs: attributes! { name="live" checked="" },
+                        icon(data: iconify_icon!("feather:activity"))
+                        "Live updates"
+                    )
                 </div>
             )
-            card_footer(
-                <p class="text-sm text-muted-foreground">"Rolled out with"</p>
-                // Anything can borrow a badge's looks: `badge_variants`
-                // returns the class string for a variant.
-                <a href="#changelog" class=(badge_variants(BadgeVariant::Outline))>
-                    "v2.0.4"
-                </a>
+        )
+    }
+}
+
+/// A share sheet, and the two things that show on hover: a tooltip carrying a
+/// few words, and a hover card carrying a view.
+#[component]
+async fn share_card() -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Share this document")
+                card_description("Anyone with the link can view it.")
+            )
+            card_content(
+                <div class="flex items-center gap-2">
+                    label(attrs: attributes! { for="share" class="sr-only" }, "Link")
+                    input(
+                        attrs: attributes! {
+                            id="share"
+                            readonly=""
+                            value="https://topcoat.dev/d/quickstart"
+                        }
+                    )
+                    tooltip(
+                        button(
+                            size: ButtonSize::Icon,
+                            variant: ButtonVariant::Outline,
+                            attrs: attributes! { type="button" },
+                            icon(
+                                data: iconify_icon!("feather:copy"),
+                                label: "Copy link"
+                            )
+                        )
+                        tooltip_content("Copy link")
+                    )
+                </div>
+                <div class="mt-4 flex items-center gap-2 text-sm">
+                    <p class="text-muted-foreground">"Shared with"</p>
+                    hover_card(
+                        <a href="#ada" class="font-medium underline">"@ada"</a>
+                        hover_card_content(
+                            <div class="flex items-center gap-3">
+                                avatar(
+                                    size: AvatarSize::Md,
+                                    avatar_image(attrs: attributes! { src=(PORTRAIT) })
+                                    avatar_fallback("AL")
+                                )
+                                <div class="min-w-0">
+                                    <p class="truncate text-sm font-medium">"Ada Lovelace"</p>
+                                    <p class="truncate text-xs text-muted-foreground">
+                                        "Owner"
+                                    </p>
+                                </div>
+                            </div>
+                            <p class="text-xs text-muted-foreground">
+                                "Joined in 2024. Deploys on Fridays anyway."
+                            </p>
+                        )
+                    )
+                </div>
             )
         )
     }
@@ -952,337 +1284,6 @@ async fn deployments_card(state: &State) -> Result {
 /// time is what "Previous" and "Next" are already for.
 fn listed(number: usize, page: usize, pages: usize) -> bool {
     number == 1 || number == pages || number == page
-}
-
-/// Notification settings mixing checkboxes and switches through their states.
-#[component]
-async fn notifications_card() -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Notifications")
-                card_description("Pick what lands in your inbox.")
-            )
-            card_content(
-                <div class="flex flex-col gap-3">
-                    <div class="flex items-center gap-2">
-                        checkbox(attrs: attributes! { id="notify-deploys" checked="" })
-                        label(
-                            attrs: attributes! { for="notify-deploys" },
-                            "Deploy results"
-                        )
-                    </div>
-                    <div class="flex items-center gap-2">
-                        checkbox(attrs: attributes! { id="notify-mentions" })
-                        label(attrs: attributes! { for="notify-mentions" }, "Mentions")
-                    </div>
-                    <div class="flex items-center gap-2">
-                        checkbox(
-                            attrs: attributes! { id="notify-digest" checked="" disabled="" }
-                        )
-                        label(
-                            attrs: attributes! { for="notify-digest" class="opacity-50" },
-                            "Weekly digest (managed by your org)"
-                        )
-                    </div>
-                </div>
-                separator(attrs: attributes! { class="my-4" })
-                <div class="flex flex-col gap-3">
-                    <div class="flex items-center justify-between gap-4">
-                        label(
-                            attrs: attributes! { for="notify-push" },
-                            "Push notifications"
-                        )
-                        switch(attrs: attributes! { id="notify-push" checked="" })
-                    </div>
-                    <div class="flex items-center justify-between gap-4">
-                        label(attrs: attributes! { for="notify-quiet" }, "Quiet hours")
-                        switch(attrs: attributes! { id="notify-quiet" })
-                    </div>
-                    <div class="flex items-center justify-between gap-4">
-                        label(
-                            attrs: attributes! { for="notify-sms" class="opacity-50" },
-                            "Text messages (not on this plan)"
-                        )
-                        switch(attrs: attributes! { id="notify-sms" disabled="" })
-                    </div>
-                </div>
-            )
-        )
-    }
-}
-
-/// A branch switcher: a menu whose items reach the server, since a menu item
-/// is a button and a form around it is all it takes.
-#[component]
-async fn branches_card(state: &State) -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Branches")
-                card_description("Switch the branch this preview builds from.")
-            )
-            card_content(
-                // The form carries the rest of the page's state along, and the
-                // item that was clicked adds the branch it stands for; the
-                // page comes back built from that branch.
-                <form>
-                    state_fields(state: state, sets: "branch")
-                    dropdown_menu(
-                        // The trigger takes any content; this one borrows the
-                        // outline button's looks and adds a flipping chevron.
-                        dropdown_menu_trigger(
-                            attrs: attributes! {
-                                class=(button_variants(
-                                    ButtonVariant::Outline,
-                                    ButtonSize::Sm,
-                                ))
-                            },
-                            (state.branch)
-                            icon(
-                                data: iconify_icon!("feather:chevron-down"),
-                                attrs: attributes! { class="transition-transform group-open:rotate-180" }
-                            )
-                        )
-                        dropdown_menu_content(
-                            dropdown_menu_label("Switch branch")
-                            for branch in BRANCHES {
-                                dropdown_menu_item(
-                                    attrs: attributes! { name="branch" value=(branch) },
-                                    (branch)
-                                )
-                            }
-                            dropdown_menu_separator()
-                            // A submenu opens its own panel beside this row.
-                            dropdown_menu_sub(
-                                dropdown_menu_sub_trigger("Checkout tag")
-                                dropdown_menu_sub_content(
-                                    for tag in TAGS {
-                                        dropdown_menu_item(
-                                            attrs: attributes! { name="branch" value=(tag) },
-                                            (tag)
-                                        )
-                                    }
-                                )
-                            )
-                        )
-                    )
-                </form>
-            )
-        )
-    }
-}
-
-/// The plans a workspace can run on: the value each goes by, its name, its
-/// price, and whether it can be picked here.
-const PLANS: [(&str, &str, &str, bool); 4] = [
-    ("starter", "Starter", "Free", true),
-    ("pro", "Pro", "$24 / month", true),
-    ("scale", "Scale", "$96 / month", true),
-    ("enterprise", "Enterprise", "Contact sales", false),
-];
-
-/// A plan picker, built on a radio group.
-#[component]
-async fn plan_card() -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Billing plan")
-                card_description("Pick the plan this workspace runs on.")
-            )
-            card_content(
-                radio_group(
-                    // The name the options share is what has the browser let
-                    // go of one when another is picked.
-                    for (value, name, price, available) in PLANS {
-                        <div class="flex items-center gap-2">
-                            radio_group_item(
-                                attrs: attributes! {
-                                    id=(value)
-                                    name="plan"
-                                    value=(value)
-                                    checked=(value == "pro")
-                                    disabled=(!available)
-                                }
-                            )
-                            label(
-                                attrs: attributes! {
-                                    for=(value)
-                                    class=(class!("flex-1", "opacity-50" if !available))
-                                },
-                                (name)
-                            )
-                            <p class="text-sm text-muted-foreground">(price)</p>
-                        </div>
-                    }
-                )
-            )
-            card_footer(button(attrs: attributes! { class="w-full" }, "Upgrade"))
-        )
-    }
-}
-
-/// A FAQ whose answers fold away, one open at a time.
-#[component]
-async fn faq_card() -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Questions")
-                card_description("The rest is in the docs.")
-            )
-            card_content(
-                accordion(
-                    // The name the sections share is what closes the open one
-                    // when another is opened.
-                    for (question, answer, open) in [
-                        (
-                            "Where do the components live?",
-                            "In your own source tree, under the components \
-                             directory you picked.",
-                            true,
-                        ),
-                        (
-                            "Can I edit them?",
-                            "They are yours: restyle, rewrite, and extend them \
-                             like any other file.",
-                            false,
-                        ),
-                        (
-                            "How do updates work?",
-                            "`topcoat ui list` marks what the registry has \
-                             changed since you added it.",
-                            false,
-                        ),
-                    ] {
-                        accordion_item(
-                            attrs: attributes! { name="faq" open=(open) },
-                            accordion_trigger((question))
-                            accordion_content((answer))
-                        )
-                    }
-                )
-            )
-        )
-    }
-}
-
-/// A share sheet, and the two things that show on hover: a tooltip carrying a
-/// few words, and a hover card carrying a view.
-#[component]
-async fn share_card() -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Share this document")
-                card_description("Anyone with the link can view it.")
-            )
-            card_content(
-                <div class="flex items-center gap-2">
-                    label(attrs: attributes! { for="share" class="sr-only" }, "Link")
-                    input(
-                        attrs: attributes! {
-                            id="share"
-                            readonly=""
-                            value="https://topcoat.dev/d/quickstart"
-                        }
-                    )
-                    tooltip(
-                        button(
-                            size: ButtonSize::Icon,
-                            variant: ButtonVariant::Outline,
-                            attrs: attributes! { type="button" },
-                            icon(
-                                data: iconify_icon!("feather:copy"),
-                                label: "Copy link"
-                            )
-                        )
-                        tooltip_content("Copy link")
-                    )
-                </div>
-                <div class="mt-4 flex items-center gap-2 text-sm">
-                    <p class="text-muted-foreground">"Shared with"</p>
-                    hover_card(
-                        <a href="#ada" class="font-medium underline">"@ada"</a>
-                        hover_card_content(
-                            <div class="flex items-center gap-3">
-                                avatar(
-                                    size: AvatarSize::Md,
-                                    avatar_image(attrs: attributes! { src=(PORTRAIT) })
-                                    avatar_fallback("AL")
-                                )
-                                <div class="min-w-0">
-                                    <p class="truncate text-sm font-medium">"Ada Lovelace"</p>
-                                    <p class="truncate text-xs text-muted-foreground">
-                                        "Owner"
-                                    </p>
-                                </div>
-                            </div>
-                            <p class="text-xs text-muted-foreground">
-                                "Joined in 2024. Deploys on Fridays anyway."
-                            </p>
-                        )
-                    )
-                </div>
-            )
-        )
-    }
-}
-
-/// A toolbar of toggles: a segmented control where picking one lets go of the
-/// rest, and toggles that press on their own.
-#[component]
-async fn toolbar_card() -> Result {
-    view! {
-        card(
-            card_header(
-                card_title("Report")
-                card_description("The range it covers, and how it reads.")
-            )
-            card_content(
-                <div class="flex flex-col items-start gap-4">
-                    toggle_group(
-                        for (value, text, picked) in [
-                            ("day", "Day", false),
-                            ("week", "Week", true),
-                            ("month", "Month", false),
-                        ] {
-                            toggle(
-                                kind: ToggleKind::Exclusive,
-                                size: ToggleSize::Sm,
-                                attrs: attributes! { name="range" value=(value) checked=(picked) },
-                                (text)
-                            )
-                        }
-                    )
-                    <div class="flex items-center gap-1">
-                        for (name, data, text, pressed) in [
-                            ("bold", iconify_icon!("feather:bold"), "Bold", true),
-                            ("italic", iconify_icon!("feather:italic"), "Italic", false),
-                            (
-                                "underline",
-                                iconify_icon!("feather:underline"),
-                                "Underline",
-                                false,
-                            ),
-                        ] {
-                            toggle(
-                                attrs: attributes! { name=(name) checked=(pressed) },
-                                icon(data: data, label: text)
-                            )
-                        }
-                    </div>
-                    toggle(
-                        size: ToggleSize::Lg,
-                        attrs: attributes! { name="live" checked="" },
-                        icon(data: iconify_icon!("feather:activity"))
-                        "Live updates"
-                    )
-                </div>
-            )
-        )
-    }
 }
 
 /// The keys that move through a form, and what each one does. They are the

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -127,7 +127,7 @@ impl State {
             branch: one_of(branch, &BRANCHES)
                 .or(one_of(branch, &TAGS))
                 .unwrap_or(BRANCHES[0]),
-            overlay: one_of(query.overlay.as_deref(), &OVERLAYS),
+            overlay: one_of(query.overlay.as_deref(), &OVERLAYS.map(|(value, _)| value)),
             side: one_of(query.side.as_deref(), &SIDES.map(|(value, ..)| value))
                 .unwrap_or(SIDES[0].0),
         })
@@ -260,8 +260,13 @@ const BRANCHES: [&str; 3] = ["main", "feature/showcase", "feature/dark-mode"];
 /// The tags a preview can build from instead of a branch.
 const TAGS: [&str; 3] = ["v1.2.0", "v1.1.0", "v1.0.0"];
 
-/// The overlays that can cover the page, one at a time.
-const OVERLAYS: [&str; 3] = ["rename", "delete", "filters"];
+/// The overlays that can cover the page, one at a time: the value each goes
+/// by in the URL, and the word for it.
+const OVERLAYS: [(&str, &str); 3] = [
+    ("rename", "Dialog"),
+    ("delete", "Alert dialog"),
+    ("filters", "Sheet"),
+];
 
 /// The edges the sheet can come in from: the value each goes by in the URL,
 /// the word for it, and the side itself. The first is the one it comes from
@@ -340,6 +345,7 @@ async fn home(cx: &Cx) -> Result {
                     // A masonry of small, self-contained demos, each built
                     // from the installed components.
                     <div class="mt-14 columns-1 gap-4 sm:columns-2 xl:columns-3">
+                        demo(overlays_card(state: &state))
                         demo(team_card())
                         demo(buttons_card())
                         demo(notices())
@@ -410,6 +416,43 @@ async fn state_fields(state: &State, sets: &str) -> Result {
                 <input type="hidden" name=(key) value=(value)>
             }
         }
+    }
+}
+
+/// The overlays gathered in one place, so each is one click from the top of
+/// the page.
+///
+/// A trigger is a plain link to this page with the overlay named in its query
+/// string, which is all it takes to open one: the same overlays are opened
+/// from the cards they belong to further down.
+#[component]
+async fn overlays_card(state: &State) -> Result {
+    view! {
+        card(
+            card_header(
+                card_title("Overlays")
+                card_description(
+                    "The URL is what holds one open, so it survives a reload \
+                     and can be linked to."
+                )
+            )
+            card_content(
+                <div class="flex flex-wrap gap-2">
+                    for (overlay, name) in OVERLAYS {
+                        <a
+                            href=(state.href("overlay", Some(overlay)))
+                            class=(button_variants(
+                                ButtonVariant::Outline,
+                                ButtonSize::Sm,
+                            ))
+                        >
+                            "Open "
+                            (name.to_lowercase())
+                        </a>
+                    }
+                </div>
+            )
+        )
     }
 }
 
@@ -1242,7 +1285,15 @@ async fn toolbar_card() -> Result {
     }
 }
 
-/// A documentation page header: the trail to it, and the shortcuts it lists.
+/// The keys that move through a form, and what each one does. They are the
+/// browser's own, so they work on this page as they read here.
+const KEYS: [(&str, &[&str]); 3] = [
+    ("Move to the next control", &["Tab"]),
+    ("Move back to the one before", &["Shift", "Tab"]),
+    ("Submit the form", &["Enter"]),
+];
+
+/// A documentation page header: the trail to it, and the keys it documents.
 #[component]
 async fn docs_card() -> Result {
     view! {
@@ -1271,15 +1322,15 @@ async fn docs_card() -> Result {
                 card_description("A panel over the page for a single task.")
             )
             card_content(
-                <div class="flex flex-col gap-3">
-                    for (action, keys) in [
-                        ("Search the docs", ["Ctrl", "K"]),
-                        ("Copy the snippet", ["Ctrl", "C"]),
-                    ] {
+                // The section a docs page ends on: how the dialog's form is
+                // worked from the keyboard.
+                <h3 class="text-sm font-medium">"Keyboard"</h3>
+                <div class="mt-3 flex flex-col gap-3">
+                    for (action, keys) in KEYS {
                         <div class="flex items-center justify-between gap-4">
                             <p class="text-sm text-muted-foreground">(action)</p>
                             kbd_group(
-                                for key in keys {
+                                for key in keys.iter().copied() {
                                     kbd((key))
                                 }
                             )

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -61,6 +61,13 @@ use topcoat::{
 /// own asset bundle.
 const PORTRAIT: Asset = asset!("./portrait.svg");
 
+/// The pages this one links out to: the framework's documentation, its
+/// source, and the registry the components here were added from.
+const CRATE: &str = "https://crates.io/crates/topcoat";
+const DOCS: &str = "https://docs.rs/topcoat";
+const REPOSITORY: &str = "https://github.com/tokio-rs/topcoat";
+const REGISTRY: &str = "https://github.com/tokio-rs/topcoat/tree/main/crates/topcoat-ui/registry";
+
 #[tokio::main]
 async fn main() {
     let router = Router::builder()
@@ -79,6 +86,8 @@ async fn main() {
 struct HomeQuery {
     tab: Option<String>,
     page: Option<usize>,
+    per_page: Option<usize>,
+    name: Option<String>,
     env: Option<String>,
     status: Option<String>,
     branch: Option<String>,
@@ -97,6 +106,10 @@ struct State {
     tab: &'static str,
     /// The page of the deployments table.
     page: usize,
+    /// How many rows a page of the deployments table holds.
+    per_page: usize,
+    /// The name the project goes by.
+    name: String,
     /// The environment the deployments table is filtered to.
     env: Option<&'static str>,
     /// The status the deployments table is filtered to.
@@ -122,6 +135,8 @@ impl State {
         Ok(Self {
             tab: one_of(query.tab.as_deref(), &TABS.map(|(value, _)| value)).unwrap_or(TABS[0].0),
             page: query.page.unwrap_or(1).max(1),
+            per_page: one_of_numbers(query.per_page, &PER_PAGE).unwrap_or(PER_PAGE[0]),
+            name: project_name(query.name.clone()),
             env: one_of(query.env.as_deref(), &ENVIRONMENTS),
             status: query.status.as_deref().and_then(status_label),
             branch: one_of(branch, &BRANCHES)
@@ -143,6 +158,12 @@ impl State {
         }
         if self.page > 1 {
             params.push(("page", self.page.to_string()));
+        }
+        if self.per_page != PER_PAGE[0] {
+            params.push(("per_page", self.per_page.to_string()));
+        }
+        if self.name != NAME {
+            params.push(("name", self.name.clone()));
         }
         if let Some(env) = self.env {
             params.push(("env", env.to_owned()));
@@ -234,6 +255,32 @@ fn one_of(value: Option<&str>, values: &[&'static str]) -> Option<&'static str> 
     values.iter().copied().find(|known| *known == value)
 }
 
+/// The entry of `values` that `value` names, for the numbers among the state.
+fn one_of_numbers(value: Option<usize>, values: &[usize]) -> Option<usize> {
+    let value = value?;
+    values.iter().copied().find(|known| *known == value)
+}
+
+/// The name the project goes by until it is renamed.
+const NAME: &str = "topcoat-ui";
+
+/// The name in `value`, if it is one the page's links can carry.
+///
+/// The links here build their query strings by hand, so a name is kept to
+/// what needs no escaping: letters, digits, dashes, and underscores, and no
+/// more than 32 of them. Anything else falls back to the default, the same
+/// way the rest of the state does.
+fn project_name(value: Option<String>) -> String {
+    let name = value.unwrap_or_default();
+    let carried = !name.is_empty()
+        && name.len() <= 32
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+
+    if carried { name } else { NAME.to_owned() }
+}
+
 /// The panels the project card tabs between: the value each goes by in the
 /// URL, and the word on its trigger. The first is the one the page opens on.
 const TABS: [(&str, &str); 3] = [
@@ -241,6 +288,10 @@ const TABS: [(&str, &str); 3] = [
     ("activity", "Activity"),
     ("settings", "Settings"),
 ];
+
+/// How many rows one page of the deployments table can hold. The first is the
+/// number it holds until another is picked.
+const PER_PAGE: [usize; 3] = [3, 6, 12];
 
 /// The environments deployments go to.
 const ENVIRONMENTS: [&str; 3] = ["production", "staging", "preview"];
@@ -264,7 +315,7 @@ const TAGS: [&str; 3] = ["v1.2.0", "v1.1.0", "v1.0.0"];
 /// by in the URL, and the word for it.
 const OVERLAYS: [(&str, &str); 3] = [
     ("rename", "Dialog"),
-    ("delete", "Alert dialog"),
+    ("reset", "Alert dialog"),
     ("filters", "Sheet"),
 ];
 
@@ -321,17 +372,22 @@ async fn home(cx: &Cx) -> Result {
                             <code class="text-foreground">"topcoat ui add"</code>
                             ". Yours to restyle, rewrite, and ship."
                         </p>
+                        // Anything can borrow a button's looks:
+                        // `button_variants` returns the class string for a
+                        // variant and size.
                         <div class="mt-6 flex flex-wrap items-center gap-3">
-                            button(
-                                size: ButtonSize::Lg,
-                                "Get started"
-                                icon(data: iconify_icon!("feather:arrow-right"))
-                            )
-                            // Anything can borrow a button's looks:
-                            // `button_variants` returns the class string for a
-                            // variant and size.
                             <a
-                                href="https://github.com/tokio-rs/topcoat"
+                                href=(DOCS)
+                                class=(button_variants(
+                                    ButtonVariant::Primary,
+                                    ButtonSize::Lg,
+                                ))
+                            >
+                                "Read the docs"
+                                icon(data: iconify_icon!("feather:arrow-right"))
+                            </a>
+                            <a
+                                href=(REPOSITORY)
                                 class=(button_variants(
                                     ButtonVariant::Outline,
                                     ButtonSize::Lg,
@@ -350,46 +406,27 @@ async fn home(cx: &Cx) -> Result {
                         demo(notices())
                         demo(team_card())
                         demo(status_card())
-                        demo(create_card())
-                        demo(notifications_card())
-                        demo(plan_card())
+                        demo(form_card())
+                        demo(checks_card())
+                        demo(rows_card(state: &state))
                         demo(overlays_card(state: &state))
                         demo(overview_card(state: &state))
                         demo(faq_card())
                         demo(branches_card(state: &state))
                         demo(toolbar_card())
                         demo(share_card())
-                        demo(settings_card(state: &state))
+                        demo(rename_card(state: &state))
                         demo(deployments_card(state: &state))
                         demo(docs_card())
                         demo(pending_card())
                         demo(deploy_card())
                     </div>
-
-                    // The separator in both of its orientations: a rule under
-                    // the page, and rules between the links.
-                    <footer class="mt-16 flex flex-col gap-4">
-                        separator()
-                        // The row's height is what gives the vertical rules
-                        // theirs.
-                        <div
-                            class="flex h-5 items-center gap-3 text-sm text-muted-foreground"
-                        >
-                            <p>"Topcoat UI"</p>
-                            separator(orientation: SeparatorOrientation::Vertical)
-                            <a href="#docs" class="hover:text-foreground">"Docs"</a>
-                            separator(orientation: SeparatorOrientation::Vertical)
-                            <a href="#registry" class="hover:text-foreground">
-                                "Registry"
-                            </a>
-                        </div>
-                    </footer>
                 </main>
 
                 // The overlays cover the page, so they stand outside the
                 // masonry rather than in the cells that open them.
                 rename_dialog(state: &state)
-                delete_dialog(state: &state)
+                reset_dialog(state: &state)
                 filters_sheet(state: &state)
             </body>
         </html>
@@ -480,47 +517,50 @@ async fn notices() -> Result {
             // column for it only when one is there.
             alert(
                 icon(data: iconify_icon!("feather:info"))
-                alert_title("Scheduled maintenance")
+                alert_title("Every control is a link or a form")
                 alert_description(
-                    "The dashboard is read-only on Sunday, 02:00 to 04:00 UTC."
+                    "Nothing on this page needs scripting; the URL holds what \
+                     each one changes."
                 )
             )
             alert(
                 variant: AlertVariant::Destructive,
                 icon(data: iconify_icon!("feather:alert-triangle"))
-                alert_title("Build failed")
+                alert_title("The destructive variant")
                 alert_description(
-                    "The preview build could not resolve its dependencies."
+                    "For what went wrong, and for what cannot be taken back."
                 )
             )
             alert(
-                alert_title("No deployments yet")
-                alert_description("Push to a branch to see it build here.")
+                alert_title("Without an icon")
+                alert_description(
+                    "The title and the text fill the width the icon would \
+                     have left them."
+                )
             )
         </div>
     }
 }
 
-/// The people with access to the workspace, after its owner: the initials
-/// their avatar falls back to, and the role they hold.
+/// The people standing in for a roster: the initials their avatar falls back
+/// to, and the role they hold.
 const MEMBERS: [(&str, &str, &str, &str); 3] = [
     ("Grace Hopper", "grace@example.com", "GH", "Member"),
     ("Alan Turing", "alan@example.com", "AT", "Member"),
     ("Katherine Johnson", "katherine@example.com", "KJ", "Viewer"),
 ];
 
-/// The roles a member of a workspace can hold.
-const ROLES: [&str; 3] = ["Owner", "Member", "Viewer"];
-
-/// The workspace's roster: its owner in full, then everyone else with the role
-/// they hold.
+/// A roster: the owner in full, then everyone else with the role they hold.
 #[component]
 async fn team_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Your team")
-                card_description("Everyone with access to this workspace.")
+                card_title("Avatars")
+                card_description(
+                    "A portrait, initials where there is none, and the role \
+                     each one reads in a badge."
+                )
             )
             card_content(
                 // The owner is the only one with a portrait; the others fall
@@ -543,8 +583,6 @@ async fn team_card() -> Result {
                 separator(attrs: attributes! { class="my-5" })
                 <div class="flex flex-col gap-3">
                     for (name, email, initials, role) in MEMBERS {
-                        let id = format!("role-{initials}");
-
                         <div class="flex items-center justify-between gap-3">
                             <div class="flex min-w-0 items-center gap-3">
                                 avatar(size: AvatarSize::Sm, avatar_fallback((initials)))
@@ -555,31 +593,10 @@ async fn team_card() -> Result {
                                     </p>
                                 </div>
                             </div>
-                            // Picking a role needs nothing behind it: the
-                            // browser keeps a select's state on its own. The
-                            // label naming it is only for assistive
-                            // technology, since the row already reads as one.
-                            label(
-                                attrs: attributes! { for=(id.as_str()) class="sr-only" },
-                                (format!("{name}'s role"))
-                            )
-                            select(
-                                attrs: attributes! { id=(id.as_str()) class="w-28" },
-                                for option in ROLES {
-                                    <option selected=(option == role)>(option)</option>
-                                }
-                            )
+                            badge(variant: BadgeVariant::Outline, (role))
                         </div>
                     }
                 </div>
-            )
-            card_footer(
-                button(
-                    size: ButtonSize::Sm,
-                    variant: ButtonVariant::Secondary,
-                    icon(data: iconify_icon!("feather:user-plus"))
-                    "Invite member"
-                )
             )
         )
     }
@@ -592,8 +609,11 @@ async fn status_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Deployment status")
-                card_description("How the last builds ended up.")
+                card_title("Badges")
+                card_description(
+                    "Every variant, counting the rows of the table below, and \
+                     a progress bar under them."
+                )
             )
             card_content(
                 <div class="flex flex-col gap-3">
@@ -615,7 +635,7 @@ async fn status_card() -> Result {
                 <div class="flex flex-col gap-2">
                     <div class="flex items-center justify-between gap-4">
                         <p class="text-sm text-muted-foreground">
-                            "Rolling out to production"
+                            "A bar with a value"
                         </p>
                         <p class="text-sm font-medium">"62%"</p>
                     </div>
@@ -623,41 +643,41 @@ async fn status_card() -> Result {
                 </div>
             )
             card_footer(
-                <p class="text-sm text-muted-foreground">"Rolled out with"</p>
+                <p class="text-sm text-muted-foreground">"Built with Topcoat"</p>
                 // Anything can borrow a badge's looks: `badge_variants`
                 // returns the class string for a variant.
-                <a href="#changelog" class=(badge_variants(BadgeVariant::Outline))>
-                    "v2.0.4"
+                <a href=(CRATE) class=(badge_variants(BadgeVariant::Outline))>
+                    (format!("v{}", env!("CARGO_PKG_VERSION")))
                 </a>
             )
         )
     }
 }
 
-/// A creation form: a labeled control per field, and a footer that commits or
-/// puts them back.
+/// The form controls, each with the label naming it.
+///
+/// Nothing is submitted here: the fields are the demo, and "Reset" is the one
+/// control that acts, which the browser does on its own.
 #[component]
-async fn create_card() -> Result {
+async fn form_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Create project")
-                card_description("Deploys go to the region you pick here.")
+                card_title("Form controls")
+                card_description("An input, a select, a textarea, and a label each.")
             )
             card_content(
-                // Nothing is created here, so the form keeps to itself: the
-                // fields are the demo, and "Cancel" puts them back.
                 <form class="flex flex-col gap-4">
                     <div class="flex flex-col gap-2">
                         label(attrs: attributes! { for="project-name" }, "Name")
                         input(
-                            attrs: attributes! { id="project-name" name="name" placeholder="my-app" }
+                            attrs: attributes! { id="project-name" placeholder="my-app" }
                         )
                     </div>
                     <div class="flex flex-col gap-2">
                         label(attrs: attributes! { for="region" }, "Region")
                         select(
-                            attrs: attributes! { id="region" name="region" },
+                            attrs: attributes! { id="region" },
                             <optgroup label="Europe">
                                 <option>"eu-central-1"</option>
                                 <option>"eu-west-2"</option>
@@ -671,28 +691,23 @@ async fn create_card() -> Result {
                     <div class="flex flex-col gap-2">
                         label(attrs: attributes! { for="summary" }, "Summary")
                         textarea(
-                            attrs: attributes! {
-                                id="summary"
-                                name="summary"
-                                placeholder="What this project is for."
-                            }
+                            attrs: attributes! { id="summary" placeholder="What this project is for." }
                         )
                     </div>
                     <div class="flex flex-col gap-2">
                         label(attrs: attributes! { for="owner" }, "Owner")
-                        // The owner is not the form's to change, so the field
-                        // shows it and stays out of the way.
+                        // A disabled field shows a value that is not the
+                        // form's to change.
                         input(
                             attrs: attributes! { id="owner" value="ada@example.com" disabled="" }
                         )
                     </div>
                     <div class="flex flex-wrap justify-end gap-2">
                         button(
-                            variant: ButtonVariant::Ghost,
+                            variant: ButtonVariant::Outline,
                             attrs: attributes! { type="reset" },
-                            "Cancel"
+                            "Reset"
                         )
-                        button(attrs: attributes! { type="button" }, "Create project")
                     </div>
                 </form>
             )
@@ -700,110 +715,116 @@ async fn create_card() -> Result {
     }
 }
 
-/// Notification settings mixing checkboxes and switches through their states.
+/// The states a checkbox is shown in: the id it goes by, the word for the
+/// state, whether it is checked, and whether it is disabled.
+const CHECKS: [(&str, &str, bool, bool); 4] = [
+    ("check-on", "Checked", true, false),
+    ("check-off", "Unchecked", false, false),
+    ("check-on-off", "Checked and disabled", true, true),
+    ("check-off-off", "Unchecked and disabled", false, true),
+];
+
+/// The same states, shown on a switch.
+const SWITCHES: [(&str, &str, bool, bool); 3] = [
+    ("switch-on", "On", true, false),
+    ("switch-off", "Off", false, false),
+    ("switch-off-off", "Off and disabled", false, true),
+];
+
+/// The checkbox and the switch, in each of the states they can be in.
+///
+/// Nothing behind them keeps a value, so every row says which state it stands
+/// in rather than naming a setting the page does not have.
 #[component]
-async fn notifications_card() -> Result {
+async fn checks_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Notifications")
-                card_description("Pick what lands in your inbox.")
+                card_title("Checkboxes and switches")
+                card_description("Each one in the states it can be in.")
             )
             card_content(
                 <div class="flex flex-col gap-3">
-                    <div class="flex items-center gap-2">
-                        checkbox(attrs: attributes! { id="notify-deploys" checked="" })
-                        label(
-                            attrs: attributes! { for="notify-deploys" },
-                            "Deploy results"
-                        )
-                    </div>
-                    <div class="flex items-center gap-2">
-                        checkbox(attrs: attributes! { id="notify-mentions" })
-                        label(attrs: attributes! { for="notify-mentions" }, "Mentions")
-                    </div>
-                    <div class="flex items-center gap-2">
-                        checkbox(
-                            attrs: attributes! { id="notify-digest" checked="" disabled="" }
-                        )
-                        label(
-                            attrs: attributes! { for="notify-digest" class="opacity-50" },
-                            "Weekly digest (managed by your org)"
-                        )
-                    </div>
+                    for (id, text, checked, disabled) in CHECKS {
+                        <div class="flex items-center gap-2">
+                            checkbox(
+                                attrs: attributes! { id=(id) checked=(checked) disabled=(disabled) }
+                            )
+                            label(
+                                attrs: attributes! { for=(id) class=(class!("opacity-50" if disabled)) },
+                                (text)
+                            )
+                        </div>
+                    }
                 </div>
                 separator(attrs: attributes! { class="my-4" })
                 <div class="flex flex-col gap-3">
-                    <div class="flex items-center justify-between gap-4">
-                        label(
-                            attrs: attributes! { for="notify-push" },
-                            "Push notifications"
-                        )
-                        switch(attrs: attributes! { id="notify-push" checked="" })
-                    </div>
-                    <div class="flex items-center justify-between gap-4">
-                        label(attrs: attributes! { for="notify-quiet" }, "Quiet hours")
-                        switch(attrs: attributes! { id="notify-quiet" })
-                    </div>
-                    <div class="flex items-center justify-between gap-4">
-                        label(
-                            attrs: attributes! { for="notify-sms" class="opacity-50" },
-                            "Text messages (not on this plan)"
-                        )
-                        switch(attrs: attributes! { id="notify-sms" disabled="" })
-                    </div>
+                    for (id, text, checked, disabled) in SWITCHES {
+                        <div class="flex items-center justify-between gap-4">
+                            label(
+                                attrs: attributes! { for=(id) class=(class!("opacity-50" if disabled)) },
+                                (text)
+                            )
+                            switch(
+                                attrs: attributes! { id=(id) checked=(checked) disabled=(disabled) }
+                            )
+                        </div>
+                    }
                 </div>
             )
         )
     }
 }
 
-/// The plans a workspace can run on: the value each goes by, its name, its
-/// price, and whether it can be picked here.
-const PLANS: [(&str, &str, &str, bool); 4] = [
-    ("starter", "Starter", "Free", true),
-    ("pro", "Pro", "$24 / month", true),
-    ("scale", "Scale", "$96 / month", true),
-    ("enterprise", "Enterprise", "Contact sales", false),
-];
-
-/// A plan picker, built on a radio group.
+/// A radio group that sets how many rows the table further down shows.
+///
+/// The choice reaches the server the way every other one on this page does:
+/// the group sits in a form, and the button submits it into the URL. The page
+/// is left out of the fields carried along, so a table resized by hand comes
+/// back at its first page rather than at one the rows no longer reach.
 #[component]
-async fn plan_card() -> Result {
+async fn rows_card(state: &State) -> Result {
     view! {
         card(
             card_header(
-                card_title("Billing plan")
-                card_description("Pick the plan this workspace runs on.")
-            )
-            card_content(
-                radio_group(
-                    // The name the options share is what has the browser let
-                    // go of one when another is picked.
-                    for (value, name, price, available) in PLANS {
-                        <div class="flex items-center gap-2">
-                            radio_group_item(
-                                attrs: attributes! {
-                                    id=(value)
-                                    name="plan"
-                                    value=(value)
-                                    checked=(value == "pro")
-                                    disabled=(!available)
-                                }
-                            )
-                            label(
-                                attrs: attributes! {
-                                    for=(value)
-                                    class=(class!("flex-1", "opacity-50" if !available))
-                                },
-                                (name)
-                            )
-                            <p class="text-sm text-muted-foreground">(price)</p>
-                        </div>
-                    }
+                card_title("Radio group")
+                card_description(
+                    "One choice at a time. This one sets how many rows the \
+                     table below shows."
                 )
             )
-            card_footer(button(attrs: attributes! { class="w-full" }, "Upgrade"))
+            card_content(
+                <form class="flex flex-col gap-4">
+                    state_fields(state: state, sets: "per_page page")
+                    radio_group(
+                        // The name the options share is what has the browser
+                        // let go of one when another is picked.
+                        for rows in PER_PAGE {
+                            let id = format!("rows-{rows}");
+
+                            <div class="flex items-center gap-2">
+                                radio_group_item(
+                                    attrs: attributes! {
+                                        id=(id.as_str())
+                                        name="per_page"
+                                        value=(rows.to_string())
+                                        checked=(rows == state.per_page)
+                                    }
+                                )
+                                label(
+                                    attrs: attributes! { for=(id.as_str()) },
+                                    (format!("{rows} rows a page"))
+                                )
+                            </div>
+                        }
+                    )
+                    button(
+                        size: ButtonSize::Sm,
+                        attrs: attributes! { class="self-start" },
+                        "Apply"
+                    )
+                </form>
+            )
         )
     }
 }
@@ -854,8 +875,8 @@ async fn overview_card(state: &State) -> Result {
     view! {
         card(
             card_header(
-                card_title("Project")
-                card_description("Everything about topcoat-ui in one place.")
+                card_title("Tabs")
+                card_description("The panel being read is the one named in the URL.")
             )
             card_content(
                 tabs(
@@ -871,11 +892,11 @@ async fn overview_card(state: &State) -> Result {
                     tabs_content(
                         <p class="text-sm text-muted-foreground">
                             (match state.tab {
-                                "activity" => "Grace deployed to production 2 hours ago.",
-                                "settings" => {
-                                    "The project is on the Pro plan, in eu-central-1."
+                                "activity" => {
+                                    "Reload the page and this same panel comes back."
                                 }
-                                _ => "Eight deploys this week, all of them green.",
+                                "settings" => "Send the URL on and it opens here too.",
+                                _ => "This panel is in the URL as ?tab=overview.",
                             })
                         </p>
                     )
@@ -891,8 +912,8 @@ async fn faq_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Questions")
-                card_description("The rest is in the docs.")
+                card_title("Accordion")
+                card_description("One section open at a time; the rest fold away.")
             )
             card_content(
                 accordion(
@@ -937,8 +958,11 @@ async fn branches_card(state: &State) -> Result {
     view! {
         card(
             card_header(
-                card_title("Branches")
-                card_description("Switch the branch this preview builds from.")
+                card_title("Dropdown menu")
+                card_description(
+                    "Picking an item submits the form around it, so the choice \
+                     lands in the URL."
+                )
             )
             card_content(
                 // The form carries the rest of the page's state along, and the
@@ -998,41 +1022,50 @@ async fn toolbar_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Report")
-                card_description("The range it covers, and how it reads.")
+                card_title("Toggles")
+                card_description(
+                    "A segmented control that keeps one pressed, and toggles \
+                     that press on their own."
+                )
             )
             card_content(
                 <div class="flex flex-col items-start gap-4">
-                    toggle_group(
-                        for (value, text, picked) in [
-                            ("day", "Day", false),
-                            ("week", "Week", true),
-                            ("month", "Month", false),
-                        ] {
-                            toggle(
-                                kind: ToggleKind::Exclusive,
-                                size: ToggleSize::Sm,
-                                attrs: attributes! { name="range" value=(value) checked=(picked) },
-                                (text)
-                            )
-                        }
-                    )
-                    <div class="flex items-center gap-1">
-                        for (name, data, text, pressed) in [
-                            ("bold", iconify_icon!("feather:bold"), "Bold", true),
-                            ("italic", iconify_icon!("feather:italic"), "Italic", false),
-                            (
-                                "underline",
-                                iconify_icon!("feather:underline"),
-                                "Underline",
-                                false,
-                            ),
-                        ] {
-                            toggle(
-                                attrs: attributes! { name=(name) checked=(pressed) },
-                                icon(data: data, label: text)
-                            )
-                        }
+                    // The groups of a toolbar stand apart with a rule
+                    // between them, and the row's height is what gives the
+                    // rule its own.
+                    <div class="flex h-9 items-center gap-2">
+                        toggle_group(
+                            for (value, text, picked) in [
+                                ("day", "Day", false),
+                                ("week", "Week", true),
+                                ("month", "Month", false),
+                            ] {
+                                toggle(
+                                    kind: ToggleKind::Exclusive,
+                                    size: ToggleSize::Sm,
+                                    attrs: attributes! { name="range" value=(value) checked=(picked) },
+                                    (text)
+                                )
+                            }
+                        )
+                        separator(orientation: SeparatorOrientation::Vertical)
+                        <div class="flex items-center gap-1">
+                            for (name, data, text, pressed) in [
+                                ("bold", iconify_icon!("feather:bold"), "Bold", true),
+                                ("italic", iconify_icon!("feather:italic"), "Italic", false),
+                                (
+                                    "underline",
+                                    iconify_icon!("feather:underline"),
+                                    "Underline",
+                                    false,
+                                ),
+                            ] {
+                                toggle(
+                                    attrs: attributes! { name=(name) checked=(pressed) },
+                                    icon(data: data, label: text)
+                                )
+                            }
+                        </div>
                     </div>
                     toggle(
                         size: ToggleSize::Lg,
@@ -1046,43 +1079,50 @@ async fn toolbar_card() -> Result {
     }
 }
 
-/// A share sheet, and the two things that show on hover: a tooltip carrying a
-/// few words, and a hover card carrying a view.
+/// The two things that show on hover: a tooltip carrying a few words, and a
+/// hover card carrying a view.
+///
+/// Both triggers are the browser's own hover and focus, so nothing here needs
+/// scripting. The tooltip's trigger is a link that goes where the hint says,
+/// since a hint is only a hint.
 #[component]
 async fn share_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Share this document")
-                card_description("Anyone with the link can view it.")
+                card_title("Tooltip and hover card")
+                card_description(
+                    "What comes up on hover: a few words, or a whole view."
+                )
             )
             card_content(
-                <div class="flex items-center gap-2">
-                    label(attrs: attributes! { for="share" class="sr-only" }, "Link")
-                    input(
-                        attrs: attributes! {
-                            id="share"
-                            readonly=""
-                            value="https://topcoat.dev/d/quickstart"
-                        }
-                    )
+                <div class="flex items-center justify-between gap-4">
+                    <p class="text-sm text-muted-foreground">"Hover the button"</p>
                     tooltip(
-                        button(
-                            size: ButtonSize::Icon,
-                            variant: ButtonVariant::Outline,
-                            attrs: attributes! { type="button" },
+                        <a
+                            href=(DOCS)
+                            class=(button_variants(
+                                ButtonVariant::Outline,
+                                ButtonSize::Icon,
+                            ))
+                        >
                             icon(
-                                data: iconify_icon!("feather:copy"),
-                                label: "Copy link"
+                                data: iconify_icon!("feather:book-open"),
+                                label: "Read the docs"
                             )
-                        )
-                        tooltip_content("Copy link")
+                        </a>
+                        tooltip_content("Read the docs")
                     )
                 </div>
-                <div class="mt-4 flex items-center gap-2 text-sm">
-                    <p class="text-muted-foreground">"Shared with"</p>
+                separator(attrs: attributes! { class="my-4" })
+                <div class="flex items-center gap-2 text-sm">
+                    <p class="text-muted-foreground">"Hover the name"</p>
                     hover_card(
-                        <a href="#ada" class="font-medium underline">"@ada"</a>
+                        // The trigger takes focus, so the card comes up for a
+                        // reader on the keyboard as well.
+                        <button type="button" class="font-medium underline">
+                            "@ada"
+                        </button>
                         hover_card_content(
                             <div class="flex items-center gap-3">
                                 avatar(
@@ -1098,7 +1138,8 @@ async fn share_card() -> Result {
                                 </div>
                             </div>
                             <p class="text-xs text-muted-foreground">
-                                "Joined in 2024. Deploys on Fridays anyway."
+                                "A hover card holds a view, where a tooltip \
+                                 holds a few words."
                             </p>
                         )
                     )
@@ -1108,19 +1149,23 @@ async fn share_card() -> Result {
     }
 }
 
-/// A settings card whose actions open the overlays. Nothing about a trigger is
-/// special: opening one is navigating to the URL the page renders it open for.
+/// The name the page carries, and the two overlays that act on it.
+///
+/// Nothing about a trigger is special: opening an overlay is navigating to the
+/// URL the page renders it open for.
 #[component]
-async fn settings_card(state: &State) -> Result {
+async fn rename_card(state: &State) -> Result {
     view! {
         card(
             card_header(
-                card_title("Project settings")
-                card_description("Rename the project, or take it down for good.")
+                card_title("Project name")
+                card_description(
+                    "The name is part of the URL, and the dialog changes it."
+                )
             )
             card_content(
                 <div class="flex items-center justify-between gap-4">
-                    <p class="truncate font-mono text-sm">"topcoat-ui"</p>
+                    <p class="truncate font-mono text-sm">(&state.name)</p>
                     <a
                         href=(state.href("overlay", Some("rename")))
                         class=(button_variants(ButtonVariant::Outline, ButtonSize::Sm))
@@ -1131,18 +1176,18 @@ async fn settings_card(state: &State) -> Result {
                 separator(attrs: attributes! { class="my-4" })
                 <div class="flex items-center justify-between gap-4">
                     <p class="truncate text-sm text-muted-foreground">
-                        "Delete this workspace"
+                        "Put the whole page back"
                     </p>
-                    // The deletion goes through an alert dialog, so it takes a
-                    // deliberate answer rather than one stray click.
+                    // Clearing the page goes through an alert dialog, so it
+                    // takes a deliberate answer rather than one stray click.
                     <a
-                        href=(state.href("overlay", Some("delete")))
+                        href=(state.href("overlay", Some("reset")))
                         class=(button_variants(
                             ButtonVariant::Destructive,
                             ButtonSize::Sm,
                         ))
                     >
-                        "Delete"
+                        "Reset"
                     </a>
                 </div>
             )
@@ -1167,32 +1212,36 @@ const DEPLOYMENTS: [(&str, &str, &str); 12] = [
     ("d4c3b2a", "staging", "Failed"),
 ];
 
-/// How many deployments one page of the table holds.
-const PER_PAGE: usize = 3;
-
-/// A table of deployments, filtered by the sheet and paginated underneath.
+/// A table of deployments, filtered by the sheet, sized by the radio group,
+/// and paginated underneath.
 ///
-/// Both the filters and the page come from the URL, so the links below the
-/// table are what change the rows and which page reads as the current one.
+/// Every one of those comes from the URL, so the links below the table are
+/// what change the rows and which page reads as the current one.
 #[component]
 async fn deployments_card(state: &State) -> Result {
     let rows: Vec<_> = DEPLOYMENTS
         .into_iter()
         .filter(|&(_, env, status)| state.shows(env, status))
         .collect();
-    let pages = rows.len().div_ceil(PER_PAGE).max(1);
+    let pages = rows.len().div_ceil(state.per_page).max(1);
     // A filter can leave fewer pages than the URL asks for, so the page being
     // read is the last one that still has rows on it.
     let page = state.page.min(pages);
-    let shown = rows.chunks(PER_PAGE).nth(page - 1).unwrap_or_default();
+    let shown = rows
+        .chunks(state.per_page)
+        .nth(page - 1)
+        .unwrap_or_default();
     let previous = state.page_href(page.saturating_sub(1).max(1));
     let next = state.page_href((page + 1).min(pages));
 
     view! {
         card(
             card_header(
-                card_title("Deployments")
-                card_description("The last builds of this project.")
+                card_title("Table")
+                card_description(
+                    "Filtered from the sheet, sized by the radio group, and \
+                     paged by the links below."
+                )
             )
             card_content(
                 <div class="flex items-center justify-between gap-4">
@@ -1215,7 +1264,9 @@ async fn deployments_card(state: &State) -> Result {
             // with the sections above and below it.
             table(
                 attrs: attributes! { class="px-3" },
-                table_caption("Deployments of the last 24 hours.")
+                table_caption(
+                    "Stand-in rows, so the table has something to page through."
+                )
                 table_header(
                     table_row(
                         table_head("Commit")
@@ -1303,7 +1354,7 @@ async fn docs_card() -> Result {
                 breadcrumb(
                     breadcrumb_list(
                         breadcrumb_item(
-                            breadcrumb_link(attrs: attributes! { href="#docs" }, "Docs")
+                            breadcrumb_link(attrs: attributes! { href=(DOCS) }, "Docs")
                         )
                         breadcrumb_separator()
                         // The steps between are collapsed into an ellipsis.
@@ -1311,7 +1362,7 @@ async fn docs_card() -> Result {
                         breadcrumb_separator()
                         breadcrumb_item(
                             breadcrumb_link(
-                                attrs: attributes! { href="#components" },
+                                attrs: attributes! { href=(REGISTRY) },
                                 "Components"
                             )
                         )
@@ -1350,8 +1401,8 @@ async fn pending_card() -> Result {
     view! {
         card(
             card_header(
-                card_title("Restoring the workspace")
-                card_description("What the page shows while the work goes on.")
+                card_title("Skeletons and spinners")
+                card_description("The shapes a page takes while it waits.")
             )
             card_content(
                 // The skeletons take the size of what they stand in for, so
@@ -1372,7 +1423,7 @@ async fn pending_card() -> Result {
                 <div class="flex flex-col gap-2">
                     <p class="flex items-center gap-1.5 text-sm text-muted-foreground">
                         spinner()
-                        "Restoring the database"
+                        "Work whose end is not in sight"
                     </p>
                     // Without a value the bar reads as work whose extent is
                     // not known yet.
@@ -1391,18 +1442,15 @@ async fn deploy_card() -> Result {
         <div class="dark">
             card(
                 card_header(
-                    card_title("Deployment ready")
+                    card_title("Dark scheme")
                     card_description(
-                        "topcoat-ui@0.4.2 built in 38s and passed all checks."
+                        "The same components, on a wrapper that carries the \
+                         `dark` class."
                     )
                 )
                 card_footer(
-                    button(size: ButtonSize::Sm, "Promote to production")
-                    button(
-                        size: ButtonSize::Sm,
-                        variant: ButtonVariant::Ghost,
-                        "View logs"
-                    )
+                    button(size: ButtonSize::Sm, "Primary")
+                    button(size: ButtonSize::Sm, variant: ButtonVariant::Ghost, "Ghost")
                 )
             )
         </div>
@@ -1412,8 +1460,9 @@ async fn deploy_card() -> Result {
 /// The dialog over the page, shown while the URL names it.
 ///
 /// Closing it is navigating back to the page that renders it closed, which the
-/// corner button and "Cancel" do as links, and "Save" does by submitting the
-/// form without an overlay among its fields.
+/// corner button and "Cancel" do as links. "Save" submits the form, which puts
+/// the new name in the URL and leaves the overlay out of it, so the page comes
+/// back renamed with the dialog closed.
 #[component]
 async fn rename_dialog(state: &State) -> Result {
     view! {
@@ -1432,18 +1481,27 @@ async fn rename_dialog(state: &State) -> Result {
                     icon(data: iconify_icon!("feather:x"), label: "Close")
                 </a>
                 <form class="flex flex-col gap-4">
-                    state_fields(state: state, sets: "overlay")
+                    state_fields(state: state, sets: "overlay name")
                     dialog_header(
                         dialog_title("Rename project")
                         dialog_description(
-                            "The project keeps its deploy URLs; only the name \
-                             shown to your team changes."
+                            "The name is carried in the query string, so it \
+                             survives a reload and travels with the link."
                         )
                     )
                     <div class="flex flex-col gap-2">
                         label(attrs: attributes! { for="rename" }, "Name")
+                        // A name the links could not carry as it stands is put
+                        // back to the default, which is what the pattern and
+                        // the length say before the form is even sent.
                         input(
-                            attrs: attributes! { id="rename" name="rename" value="topcoat-ui" }
+                            attrs: attributes! {
+                                id="rename"
+                                name="name"
+                                value=(&state.name)
+                                maxlength="32"
+                                pattern="[A-Za-z0-9_-]+"
+                            }
                         )
                     </div>
                     dialog_footer(
@@ -1461,31 +1519,34 @@ async fn rename_dialog(state: &State) -> Result {
     }
 }
 
-/// The alert dialog behind the delete action: it asks the question and offers
+/// The alert dialog behind the reset action: it asks the question and offers
 /// nothing but the two answers to it.
+///
+/// Resetting is a link to the page without a query string, which is the page
+/// with every choice on it back at its default.
 #[component]
-async fn delete_dialog(state: &State) -> Result {
+async fn reset_dialog(state: &State) -> Result {
     // Bound out here rather than inline: a hyphenated attribute name inside an
     // `attributes!` nested in a `view!` currently trips `topcoat fmt`.
     let labels = attributes! {
-        aria-labelledby="delete-title"
-        aria-describedby="delete-description"
+        aria-labelledby="reset-title"
+        aria-describedby="reset-description"
     };
 
     view! {
         alert_dialog(
-            open: state.overlay == Some("delete"),
+            open: state.overlay == Some("reset"),
             attrs: labels,
             dialog_content(
                 dialog_header(
                     dialog_title(
-                        attrs: attributes! { id="delete-title" },
-                        "Delete this workspace?"
+                        attrs: attributes! { id="reset-title" },
+                        "Reset this page?"
                     )
                     dialog_description(
-                        attrs: attributes! { id="delete-description" },
-                        "Its projects, deploys, and audit log go with it. This \
-                         cannot be undone."
+                        attrs: attributes! { id="reset-description" },
+                        "The panel, the filters, the page of the table, the \
+                         branch, and the name all go back to their defaults."
                     )
                 )
                 dialog_footer(
@@ -1493,12 +1554,17 @@ async fn delete_dialog(state: &State) -> Result {
                         href=(state.closed())
                         class=(button_variants(ButtonVariant::Ghost, ButtonSize::Md))
                     >
-                        "Keep the workspace"
+                        "Leave it as it is"
                     </a>
-                    <form>
-                        state_fields(state: state, sets: "overlay")
-                        button(variant: ButtonVariant::Destructive, "Delete")
-                    </form>
+                    <a
+                        href="?"
+                        class=(button_variants(
+                            ButtonVariant::Destructive,
+                            ButtonSize::Md,
+                        ))
+                    >
+                        "Reset the page"
+                    </a>
                 )
             )
         )


### PR DESCRIPTION
This PR attempts to improve the clarity of the `ui` example by reordering tiles and changing the example texts to be more direct. Previously, some sample texts suggested features that don't exist yet (e.g. "notifications").