### PR TITLE
feat(ui): slightly adapt topcoat-ui default colors

### DIFF
--- a/crates/topcoat-ui/registry/themes/neutral.css
+++ b/crates/topcoat-ui/registry/themes/neutral.css
@@ -54,12 +54,12 @@
   --background: oklch(0.995 0.003 260);
   --foreground: oklch(0.24 0.012 260);
   --muted-foreground: oklch(0.51 0.014 260);
-  --primary: oklch(0.31 0.02 260);
+  --primary: oklch(0.21 0.02 260);
   --primary-foreground: oklch(0.985 0.003 260);
   --destructive: oklch(0.55 0.2 27);
   --destructive-foreground: oklch(0.99 0.012 27);
   --border: oklch(0.9 0.008 260);
-  --ring: oklch(0.62 0.06 260);
+  --ring: oklch(0.32 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 12%);
   --shadow-sm:
     0 1px 2px oklch(0.24 0.02 260 / 10%),
@@ -75,10 +75,11 @@
   --destructive: oklch(0.66 0.18 25);
   --destructive-foreground: oklch(0.14 0.02 25);
   --border: oklch(0.3 0.012 260);
-  --ring: oklch(0.6 0.05 260);
-  /* Light-mode shadows disappear on a dark background, so these are deeper. */
+  --ring: oklch(0.6 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0 0 0 / 35%);
-  --shadow-sm: 0 1px 2px oklch(0 0 0 / 35%), 0 2px 8px -2px oklch(0 0 0 / 30%);
+  --shadow-sm:
+    0 1px 2px oklch(0 0 0 / 35%),
+    0 2px 8px -2px oklch(0 0 0 / 30%);
 }
 
 @layer base {

--- a/demos/coffee-shop/components.toml
+++ b/demos/coffee-shop/components.toml
@@ -5,7 +5,7 @@ components_dir = "src/components"
 [theme]
 name = "neutral"
 registry = "topcoat"
-hash = "sha256:c7bdcb5ea4ff757611ba616e92178169b262be98155c06dfa2407584d51e7459"
+hash = "sha256:22cb1d72ddbe6fe2e3375fc32228ae5d67c26c74fe26dd00af451dc918367a18"
 file = "styles.css"
 
 [registries.topcoat.components.badge]

--- a/demos/coffee-shop/styles.css
+++ b/demos/coffee-shop/styles.css
@@ -54,12 +54,12 @@
   --background: oklch(0.995 0.003 260);
   --foreground: oklch(0.24 0.012 260);
   --muted-foreground: oklch(0.51 0.014 260);
-  --primary: oklch(0.31 0.02 260);
+  --primary: oklch(0.21 0.02 260);
   --primary-foreground: oklch(0.985 0.003 260);
   --destructive: oklch(0.55 0.2 27);
   --destructive-foreground: oklch(0.99 0.012 27);
   --border: oklch(0.9 0.008 260);
-  --ring: oklch(0.62 0.06 260);
+  --ring: oklch(0.32 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 12%);
   --shadow-sm:
     0 1px 2px oklch(0.24 0.02 260 / 10%),
@@ -75,10 +75,11 @@
   --destructive: oklch(0.66 0.18 25);
   --destructive-foreground: oklch(0.14 0.02 25);
   --border: oklch(0.3 0.012 260);
-  --ring: oklch(0.6 0.05 260);
-  /* Light-mode shadows disappear on a dark background, so these are deeper. */
+  --ring: oklch(0.6 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0 0 0 / 35%);
-  --shadow-sm: 0 1px 2px oklch(0 0 0 / 35%), 0 2px 8px -2px oklch(0 0 0 / 30%);
+  --shadow-sm:
+    0 1px 2px oklch(0 0 0 / 35%),
+    0 2px 8px -2px oklch(0 0 0 / 30%);
 }
 
 @layer base {

--- a/examples/ui/components.toml
+++ b/examples/ui/components.toml
@@ -5,7 +5,7 @@ components_dir = "src/components"
 [theme]
 name = "neutral"
 registry = "topcoat"
-hash = "sha256:c7bdcb5ea4ff757611ba616e92178169b262be98155c06dfa2407584d51e7459"
+hash = "sha256:22cb1d72ddbe6fe2e3375fc32228ae5d67c26c74fe26dd00af451dc918367a18"
 file = "styles.css"
 
 [registries.topcoat.components.accordion]

--- a/examples/ui/styles.css
+++ b/examples/ui/styles.css
@@ -54,12 +54,12 @@
   --background: oklch(0.995 0.003 260);
   --foreground: oklch(0.24 0.012 260);
   --muted-foreground: oklch(0.51 0.014 260);
-  --primary: oklch(0.31 0.02 260);
+  --primary: oklch(0.21 0.02 260);
   --primary-foreground: oklch(0.985 0.003 260);
   --destructive: oklch(0.55 0.2 27);
   --destructive-foreground: oklch(0.99 0.012 27);
   --border: oklch(0.9 0.008 260);
-  --ring: oklch(0.62 0.06 260);
+  --ring: oklch(0.32 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0.24 0.02 260 / 12%);
   --shadow-sm:
     0 1px 2px oklch(0.24 0.02 260 / 10%),
@@ -75,10 +75,11 @@
   --destructive: oklch(0.66 0.18 25);
   --destructive-foreground: oklch(0.14 0.02 25);
   --border: oklch(0.3 0.012 260);
-  --ring: oklch(0.6 0.05 260);
-  /* Light-mode shadows disappear on a dark background, so these are deeper. */
+  --ring: oklch(0.6 0.02 260);
   --shadow-xs: 0 1px 2px oklch(0 0 0 / 35%);
-  --shadow-sm: 0 1px 2px oklch(0 0 0 / 35%), 0 2px 8px -2px oklch(0 0 0 / 30%);
+  --shadow-sm:
+    0 1px 2px oklch(0 0 0 / 35%),
+    0 2px 8px -2px oklch(0 0 0 / 30%);
 }
 
 @layer base {


### PR DESCRIPTION
Increases contrast and clarity.

Before:
<img width="369" height="298" alt="screen-before" src="https://github.com/user-attachments/assets/f30032d6-54a1-4ee4-8312-320f2a1b979f" />

After:
<img width="369" height="298" alt="screen-after" src="https://github.com/user-attachments/assets/3bb06964-d162-4e12-b481-b5830c078f97" />
