### PR TITLE
fix(router): treat an empty form or query value as None for Option<T>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,7 +2810,6 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "tokio",
  "tokio-tungstenite",
  "topcoat-alpine-ajax",

--- a/crates/topcoat-router/macro/docs/query_params.md
+++ b/crates/topcoat-router/macro/docs/query_params.md
@@ -12,7 +12,7 @@ struct PageQuery {
 
 # Reading the value
 
-[`query_params::<T>(cx)`](fn.query_params.html) parses the current request's query string with [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) and returns `Result<&T, &QueryParamsError>`: a reference to the parsed struct, or to the [`QueryParamsError`](type.QueryParamsError.html) naming the key that failed. Unlike a path parameter, the struct is not tied to a route: any handler can read it. Parsing runs at most once per request; the result is then memoized.
+[`query_params::<T>(cx)`](fn.query_params.html) parses the current request's query string and returns `Result<&T, &QueryParamsError>`: a reference to the parsed struct, or to the [`QueryParamsError`](type.QueryParamsError.html) naming the key that failed. Unlike a path parameter, the struct is not tied to a route: any handler can read it. Parsing runs at most once per request; the result is then memoized.
 
 # Failing with an error response
 
@@ -60,5 +60,5 @@ This relies on every field being optional; a required key would still be missing
 
 # Requirements
 
-- Use `Option<T>` for optional keys. `serde_urlencoded` does not apply `#[serde(default)]`, so a missing key on a non-`Option` field is a parse error.
+- Use `Option<T>` for optional keys. A missing key and an empty value (`?page=`, as a browser sends for a blank input) both read as `None`. `#[serde(default)]` is not applied, so a missing key on a non-`Option` field is a parse error.
 - The struct must be `Send + Sync + 'static`, since it is memoized for the request.

--- a/crates/topcoat-router/src/content/form.rs
+++ b/crates/topcoat-router/src/content/form.rs
@@ -116,9 +116,10 @@ where
     /// # Errors
     ///
     /// Returns a bad-request error when `bytes` are not valid URL-encoded form
-    /// data matching `T`.
+    /// data matching `T`. An empty value, as a browser sends for a blank input,
+    /// deserializes to `None` for an `Option<T>` field.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let deserializer = serde_urlencoded::Deserializer::new(form_urlencoded::parse(bytes));
+        let deserializer = crate::urlencoded::Deserializer::new(form_urlencoded::parse(bytes));
         let value = serde_path_to_error::deserialize(deserializer).map_err(|error| {
             bad_request_at(
                 error.path(),
@@ -399,5 +400,95 @@ mod tests {
         assert!(!form_content_type(None));
         assert!(!form_content_type(Some("application/json")));
         assert!(!form_content_type(Some("text/plain")));
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Deadline {
+        due: Option<f64>,
+    }
+
+    #[test]
+    fn from_bytes_reads_empty_optional_value_as_none() {
+        let Form(deadline) =
+            Form::<Deadline>::from_bytes(b"due=").expect("an empty optional value");
+
+        assert_eq!(deadline.due, None);
+    }
+
+    #[test]
+    fn from_bytes_reads_present_optional_value() {
+        let Form(deadline) =
+            Form::<Deadline>::from_bytes(b"due=1.5").expect("a valid optional value");
+
+        assert_eq!(deadline.due, Some(1.5));
+    }
+
+    #[test]
+    fn from_bytes_reads_missing_optional_key_as_none() {
+        let Form(deadline) = Form::<Deadline>::from_bytes(b"").expect("no keys at all");
+
+        assert_eq!(deadline.due, None);
+    }
+
+    #[test]
+    fn from_bytes_keeps_empty_required_string() {
+        #[derive(Debug, serde::Deserialize)]
+        struct Named {
+            name: String,
+        }
+
+        let Form(named) = Form::<Named>::from_bytes(b"name=").expect("an empty string value");
+
+        assert_eq!(named.name, "");
+    }
+
+    #[test]
+    fn from_bytes_reads_empty_optional_string_as_none() {
+        #[derive(Debug, serde::Deserialize)]
+        struct Nickname {
+            nick: Option<String>,
+        }
+
+        let Form(nickname) =
+            Form::<Nickname>::from_bytes(b"nick=").expect("an empty optional string");
+
+        assert_eq!(nickname.nick, None);
+    }
+
+    #[test]
+    fn from_bytes_rejects_empty_required_number() {
+        #[derive(Debug, serde::Deserialize)]
+        struct Count {
+            #[allow(dead_code)]
+            n: f64,
+        }
+
+        let error = Form::<Count>::from_bytes(b"n=").expect_err("an empty required number");
+
+        assert!(error.to_string().contains("invalid form value"), "{error}");
+    }
+
+    #[derive(Debug, PartialEq, serde::Deserialize)]
+    enum Priority {
+        High,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Task {
+        priority: Option<Priority>,
+    }
+
+    #[test]
+    fn from_bytes_reads_empty_optional_enum_as_none() {
+        let Form(task) = Form::<Task>::from_bytes(b"priority=").expect("an empty optional enum");
+
+        assert_eq!(task.priority, None);
+    }
+
+    #[test]
+    fn from_bytes_reads_present_optional_enum() {
+        let Form(task) = Form::<Task>::from_bytes(b"priority=High").expect("a valid optional enum");
+
+        assert_eq!(task.priority, Some(Priority::High));
     }
 }

--- a/crates/topcoat-router/src/lib.rs
+++ b/crates/topcoat-router/src/lib.rs
@@ -27,6 +27,7 @@ mod router;
 mod service;
 #[cfg(feature = "tower")]
 pub mod tower;
+mod urlencoded;
 
 pub use body::*;
 pub use body_limit::*;

--- a/crates/topcoat-router/src/query_param.rs
+++ b/crates/topcoat-router/src/query_param.rs
@@ -35,7 +35,7 @@ pub fn query_params<T: QueryParams>(cx: &Cx) -> T::Output<'_> {
 
 /// The error produced when the request's query string fails to deserialize,
 /// carrying the path of the key that failed.
-pub type QueryParamsError = serde_path_to_error::Error<serde_urlencoded::de::Error>;
+pub type QueryParamsError = serde_path_to_error::Error<serde::de::value::Error>;
 
 /// Deserializes the query string of the request `cx` belongs to into `T`.
 ///

--- a/crates/topcoat-router/src/query_param.rs
+++ b/crates/topcoat-router/src/query_param.rs
@@ -49,7 +49,7 @@ pub type QueryParamsError = serde_path_to_error::Error<serde_urlencoded::de::Err
 pub fn parse_query_params<T: DeserializeOwned>(cx: &Cx) -> Result<T, QueryParamsError> {
     let query = uri(cx).query().unwrap_or("");
     let deserializer =
-        serde_urlencoded::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
+        crate::urlencoded::Deserializer::new(form_urlencoded::parse(query.as_bytes()));
     serde_path_to_error::deserialize(deserializer)
 }
 
@@ -65,5 +65,45 @@ pub struct QueryParamsSealed(());
 impl QueryParamsSealed {
     pub(crate) fn new() -> Self {
         Self(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Request;
+    use topcoat_core::context::CxTestBuilder;
+
+    use super::*;
+
+    #[derive(Debug, serde::Deserialize)]
+    struct Paging {
+        page: Option<f64>,
+    }
+
+    /// Builds a `Cx` carrying request `Parts` for a `GET` of `uri`.
+    fn cx(uri: &str) -> Cx {
+        let (parts, ()) = Request::builder()
+            .uri(uri)
+            .body(())
+            .expect("request should build")
+            .into_parts();
+
+        CxTestBuilder::new().request_context(parts).build()
+    }
+
+    #[test]
+    fn parse_query_params_reads_empty_optional_value_as_none() {
+        let paging: Paging =
+            parse_query_params(&cx("/items?page=")).expect("an empty optional value");
+
+        assert_eq!(paging.page, None);
+    }
+
+    #[test]
+    fn parse_query_params_reads_present_optional_value() {
+        let paging: Paging =
+            parse_query_params(&cx("/items?page=2")).expect("a valid optional value");
+
+        assert_eq!(paging.page, Some(2.0));
     }
 }

--- a/crates/topcoat-router/src/urlencoded.rs
+++ b/crates/topcoat-router/src/urlencoded.rs
@@ -5,13 +5,12 @@
 //! field. `serde_urlencoded` hands the empty string to `T` instead, so only
 //! `Option<String>` accepts a blank input.
 
-use std::borrow::Cow;
-use std::fmt::Display;
-use std::str::FromStr;
+use std::{borrow::Cow, fmt::Display, str::FromStr};
 
-use serde::de::value::MapDeserializer;
-use serde::de::{self, IntoDeserializer};
-use serde::forward_to_deserialize_any;
+use serde::{
+    de::{self, IntoDeserializer, value::MapDeserializer},
+    forward_to_deserialize_any,
+};
 
 /// The error type, the same one `serde_urlencoded` reports.
 pub(crate) type Error = serde::de::value::Error;

--- a/crates/topcoat-router/src/urlencoded.rs
+++ b/crates/topcoat-router/src/urlencoded.rs
@@ -1,0 +1,241 @@
+//! A `serde` deserializer for `application/x-www-form-urlencoded` data.
+//!
+//! It mirrors `serde_urlencoded` with one difference: an empty value, as a
+//! browser sends for a blank input, deserializes to `None` for an `Option<T>`
+//! field. `serde_urlencoded` hands the empty string to `T` instead, so only
+//! `Option<String>` accepts a blank input.
+
+use std::borrow::Cow;
+use std::fmt::Display;
+use std::str::FromStr;
+
+use serde::de::value::MapDeserializer;
+use serde::de::{self, IntoDeserializer};
+use serde::forward_to_deserialize_any;
+
+/// The error type, the same one `serde_urlencoded` reports.
+pub(crate) type Error = serde::de::value::Error;
+
+/// Deserializes the pairs of a form body or a query string into a `T`.
+pub(crate) struct Deserializer<'de> {
+    inner: MapDeserializer<'de, Pairs<'de>, Error>,
+}
+
+impl<'de> Deserializer<'de> {
+    /// Wraps the parsed pairs of a form body or a query string.
+    pub(crate) fn new(pairs: form_urlencoded::Parse<'de>) -> Self {
+        Self {
+            inner: MapDeserializer::new(Pairs(pairs)),
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_map(self.inner)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_seq(self.inner)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.inner.end().and_then(|()| visitor.visit_unit())
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string option bytes
+        byte_buf unit_struct newtype_struct tuple_struct struct identifier tuple
+        enum ignored_any
+    }
+}
+
+/// The parsed pairs, each value wrapped in a [`Value`].
+struct Pairs<'de>(form_urlencoded::Parse<'de>);
+
+impl<'de> Iterator for Pairs<'de> {
+    type Item = (Cow<'de, str>, Value<'de>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(key, value)| (key, Value(value)))
+    }
+}
+
+/// One value of a form body or a query string.
+struct Value<'de>(Cow<'de, str>);
+
+impl<'de> IntoDeserializer<'de, Error> for Value<'de> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+/// Parses `value` as a `T` and hands the result to `visit`.
+fn parsed<'de, T, V>(
+    value: &str,
+    visitor: V,
+    visit: fn(V, T) -> Result<V::Value, Error>,
+) -> Result<V::Value, Error>
+where
+    T: FromStr,
+    T::Err: Display,
+    V: de::Visitor<'de>,
+{
+    value
+        .parse::<T>()
+        .map_err(de::Error::custom)
+        .and_then(|parsed| visit(visitor, parsed))
+}
+
+impl<'de> de::Deserializer<'de> for Value<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.0 {
+            Cow::Borrowed(value) => visitor.visit_borrowed_str(value),
+            Cow::Owned(value) => visitor.visit_string(value),
+        }
+    }
+
+    /// An empty value is `None`. Any other value is `Some` of the parsed `T`.
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if self.0.is_empty() {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.0
+            .into_deserializer()
+            .deserialize_enum(name, variants, visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_bool::<Error>)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_u8::<Error>)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_u16::<Error>)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_u32::<Error>)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_u64::<Error>)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_i8::<Error>)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_i16::<Error>)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_i32::<Error>)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_i64::<Error>)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_f32::<Error>)
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        parsed(&self.0, visitor, V::visit_f64::<Error>)
+    }
+
+    forward_to_deserialize_any! {
+        char str string unit bytes byte_buf unit_struct tuple_struct struct
+        identifier tuple ignored_any seq map
+    }
+}

