### PR TITLE
feat(router): allow using SeeOther as error

### DIFF
--- a/crates/topcoat-router/docs/error.md
+++ b/crates/topcoat-router/docs/error.md
@@ -4,7 +4,7 @@ Every page, layout, layer, and route handler returns a `Result`. An `Err` become
 
 # Constructors
 
-Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], and [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description. [`too_many_requests(secs)`](too_many_requests) and [`service_unavailable(secs)`](service_unavailable) respond 429 and 503, each carrying a `Retry-After` header.
+Every error type in this module has a constructor function named after its response. For example, [`not_found()`](not_found) responds 404 with [`NotFoundError`], [`redirect(uri)`](redirect) responds 307 with [`RedirectError`], and [`bad_request(description)`](bad_request) responds 400 with [`BadRequestError`] and a client-safe description. [`too_many_requests(secs)`](too_many_requests) and [`service_unavailable(secs)`](service_unavailable) respond 429 and 503, each carrying a `Retry-After` header. [`see_other(uri)`](see_other) responds 303 with [`SeeOther`], which doubles as a successful response, so a route can also return it through `Ok`.
 
 A constructor returns a concrete error type that converts into the handler's error, so bubble it up with `?` or return it directly:
 

--- a/crates/topcoat-router/src/content/view.rs
+++ b/crates/topcoat-router/src/content/view.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bytes::Bytes;
 use futures_util::future::poll_fn;
-use http::{HeaderMap, StatusCode};
+use http::{HeaderMap, HeaderValue, StatusCode};
 use http_body::Frame;
 use pin_project_lite::pin_project;
 use topcoat_core::{context::Cx, error::Result};
@@ -15,7 +15,7 @@ use topcoat_view::{BoxView, Formatter, View, ViewExt, ViewHandle, internal::Move
 use crate::{
     Body, BoxError,
     content::Html,
-    error::RedirectError,
+    error::redirect_location,
     response::{AsyncIntoResponse, IntoResponse, Response},
 };
 
@@ -109,14 +109,11 @@ window.topcoat ??= {
 </script>";
 
 /// Builds the script a mid-stream redirect is sent as: a navigation to the
-/// redirect's target. `replace` keeps the partially streamed page out of the
-/// session history, so going back skips it.
-fn redirect_script(redirect: &RedirectError) -> String {
+/// redirect's `location`. `replace` keeps the partially streamed page out of
+/// the session history, so going back skips it.
+fn redirect_script(location: &HeaderValue) -> String {
     // The location is percent-encoded down to ASCII, so it converts back.
-    let uri = redirect
-        .location()
-        .to_str()
-        .expect("redirect location is ASCII");
+    let uri = location.to_str().expect("redirect location is ASCII");
     let mut location = String::with_capacity(uri.len());
     for c in uri.chars() {
         match c {
@@ -188,9 +185,9 @@ impl<V: View + 'static> http_body::Body for ViewBody<V> {
                 // The response committed with the first content, so a
                 // redirect can no longer change the status line; it degrades
                 // to a client-side navigation instead.
-                match error.downcast::<RedirectError>() {
-                    Ok(redirect) => {
-                        Poll::Ready(Some(Ok(Frame::data(redirect_script(&redirect).into()))))
+                match redirect_location(error) {
+                    Ok(location) => {
+                        Poll::Ready(Some(Ok(Frame::data(redirect_script(&location).into()))))
                     }
                     Err(error) => Poll::Ready(Some(Err(error.into()))),
                 }
@@ -214,7 +211,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        BodyPanicError, LayoutFn, Method, PageFn, Router, RouterBuilder, Slot, error::redirect,
+        BodyPanicError, LayoutFn, Method, PageFn, Router, RouterBuilder, Slot,
+        error::{redirect, see_other},
         to_bytes,
     };
 
@@ -662,6 +660,26 @@ mod tests {
         .boxed()
     }
 
+    /// A page that answers with a "see other" before it produces any content.
+    fn render_see_other_page(cx: &Cx, _body: Body) -> BoxView<'_> {
+        view! { cx => <main>(live! { Err(see_other("/target").into()) })</main> }.boxed()
+    }
+
+    /// A page that answers with a "see other" after its first emission.
+    fn render_late_see_other_page(cx: &Cx, _body: Body) -> BoxView<'_> {
+        view! {
+            cx =>
+            <main>
+                (live! {
+                    emit! { <p>"first"</p> }?;
+                    tokio::task::yield_now().await;
+                    Err(see_other("/target").into())
+                })
+            </main>
+        }
+        .boxed()
+    }
+
     #[tokio::test]
     async fn a_redirect_before_the_first_content_is_a_real_redirect() {
         let response = send_page(render_redirecting_page).await;
@@ -690,9 +708,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn a_see_other_before_the_first_content_is_a_real_redirect() {
+        let response = send_page(render_see_other_page).await;
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(http::header::LOCATION).unwrap(),
+            "/target"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_see_other_after_the_first_content_streams_a_navigation_script() {
+        let response = send_page(render_late_see_other_page).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let frames = data_frames(response.into_body()).await;
+        assert_eq!(frames.len(), 2);
+        assert_eq!(
+            frames[1],
+            "<script>window.location.replace(\"/target\")</script>"
+        );
+    }
+
     #[test]
     fn the_navigation_script_escapes_the_redirect_target() {
-        let script = redirect_script(&redirect("/a\"b\\c<d"));
+        let script = redirect_script(redirect("/a\"b\\c<d").location());
         assert_eq!(
             script,
             "<script>window.location.replace(\"/a\\\"b\\\\c\\x3Cd\")</script>"
@@ -701,7 +742,7 @@ mod tests {
 
     #[test]
     fn the_navigation_script_keeps_a_non_ascii_redirect_target() {
-        let script = redirect_script(&redirect("/caf\u{e9}"));
+        let script = redirect_script(redirect("/caf\u{e9}").location());
         assert_eq!(
             script,
             "<script>window.location.replace(\"/caf%C3%A9\")</script>"

--- a/crates/topcoat-router/src/error.rs
+++ b/crates/topcoat-router/src/error.rs
@@ -68,6 +68,7 @@ fn error_into_response(cx: &Cx, error: Error) -> Response {
     let error = try_downcast!(error as NotFoundError);
     let error = try_downcast!(error as MethodNotAllowedError);
     let error = try_downcast!(error as RedirectError);
+    let error = try_downcast!(error as SeeOther);
     let error = try_downcast!(error as UnauthorizedError);
     let error = try_downcast!(error as ServiceUnavailableError);
     let error = try_downcast!(error as TooManyRequestsError);

--- a/crates/topcoat-router/src/error/redirect.rs
+++ b/crates/topcoat-router/src/error/redirect.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use http::{HeaderValue, StatusCode, header::LOCATION};
 use percent_encoding::{CONTROLS, utf8_percent_encode};
-use topcoat_core::{context::Cx, error::Result};
+use topcoat_core::{
+    context::Cx,
+    error::{Error, Result},
+};
 
 use crate::response::{IntoResponse, Response};
 
@@ -61,8 +64,8 @@ pub fn redirect_permanent(uri: impl AsRef<str>) -> RedirectError {
 ///
 /// Construct one with [`redirect`] or [`redirect_permanent`], or derive one
 /// from an `Option` / `Result` via [`RouterErrorExt`](crate::error::RouterErrorExt).
-/// For the Post/Redirect/Get pattern, where the redirect is a *successful*
-/// response returned through `Ok`, reach for [`see_other`] instead.
+/// For the Post/Redirect/Get pattern, which sends the browser on with a
+/// `GET`, reach for [`see_other`] instead.
 #[derive(Debug)]
 pub struct RedirectError {
     status: StatusCode,
@@ -79,6 +82,7 @@ impl RedirectError {
     }
 
     /// The target the redirect points at.
+    #[cfg(test)]
     pub(crate) fn location(&self) -> &HeaderValue {
         &self.location
     }
@@ -106,7 +110,12 @@ impl IntoResponse for RedirectError {
 /// -- the Post/Redirect/Get pattern that keeps a reload from re-submitting the
 /// mutation. The target is percent-encoded like [`redirect`] does.
 ///
+/// A route returns the redirect as its `Ok` value. A page renders a view, so
+/// it returns the redirect through `Err` instead, like the other redirects.
+///
 /// # Examples
+///
+/// From a route:
 ///
 /// ```rust
 /// use topcoat::{
@@ -124,6 +133,29 @@ impl IntoResponse for RedirectError {
 ///     Ok(see_other("/"))
 /// }
 /// ```
+///
+/// From a page:
+///
+/// ```rust
+/// use topcoat::{
+///     Result,
+///     context::Cx,
+///     router::{content::Form, error::see_other, page},
+///     view::{View, view},
+/// };
+/// # use serde::Deserialize;
+/// # #[derive(Deserialize)]
+/// # struct Signup { email: String }
+/// # async fn create_account(_cx: &Cx, _email: &str) -> Result<bool> { Ok(true) }
+///
+/// #[page(POST "/signup")]
+/// async fn signup(cx: &Cx, Form(input): Form<Signup>) -> Result<impl View> {
+///     if create_account(cx, &input.email).await? {
+///         return Err(see_other("/welcome").into());
+///     }
+///     Ok(view! { <p>"That email is already taken."</p> })
+/// }
+/// ```
 #[must_use]
 pub fn see_other(uri: impl AsRef<str>) -> SeeOther {
     SeeOther::new(uri.as_ref())
@@ -131,10 +163,13 @@ pub fn see_other(uri: impl AsRef<str>) -> SeeOther {
 
 /// A "see other" (HTTP 303) redirect response.
 ///
-/// Unlike [`RedirectError`], this is a successful response rather than an error,
-/// so return it from the `Ok` branch of a handler. It is the Post/Redirect/Get
-/// reply for a completed `POST`, `PUT`, or `DELETE`, sending the browser to a
-/// new location with a `GET`. Construct one with [`see_other`].
+/// It is the Post/Redirect/Get reply for a completed `POST`, `PUT`, or
+/// `DELETE`, sending the browser to a new location with a `GET`. Construct one
+/// with [`see_other`].
+///
+/// The redirect is both a response and an error, so a handler can return it
+/// either way: a route returns it through `Ok`, and a page, whose `Ok` value
+/// is a view, returns it through `Err`. Both produce the same 303 response.
 #[derive(Debug)]
 pub struct SeeOther {
     location: HeaderValue,
@@ -147,12 +182,42 @@ impl SeeOther {
             location: location(uri),
         }
     }
+
+    /// The target the redirect points at.
+    #[cfg(test)]
+    pub(crate) fn location(&self) -> &HeaderValue {
+        &self.location
+    }
 }
+
+impl std::fmt::Display for SeeOther {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("see other")
+    }
+}
+
+impl std::error::Error for SeeOther {}
 
 impl IntoResponse for SeeOther {
     fn into_response(self, cx: &Cx) -> Result<Response> {
         (StatusCode::SEE_OTHER, ([(LOCATION, self.location)], ())).into_response(cx)
     }
+}
+
+/// Extracts the target of a redirect carried as an error, handing any other
+/// error back unchanged.
+///
+/// # Errors
+///
+/// Returns `Err(error)` if the error is not a redirect.
+pub(crate) fn redirect_location(error: Error) -> Result<HeaderValue, Error> {
+    let error = match error.downcast::<RedirectError>() {
+        Ok(redirect) => return Ok(redirect.location),
+        Err(error) => error,
+    };
+    error
+        .downcast::<SeeOther>()
+        .map(|redirect| redirect.location)
 }
 
 /// Builds the `Location` header value pointing at `uri`.
@@ -185,7 +250,7 @@ mod tests {
             redirect_permanent("https://\u{4f8b}\u{3048}.jp/").location(),
             "https://%E4%BE%8B%E3%81%88.jp/"
         );
-        assert_eq!(see_other("/caf\u{e9}").location, "/caf%C3%A9");
+        assert_eq!(see_other("/caf\u{e9}").location(), "/caf%C3%A9");
     }
 
     #[test]
@@ -204,5 +269,23 @@ mod tests {
     #[test]
     fn the_location_converts_back_to_a_str() {
         assert!(redirect("/caf\u{e9} \u{4f8b}").location().to_str().is_ok());
+    }
+
+    #[test]
+    fn the_location_of_a_redirect_error_is_extracted() {
+        assert_eq!(
+            redirect_location(redirect("/target").into()).unwrap(),
+            "/target"
+        );
+        assert_eq!(
+            redirect_location(see_other("/target").into()).unwrap(),
+            "/target"
+        );
+    }
+
+    #[test]
+    fn other_errors_are_handed_back() {
+        let error = redirect_location(std::fmt::Error.into()).unwrap_err();
+        assert!(error.downcast_ref::<std::fmt::Error>().is_some());
     }
 }


### PR DESCRIPTION
Makes it possible to return `SeeOther` in the error variant of a `Result`, e.g. for pages:
```rust
use topcoat::{
    Result,
    context::Cx,
    router::{content::Form, error::see_other, page},
    view::{View, view},
};
                                                                      
#[page(POST "/signup")]
async fn signup(cx: &Cx, Form(input): Form<Signup>) -> Result<impl View> {
    if create_account(cx, &input.email).await? {
        return Err(see_other("/welcome").into());
    }
    Ok(view! { <p>"That email is already taken."</p> })
}
```