### PR TITLE
feat(ui): switch from feather icons to lucide in topcoat-ui

### DIFF
--- a/crates/topcoat-ui/registry/Cargo.toml
+++ b/crates/topcoat-ui/registry/Cargo.toml
@@ -17,7 +17,7 @@ rust-version.workspace = true
 [package.metadata.topcoat-ui]
 registry = "."
 
-# Stages the Feather icon set at build time. Off by default so ordinary builds
+# Stages the Lucide icon set at build time. Off by default so ordinary builds
 # and docs.rs never hit the network; enable it (CI does, via `--all-features`)
 # to compile the `#[cfg(test)]` component sources, whose `iconify_icon!`
 # references read the staged set.

--- a/crates/topcoat-ui/registry/build.rs
+++ b/crates/topcoat-ui/registry/build.rs
@@ -1,11 +1,11 @@
 fn main() {
-    // Stage the Feather icon set for the `iconify_icon!` references in the
+    // Stage the Lucide icon set for the `iconify_icon!` references in the
     // `#[cfg(test)]` component sources. Gated behind the `stage-icons` feature
     // so ordinary builds and docs.rs stay offline; see the feature in
     // `Cargo.toml`.
     #[cfg(feature = "stage-icons")]
     topcoat_icon::iconify::BuildConfig::new()
-        .icon_set("feather")
+        .icon_set("lucide")
         .stage()
         .unwrap();
 }