--- a/crates/topcoat/Cargo.toml
+++ b/crates/topcoat/Cargo.toml
@@ -198,7 +198,6 @@ topcoat-view-macro = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 inventory = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde_urlencoded.workspace = true
 tokio = { workspace = true, optional = true, features = ["macros", "net", "signal"] }
 tokio-tungstenite = { workspace = true, optional = true, features = ["connect"] }
 

--- a/crates/topcoat/src/internal.rs
+++ b/crates/topcoat/src/internal.rs
@@ -1,5 +1,4 @@
 #[cfg(feature = "discover")]
 pub use inventory;
 pub use serde;
-pub use serde_urlencoded;
 pub use topcoat_core::internal::*;


### PR DESCRIPTION
## Summary

A browser submits a blank input as `due=` (key present, value empty).  `Form<T>` and `#[query_params]` handed that empty value to the field's own parser, so any `Option<T>` whose `T` rejects `""` (`f64`, `bool`, `jiff::civil::Date`, an enum, ...) failed with `bad request: invalid form value: ...`.  Only `Option<String>` survived, as `Some("")`.

This adds a small in-crate deserializer (`crates/topcoat-router/src/urlencoded.rs`) that mirrors `serde_urlencoded` with one rule added: an empty value deserializes to `None` for any `Option<T>`.  `Form<T>` and `#[query_params]` now decode through it.  Serialization keeps using `serde_urlencoded`, and `QueryParamsError` is the same type as before.

Behavior changes, each covered by a test:
- `Option<T>` from an empty value is `None` for every `T`, including enums and other types with their own parser (was a bad request).
- `Option<String>` from an empty value is `None` (was `Some("")`).
- Unchanged: a required `String` reads `""`, a required number still returns a bad request, and a missing key for `Option<T>` is `None`.

Alternative considered: switching to `serde_html_form`, the fork `axum-extra` uses.  It only maps an empty value to `None` for a fixed list of primitive types (`bool`, integers, floats), so the `Option<Date>` from the issue would still fail.  If you would rather keep `Some("")` for `Option<String>`, I can drop that part of the rule.

Closes #187

## Testing

- `cargo test -p topcoat-router --lib`: 445 passed, 0 failed (Rust 1.98.1)
- `cargo clippy -p topcoat-router --no-deps --all-targets -- -D warnings`: clean
- `cargo fmt -p topcoat-router -- --check`: clean
