### PR TITLE
docs: fix "hello world" examples so that they compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Topcoat is a modular, batteries-included Rust framework for building full-stack 
 use topcoat::{
     Result,
     router::{Router, RouterBuilderDiscoverExt, page},
-    view::{View, component, view},
+    view::{component, view},
 };
 
 #[tokio::main]
@@ -47,20 +47,20 @@ async fn main() {
 }
 
 #[page("/")]
-async fn home() -> Result<impl View> {
-    Ok(view! {
+async fn home() -> Result {
+    view! {
         <!DOCTYPE html>
         <html>
             <body>
                 hello(name: "World")
             </body>
         </html>
-    })
+    }
 }
 
 #[component]
-async fn hello(name: &str) -> Result<impl View> {
-    Ok(view! { <h1>"Hello, " (name) "!"</h1> })
+async fn hello(name: &str) -> Result {
+    view! { <h1>"Hello, " (name) "!"</h1> }
 }
 ```
 

--- a/crates/topcoat/docs/getting_started.md
+++ b/crates/topcoat/docs/getting_started.md
@@ -24,7 +24,7 @@ Replace `src/main.rs` with:
 use topcoat::{
     Result,
     router::{Router, RouterBuilderDiscoverExt, page},
-    view::{View, component, view},
+    view::{component, view},
 };
 
 #[tokio::main]
@@ -33,8 +33,8 @@ async fn main() {
 }
 
 #[page("/")]
-async fn home() -> Result<impl View> {
-    Ok(view! {
+async fn home() -> Result {
+    view! {
         <!DOCTYPE html>
         <html>
             <head>
@@ -45,14 +45,12 @@ async fn home() -> Result<impl View> {
                 hello(name: "World")
             </body>
         </html>
-    })
+    }
 }
 
 #[component]
-async fn hello(name: &str) -> Result<impl View> {
-    Ok(view! {
-        <h1>"Hello, " (name) "!"</h1>
-    })
+async fn hello(name: &str) -> Result {
+    view! { <h1>"Hello, " (name) "!"</h1> }
 }
 ```
 


### PR DESCRIPTION
Hi there! While walking through the `getting_started.md`, I noticed that these examples did not compile. I've updated them minimally so that they compile.