--- a/crates/topcoat-ui/registry/src/components/accordion.rs
+++ b/crates/topcoat-ui/registry/src/components/accordion.rs
@@ -102,7 +102,7 @@ pub async fn accordion_trigger(#[default] mut attrs: Attributes, #[default] chil
         >
             (child)
             icon(
-                data: iconify_icon!("feather:chevron-down"),
+                data: iconify_icon!("lucide:chevron-down"),
                 attrs: attributes! {
                     class="size-4 shrink-0 text-muted-foreground transition-transform \
                         duration-200 ease-out group-open:rotate-180"

--- a/crates/topcoat-ui/registry/src/components/alert.rs
+++ b/crates/topcoat-ui/registry/src/components/alert.rs
@@ -55,7 +55,7 @@ const BASE: StaticClass = class!(
 /// view! {
 ///     alert(
 ///         variant: AlertVariant::Destructive,
-///         icon(data: iconify_icon!("feather:alert-triangle"))
+///         icon(data: iconify_icon!("lucide:triangle-alert"))
 ///         alert_title("Build failed")
 ///         alert_description("The last deploy did not finish.")
 ///     )

--- a/crates/topcoat-ui/registry/src/components/breadcrumb.rs
+++ b/crates/topcoat-ui/registry/src/components/breadcrumb.rs
@@ -112,7 +112,7 @@ pub async fn breadcrumb_separator(#[default] mut attrs: Attributes) -> Result {
     view! {
         <li aria-hidden="true" class=(attrs.remove("class")) (attrs)>
             icon(
-                data: iconify_icon!("feather:chevron-right"),
+                data: iconify_icon!("lucide:chevron-right"),
                 attrs: attributes! { class="size-3.5" }
             )
         </li>
@@ -129,7 +129,7 @@ pub async fn breadcrumb_ellipsis(#[default] mut attrs: Attributes) -> Result {
     view! {
         <span class=(class!("flex items-center", attrs.remove("class"))) (attrs)>
             icon(
-                data: iconify_icon!("feather:more-horizontal"),
+                data: iconify_icon!("lucide:ellipsis"),
                 attrs: attributes! { class="size-4" }
             )
             <span class="sr-only">"More"</span>

--- a/crates/topcoat-ui/registry/src/components/checkbox.rs
+++ b/crates/topcoat-ui/registry/src/components/checkbox.rs
@@ -49,7 +49,7 @@ pub async fn checkbox(#[default] mut attrs: Attributes) -> Result {
         >
             <input type="checkbox" class=(CHECKBOX) (attrs)>
             icon(
-                data: iconify_icon!("feather:check"),
+                data: iconify_icon!("lucide:check"),
                 attrs: attributes! {
                     class="pointer-events-none absolute inset-0 m-auto size-3.5 \
                         text-primary-foreground opacity-0 peer-checked:opacity-100"

--- a/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
+++ b/crates/topcoat-ui/registry/src/components/dropdown_menu.rs
@@ -62,7 +62,7 @@ const TRIGGER: StaticClass = class!("cursor-pointer list-none [&::-webkit-detail
 ///         },
 ///         "Options"
 ///         icon(
-///             data: iconify_icon!("feather:chevron-down"),
+///             data: iconify_icon!("lucide:chevron-down"),
 ///             attrs: attributes! { class="group-open:rotate-180" }
 ///         )
 ///     )
@@ -187,7 +187,7 @@ pub async fn dropdown_menu_sub_trigger(
         >
             (child)
             icon(
-                data: iconify_icon!("feather:chevron-right"),
+                data: iconify_icon!("lucide:chevron-right"),
                 attrs: attributes! { class="ml-auto size-4" }
             )
         </summary>

--- a/crates/topcoat-ui/registry/src/components/pagination.rs
+++ b/crates/topcoat-ui/registry/src/components/pagination.rs
@@ -143,7 +143,7 @@ pub async fn pagination_previous(
             ))
             (attrs)
         >
-            icon(data: iconify_icon!("feather:chevron-left"))
+            icon(data: iconify_icon!("lucide:chevron-left"))
             <span class=(LABEL)>(label)</span>
         </a>
     }
@@ -169,7 +169,7 @@ pub async fn pagination_next(
             (attrs)
         >
             <span class=(LABEL)>(label)</span>
-            icon(data: iconify_icon!("feather:chevron-right"))
+            icon(data: iconify_icon!("lucide:chevron-right"))
         </a>
     }
 }
@@ -190,7 +190,7 @@ pub async fn pagination_ellipsis(#[default] mut attrs: Attributes) -> Result {
             (attrs)
         >
             icon(
-                data: iconify_icon!("feather:more-horizontal"),
+                data: iconify_icon!("lucide:ellipsis"),
                 attrs: attributes! { class="size-4" }
             )
             <span class="sr-only">"More pages"</span>

--- a/crates/topcoat-ui/registry/src/components/select.rs
+++ b/crates/topcoat-ui/registry/src/components/select.rs
@@ -48,7 +48,7 @@ const PICKER: StaticClass = class!(
 );
 
 /// The icon marking the picker's checked option.
-const CHECKMARK: IconData = iconify_icon!("feather:check");
+const CHECKMARK: IconData = iconify_icon!("lucide:check");
 
 /// The inline style for the [`select`] wrapper, carrying [`CHECKMARK`] as a
 /// data URI in the `--select-checkmark` custom property. The indirection
@@ -117,7 +117,7 @@ pub async fn select(cx: &Cx, #[default] mut attrs: Attributes, #[default] child:
         >
             <select class=(class!(SELECT, PICKER)) (attrs)>(child)</select>
             icon(
-                data: iconify_icon!("feather:chevron-down"),
+                data: iconify_icon!("lucide:chevron-down"),
                 attrs: attributes! {
                     class="pointer-events-none absolute top-1/2 right-3 size-4 \
                         -translate-y-1/2 text-muted-foreground transition-transform"

--- a/crates/topcoat-ui/registry/src/components/spinner.rs
+++ b/crates/topcoat-ui/registry/src/components/spinner.rs
@@ -36,7 +36,7 @@ pub async fn spinner(
 ) -> Result {
     view! {
         icon(
-            data: iconify_icon!("lucide:loader"),
+            data: iconify_icon!("lucide:loader-circle"),
             size: size,
             label: label,
             attrs: attributes! {

--- a/crates/topcoat-ui/registry/src/components/spinner.rs
+++ b/crates/topcoat-ui/registry/src/components/spinner.rs
@@ -36,7 +36,7 @@ pub async fn spinner(
 ) -> Result {
     view! {
         icon(
-            data: iconify_icon!("feather:loader"),
+            data: iconify_icon!("lucide:loader"),
             size: size,
             label: label,
             attrs: attributes! {

--- a/crates/topcoat-ui/registry/src/components/toggle.rs
+++ b/crates/topcoat-ui/registry/src/components/toggle.rs
@@ -88,7 +88,7 @@ const BASE: StaticClass = class!(
 /// view! {
 ///     toggle(
 ///         attrs: attributes! { name="bold" checked="" },
-///         icon(data: iconify_icon!("feather:bold"), label: "Bold")
+///         icon(data: iconify_icon!("lucide:bold"), label: "Bold")
 ///     )
 /// }
 /// ```

--- a/crates/topcoat-ui/registry/src/components/tooltip.rs
+++ b/crates/topcoat-ui/registry/src/components/tooltip.rs
@@ -22,7 +22,7 @@ use topcoat::{
 ///         button(
 ///             size: ButtonSize::Icon,
 ///             variant: ButtonVariant::Outline,
-///             icon(data: iconify_icon!("feather:copy"), label: "Copy link")
+///             icon(data: iconify_icon!("lucide:copy"), label: "Copy link")
 ///         )
 ///         tooltip_content("Copy link")
 ///     )

--- a/examples/ui/build.rs
+++ b/examples/ui/build.rs
@@ -6,9 +6,9 @@ fn main() {
         .render()
         .unwrap();
 
-    // Stage the Feather icon set for the `iconify_icon!` references in main.rs.
+    // Stage the Lucide icon set for the `iconify_icon!` references in main.rs.
     topcoat::icon::iconify::BuildConfig::new()
-        .icon_set("feather")
+        .icon_set("lucide")
         .stage()
         .unwrap();
 }

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -97,7 +97,7 @@ hash = "sha256:b43fd188519fd83a1161ac995422244d95169ed870c9677974ffd53f84c79b77"
 file = "src/components/skeleton.rs"
 
 [registries.topcoat.components.spinner]
-hash = "sha256:25bf884f5a5fc1c36c77f1c77fcb0399ce5fe3abf94539e1d961b5121863ebdf"
+hash = "sha256:1e373e4dc4a1bd79164a64b5624d304f4c386c2d70d3ae2949b6746618a67884"
 file = "src/components/spinner.rs"
 
 [registries.topcoat.components.switch]

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -9,11 +9,11 @@ hash = "sha256:c7bdcb5ea4ff757611ba616e92178169b262be98155c06dfa2407584d51e7459"
 file = "styles.css"
 
 [registries.topcoat.components.accordion]
-hash = "sha256:602299bc16055e1c2c12c8e0c443803967b8c29c28352d62390de3f40718fc36"
+hash = "sha256:ab63888a337354cda96dd20a47b3187d35c4164fdb08acd17c37466827c88e6c"
 file = "src/components/accordion.rs"
 
 [registries.topcoat.components.alert]
-hash = "sha256:bb732eac12e2cfb8444dc4154f72fb4e5d25e4023d665b575d70cedea6ae5211"
+hash = "sha256:7bbe09b7d0b318be28f9f2ead0a1b4541a9ac63474bd396e1acf93aae7c51f05"
 file = "src/components/alert.rs"
 
 [registries.topcoat.components.alert_dialog]
@@ -29,7 +29,7 @@ hash = "sha256:237e2d1d23687302808316618a4de08cbf0cf5ffbadb49117d00df86a9166b0f"
 file = "src/components/badge.rs"
 
 [registries.topcoat.components.breadcrumb]
-hash = "sha256:1540711f2c98e58dd0ca0fbce8f7a7a2a103b6d3f48dbfbf2fc5a8581bc5d152"
+hash = "sha256:71342e8b336ac11bf7c5a7a1ab9438bd53b0e390e0c7326ea52c9b744451ff9b"
 file = "src/components/breadcrumb.rs"
 
 [registries.topcoat.components.button]
@@ -41,7 +41,7 @@ hash = "sha256:edfefa3c9ef8e98aedc2f5bad6db77aea7af04211722a23bdac7c532768a554d"
 file = "src/components/card.rs"
 
 [registries.topcoat.components.checkbox]
-hash = "sha256:367826905b0aae7448b2ce1929dd57be0c0779a09a3c6b0180666008ae0a7805"
+hash = "sha256:7cf7c2b376f5b9c5bdb717c220314f2a44e3ee00fd6fc0c309cbcd8ee4b8b371"
 file = "src/components/checkbox.rs"
 
 [registries.topcoat.components.dialog]
@@ -49,7 +49,7 @@ hash = "sha256:afaddd6f29a2e0f456fae1511bb7cff5441984d070d605c67392b6390db34e6f"
 file = "src/components/dialog.rs"
 
 [registries.topcoat.components.dropdown_menu]
-hash = "sha256:cab2d0864593f3c65d60cdbd97d72956e1614aa811b972bd726afdd68510dfd9"
+hash = "sha256:7d7376bdcdeb59bfff65df58e686d1d9d5c6ef1fa7381de1b46a97bfe9233563"
 file = "src/components/dropdown_menu.rs"
 
 [registries.topcoat.components.hover_card]
@@ -69,7 +69,7 @@ hash = "sha256:ca749b5e7995b78ffb99e57cf01997282ee737cf34f5c8dc27bbdf143306823f"
 file = "src/components/label.rs"
 
 [registries.topcoat.components.pagination]
-hash = "sha256:b4e1b4f92715e99e66831eaa94da4d0180822d3fd5e3698c95e3dfda55f877ac"
+hash = "sha256:6e57265f847d07a435cded460f9c4dd4e8a9e7041f439709876930d839471c1b"
 file = "src/components/pagination.rs"
 
 [registries.topcoat.components.progress]
@@ -81,7 +81,7 @@ hash = "sha256:7186255a014d210bfec09f7d8f5885dc8bfdf927c3da07e058036706bb522e21"
 file = "src/components/radio_group.rs"
 
 [registries.topcoat.components.select]
-hash = "sha256:18249cc6f7265325d8dcd4378fe3d27230c272678bb4bd04eb36b5ea1f73332a"
+hash = "sha256:efaff9603a1e2b510f2a13a9fb5689ab906cc3339f20970899a0c953da3cdc9d"
 file = "src/components/select.rs"
 
 [registries.topcoat.components.separator]
@@ -97,7 +97,7 @@ hash = "sha256:b43fd188519fd83a1161ac995422244d95169ed870c9677974ffd53f84c79b77"
 file = "src/components/skeleton.rs"
 
 [registries.topcoat.components.spinner]
-hash = "sha256:f34fa1b6689a0636cbb43f6b5e7f7fe7fa606bccb5c2941216de0a8ce78e0ea2"
+hash = "sha256:25bf884f5a5fc1c36c77f1c77fcb0399ce5fe3abf94539e1d961b5121863ebdf"
 file = "src/components/spinner.rs"
 
 [registries.topcoat.components.switch]
@@ -117,9 +117,9 @@ hash = "sha256:530fd5976d4d14f12ae6b766846dbf5f9871ffd56b825f75eb311b3fc66caf5b"
 file = "src/components/textarea.rs"
 
 [registries.topcoat.components.toggle]
-hash = "sha256:d061afc50d0478803a95ba9b0c44816735fae7aeb6047d7272f69d7cd4b60e43"
+hash = "sha256:b2343154428785909ef3216b38c2759659bf2a14ab1ac91e42367c291ff04716"
 file = "src/components/toggle.rs"
 
 [registries.topcoat.components.tooltip]
-hash = "sha256:3e3929e2330f126467f584bee4d88bbfc577cf2ff6abe3fd1680f2fef880c120"
+hash = "sha256:786e18a3c7361718096b1b1d5acae3c09ec0b8076fdfe4da700b30b88faca7c9"
 file = "src/components/tooltip.rs"

--- a/examples/ui/src/components/accordion.rs
+++ b/examples/ui/src/components/accordion.rs
@@ -102,7 +102,7 @@ pub async fn accordion_trigger(#[default] mut attrs: Attributes, #[default] chil
         >
             (child)
             icon(
-                data: iconify_icon!("feather:chevron-down"),
+                data: iconify_icon!("lucide:chevron-down"),
                 attrs: attributes! {
                     class="size-4 shrink-0 text-muted-foreground transition-transform \
                         duration-200 ease-out group-open:rotate-180"

--- a/examples/ui/src/components/alert.rs
+++ b/examples/ui/src/components/alert.rs
@@ -55,7 +55,7 @@ const BASE: StaticClass = class!(
 /// view! {
 ///     alert(
 ///         variant: AlertVariant::Destructive,
-///         icon(data: iconify_icon!("feather:alert-triangle"))
+///         icon(data: iconify_icon!("lucide:triangle-alert"))
 ///         alert_title("Build failed")
 ///         alert_description("The last deploy did not finish.")
 ///     )

--- a/examples/ui/src/components/breadcrumb.rs
+++ b/examples/ui/src/components/breadcrumb.rs
@@ -112,7 +112,7 @@ pub async fn breadcrumb_separator(#[default] mut attrs: Attributes) -> Result {
     view! {
         <li aria-hidden="true" class=(attrs.remove("class")) (attrs)>
             icon(
-                data: iconify_icon!("feather:chevron-right"),
+                data: iconify_icon!("lucide:chevron-right"),
                 attrs: attributes! { class="size-3.5" }
             )
         </li>
@@ -129,7 +129,7 @@ pub async fn breadcrumb_ellipsis(#[default] mut attrs: Attributes) -> Result {
     view! {
         <span class=(class!("flex items-center", attrs.remove("class"))) (attrs)>
             icon(
-                data: iconify_icon!("feather:more-horizontal"),
+                data: iconify_icon!("lucide:ellipsis"),
                 attrs: attributes! { class="size-4" }
             )
             <span class="sr-only">"More"</span>

--- a/examples/ui/src/components/checkbox.rs
+++ b/examples/ui/src/components/checkbox.rs
@@ -49,7 +49,7 @@ pub async fn checkbox(#[default] mut attrs: Attributes) -> Result {
         >
             <input type="checkbox" class=(CHECKBOX) (attrs)>
             icon(
-                data: iconify_icon!("feather:check"),
+                data: iconify_icon!("lucide:check"),
                 attrs: attributes! {
                     class="pointer-events-none absolute inset-0 m-auto size-3.5 \
                         text-primary-foreground opacity-0 peer-checked:opacity-100"

--- a/examples/ui/src/components/dropdown_menu.rs
+++ b/examples/ui/src/components/dropdown_menu.rs
@@ -62,7 +62,7 @@ const TRIGGER: StaticClass = class!("cursor-pointer list-none [&::-webkit-detail
 ///         },
 ///         "Options"
 ///         icon(
-///             data: iconify_icon!("feather:chevron-down"),
+///             data: iconify_icon!("lucide:chevron-down"),
 ///             attrs: attributes! { class="group-open:rotate-180" }
 ///         )
 ///     )
@@ -187,7 +187,7 @@ pub async fn dropdown_menu_sub_trigger(
         >
             (child)
             icon(
-                data: iconify_icon!("feather:chevron-right"),
+                data: iconify_icon!("lucide:chevron-right"),
                 attrs: attributes! { class="ml-auto size-4" }
             )
         </summary>

--- a/examples/ui/src/components/pagination.rs
+++ b/examples/ui/src/components/pagination.rs
@@ -143,7 +143,7 @@ pub async fn pagination_previous(
             ))
             (attrs)
         >
-            icon(data: iconify_icon!("feather:chevron-left"))
+            icon(data: iconify_icon!("lucide:chevron-left"))
             <span class=(LABEL)>(label)</span>
         </a>
     }
@@ -169,7 +169,7 @@ pub async fn pagination_next(
             (attrs)
         >
             <span class=(LABEL)>(label)</span>
-            icon(data: iconify_icon!("feather:chevron-right"))
+            icon(data: iconify_icon!("lucide:chevron-right"))
         </a>
     }
 }
@@ -190,7 +190,7 @@ pub async fn pagination_ellipsis(#[default] mut attrs: Attributes) -> Result {
             (attrs)
         >
             icon(
-                data: iconify_icon!("feather:more-horizontal"),
+                data: iconify_icon!("lucide:ellipsis"),
                 attrs: attributes! { class="size-4" }
             )
             <span class="sr-only">"More pages"</span>

--- a/examples/ui/src/components/select.rs
+++ b/examples/ui/src/components/select.rs
@@ -48,7 +48,7 @@ const PICKER: StaticClass = class!(
 );
 
 /// The icon marking the picker's checked option.
-const CHECKMARK: IconData = iconify_icon!("feather:check");
+const CHECKMARK: IconData = iconify_icon!("lucide:check");
 
 /// The inline style for the [`select`] wrapper, carrying [`CHECKMARK`] as a
 /// data URI in the `--select-checkmark` custom property. The indirection
@@ -117,7 +117,7 @@ pub async fn select(cx: &Cx, #[default] mut attrs: Attributes, #[default] child:
         >
             <select class=(class!(SELECT, PICKER)) (attrs)>(child)</select>
             icon(
-                data: iconify_icon!("feather:chevron-down"),
+                data: iconify_icon!("lucide:chevron-down"),
                 attrs: attributes! {
                     class="pointer-events-none absolute top-1/2 right-3 size-4 \
                         -translate-y-1/2 text-muted-foreground transition-transform"

--- a/examples/ui/src/components/spinner.rs
+++ b/examples/ui/src/components/spinner.rs
@@ -36,7 +36,7 @@ pub async fn spinner(
 ) -> Result {
     view! {
         icon(
-            data: iconify_icon!("feather:loader"),
+            data: iconify_icon!("lucide:loader-circle"),
             size: size,
             label: label,
             attrs: attributes! {

--- a/examples/ui/src/components/toggle.rs
+++ b/examples/ui/src/components/toggle.rs
@@ -88,7 +88,7 @@ const BASE: StaticClass = class!(
 /// view! {
 ///     toggle(
 ///         attrs: attributes! { name="bold" checked="" },
-///         icon(data: iconify_icon!("feather:bold"), label: "Bold")
+///         icon(data: iconify_icon!("lucide:bold"), label: "Bold")
 ///     )
 /// }
 /// ```

--- a/examples/ui/src/components/tooltip.rs
+++ b/examples/ui/src/components/tooltip.rs
@@ -22,7 +22,7 @@ use topcoat::{
 ///         button(
 ///             size: ButtonSize::Icon,
 ///             variant: ButtonVariant::Outline,
-///             icon(data: iconify_icon!("feather:copy"), label: "Copy link")
+///             icon(data: iconify_icon!("lucide:copy"), label: "Copy link")
 ///         )
 ///         tooltip_content("Copy link")
 ///     )

--- a/examples/ui/src/main.rs
+++ b/examples/ui/src/main.rs
@@ -384,7 +384,7 @@ async fn home(cx: &Cx) -> Result {
                                 ))
                             >
                                 "Read the docs"
-                                icon(data: iconify_icon!("feather:arrow-right"))
+                                icon(data: iconify_icon!("lucide:arrow-right"))
                             </a>
                             <a
                                 href=(REPOSITORY)
@@ -486,7 +486,7 @@ async fn buttons_card() -> Result {
                         button(
                             size: ButtonSize::Icon,
                             variant: ButtonVariant::Outline,
-                            icon(data: iconify_icon!("feather:plus"), label: "Add item")
+                            icon(data: iconify_icon!("lucide:plus"), label: "Add item")
                         )
                     </div>
                     <div class="flex flex-wrap items-center gap-2">
@@ -516,7 +516,7 @@ async fn notices() -> Result {
             // The leading icon is an ordinary child: the alert lays out a
             // column for it only when one is there.
             alert(
-                icon(data: iconify_icon!("feather:info"))
+                icon(data: iconify_icon!("lucide:info"))
                 alert_title("Every control is a link or a form")
                 alert_description(
                     "Nothing on this page needs scripting; the URL holds what \
@@ -525,7 +525,7 @@ async fn notices() -> Result {
             )
             alert(
                 variant: AlertVariant::Destructive,
-                icon(data: iconify_icon!("feather:alert-triangle"))
+                icon(data: iconify_icon!("lucide:triangle-alert"))
                 alert_title("The destructive variant")
                 alert_description(
                     "For what went wrong, and for what cannot be taken back."
@@ -982,7 +982,7 @@ async fn branches_card(state: &State) -> Result {
                             },
                             (state.branch)
                             icon(
-                                data: iconify_icon!("feather:chevron-down"),
+                                data: iconify_icon!("lucide:chevron-down"),
                                 attrs: attributes! { class="transition-transform group-open:rotate-180" }
                             )
                         )
@@ -1051,11 +1051,11 @@ async fn toolbar_card() -> Result {
                         separator(orientation: SeparatorOrientation::Vertical)
                         <div class="flex items-center gap-1">
                             for (name, data, text, pressed) in [
-                                ("bold", iconify_icon!("feather:bold"), "Bold", true),
-                                ("italic", iconify_icon!("feather:italic"), "Italic", false),
+                                ("bold", iconify_icon!("lucide:bold"), "Bold", true),
+                                ("italic", iconify_icon!("lucide:italic"), "Italic", false),
                                 (
                                     "underline",
-                                    iconify_icon!("feather:underline"),
+                                    iconify_icon!("lucide:underline"),
                                     "Underline",
                                     false,
                                 ),
@@ -1070,7 +1070,7 @@ async fn toolbar_card() -> Result {
                     toggle(
                         size: ToggleSize::Lg,
                         attrs: attributes! { name="live" checked="" },
-                        icon(data: iconify_icon!("feather:activity"))
+                        icon(data: iconify_icon!("lucide:activity"))
                         "Live updates"
                     )
                 </div>
@@ -1107,7 +1107,7 @@ async fn share_card() -> Result {
                             ))
                         >
                             icon(
-                                data: iconify_icon!("feather:book-open"),
+                                data: iconify_icon!("lucide:book-open"),
                                 label: "Read the docs"
                             )
                         </a>
@@ -1254,7 +1254,7 @@ async fn deployments_card(state: &State) -> Result {
                         href=(state.href("overlay", Some("filters")))
                         class=(button_variants(ButtonVariant::Outline, ButtonSize::Sm))
                     >
-                        icon(data: iconify_icon!("feather:filter"))
+                        icon(data: iconify_icon!("lucide:filter"))
                         "Filters"
                     </a>
                 </div>
@@ -1478,7 +1478,7 @@ async fn rename_dialog(state: &State) -> Result {
                         "absolute top-3 right-3",
                     ))
                 >
-                    icon(data: iconify_icon!("feather:x"), label: "Close")
+                    icon(data: iconify_icon!("lucide:x"), label: "Close")
                 </a>
                 <form class="flex flex-col gap-4">
                     state_fields(state: state, sets: "overlay name")


### PR DESCRIPTION
This is primarily motivated by the lack of a "loader-circle" icon in feather (now used in the `spinner` component).